### PR TITLE
Improve annotator class (colors)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,6 +87,10 @@ tasks {
     }
 
     intellijPlatform {
+        buildSearchableOptions {
+            enabled = false
+        }
+
         patchPluginXml {
             sinceBuild.set("242")
             untilBuild.set("252.*")

--- a/src/main/kotlin/org/phellang/PhelColorSettingsPage.kt
+++ b/src/main/kotlin/org/phellang/PhelColorSettingsPage.kt
@@ -155,9 +155,7 @@ private val DESCRIPTORS = arrayOf(
     AttributesDescriptor("Bad characters", PhelSyntaxHighlighter.BAD_CHARACTER),  // Additional descriptors for annotator colors
     AttributesDescriptor("PHP interop", PHP_INTEROP),
     AttributesDescriptor("PHP variables", PHP_VARIABLE),
-    AttributesDescriptor("Core functions", CORE_FUNCTION),
-    AttributesDescriptor("Macros", MACRO),
-    AttributesDescriptor("Special forms", SPECIAL_FORM),
+    AttributesDescriptor("Functions", SPECIAL_FORM),
     AttributesDescriptor("Namespace prefix", NAMESPACE_PREFIX),
     AttributesDescriptor("Function parameters", FUNCTION_PARAMETER),
 )


### PR DESCRIPTION
## 📚 Description

Now all functions are orange, not only special forms (like `def`, `defn`, and a few more)

<img width="470" height="661" alt="image" src="https://github.com/user-attachments/assets/88b8b971-f7a1-4008-8347-9e1beaa96089" />
