### PR TITLE
Set correct placement of new lines

### DIFF
--- a/src/main/kotlin/org/phellang/PhelEnterHandlerDelegate.kt
+++ b/src/main/kotlin/org/phellang/PhelEnterHandlerDelegate.kt
@@ -1,0 +1,87 @@
+package org.phellang
+
+import com.intellij.codeInsight.editorActions.enter.EnterHandlerDelegate
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.actionSystem.EditorActionHandler
+import com.intellij.openapi.util.Ref
+import com.intellij.psi.PsiFile
+import org.phellang.editor.PhelEnterPatternDetector
+import org.phellang.editor.PhelIndentationCalculator
+import org.phellang.editor.PhelParenthesesMover
+
+class PhelEnterHandlerDelegate : EnterHandlerDelegate {
+
+    override fun preprocessEnter(
+        file: PsiFile,
+        editor: Editor,
+        caretOffsetRef: Ref<Int>,
+        caretAdvance: Ref<Int>,
+        dataContext: DataContext,
+        originalHandler: EditorActionHandler?
+    ): EnterHandlerDelegate.Result {
+        if (file.fileType !is PhelFileType) {
+            return EnterHandlerDelegate.Result.Continue
+        }
+
+        val document = editor.document
+        val caretOffset = caretOffsetRef.get()
+        val text = document.charsSequence
+
+        if (PhelEnterPatternDetector.shouldHandleSmartEnter(text, caretOffset)) {
+            val lineStart = document.getLineStartOffset(document.getLineNumber(caretOffset))
+            val lineEnd = document.getLineEndOffset(document.getLineNumber(caretOffset))
+            val currentLine = text.substring(lineStart, lineEnd)
+
+            val currentIndent = PhelIndentationCalculator.getIndentSize(currentLine)
+            val newIndentSpaces = PhelIndentationCalculator.getNextIndentLevel(currentIndent)
+            val newIndent = PhelIndentationCalculator.createIndent(newIndentSpaces)
+            val originalIndent = PhelIndentationCalculator.createIndent(currentIndent)
+
+            val insertText = "\n${newIndent}\n${originalIndent})"
+
+            document.insertString(caretOffset, insertText)
+
+            editor.caretModel.moveToOffset(caretOffset + 1 + newIndentSpaces)
+
+            return EnterHandlerDelegate.Result.Stop
+        }
+
+        return EnterHandlerDelegate.Result.Continue
+    }
+
+    override fun postProcessEnter(
+        file: PsiFile, editor: Editor, dataContext: DataContext
+    ): EnterHandlerDelegate.Result {
+        if (file.fileType !is PhelFileType) {
+            return EnterHandlerDelegate.Result.Continue
+        }
+
+        val document = editor.document
+        val caretOffset = editor.caretModel.offset
+        val text = document.charsSequence
+
+        if (PhelEnterPatternDetector.shouldHandlePostEnter(text, caretOffset, document)) {
+            val currentLineNum = document.getLineNumber(caretOffset)
+
+            val prevLineNum = currentLineNum - 1
+            val prevLineStart = document.getLineStartOffset(prevLineNum)
+            val prevLineEnd = document.getLineEndOffset(prevLineNum)
+            val prevLine = text.substring(prevLineStart, prevLineEnd)
+            val baseIndent = PhelIndentationCalculator.getIndentSize(prevLine)
+            val targetIndent = PhelIndentationCalculator.getNextIndentLevel(baseIndent)
+            val indentText = PhelIndentationCalculator.createIndent(targetIndent)
+
+            if (PhelParenthesesMover.moveClosingParenthesesFromNextLine(editor, document, caretOffset, indentText)) {
+                return EnterHandlerDelegate.Result.Stop
+            }
+
+            document.insertString(caretOffset, indentText)
+            editor.caretModel.moveToOffset(caretOffset + targetIndent)
+
+            return EnterHandlerDelegate.Result.Stop
+        }
+
+        return EnterHandlerDelegate.Result.Continue
+    }
+}

--- a/src/main/kotlin/org/phellang/PhelQuoteHandler.kt
+++ b/src/main/kotlin/org/phellang/PhelQuoteHandler.kt
@@ -5,28 +5,20 @@ import com.intellij.openapi.editor.highlighter.HighlighterIterator
 import com.intellij.psi.tree.TokenSet
 import org.phellang.language.psi.PhelTypes
 
-/**
- * Quote handler for Phel language - provides smart quote handling
- * Handles auto-closing and navigation within string literals
- */
 class PhelQuoteHandler : SimpleTokenSetQuoteHandler(STRING_LITERALS) {
     override fun isClosingQuote(iterator: HighlighterIterator, offset: Int): Boolean {
-        // Check if this quote closes a string literal
         if (STRING_LITERALS.contains(iterator.tokenType)) {
             val end = iterator.end
 
-            // If we're at the end of a string token, this is a closing quote
             return offset == end - 1
         }
         return false
     }
 
     override fun isOpeningQuote(iterator: HighlighterIterator, offset: Int): Boolean {
-        // Check if this quote opens a string literal
         if (STRING_LITERALS.contains(iterator.tokenType)) {
             val start = iterator.start
 
-            // If we're at the start of a string token, this is an opening quote
             return offset == start
         }
         return false

--- a/src/main/kotlin/org/phellang/editor/ParenthesesInfo.kt
+++ b/src/main/kotlin/org/phellang/editor/ParenthesesInfo.kt
@@ -1,0 +1,5 @@
+package org.phellang.editor
+
+data class ParenthesesInfo(
+    val closingParens: String, val remainingContent: String, val count: Int
+)

--- a/src/main/kotlin/org/phellang/editor/PhelEnterPatternDetector.kt
+++ b/src/main/kotlin/org/phellang/editor/PhelEnterPatternDetector.kt
@@ -1,0 +1,41 @@
+package org.phellang.editor
+
+import com.intellij.openapi.editor.Document
+
+object PhelEnterPatternDetector {
+
+    fun shouldHandleSmartEnter(text: CharSequence, offset: Int): Boolean {
+        if (offset > 0 && offset < text.length) {
+            val prevChar = text[offset - 1]
+            val nextChar = text[offset]
+
+            if (prevChar == '(' && nextChar == ')') {
+                return !PhelStringDetector.isInsideString(text, offset)
+            }
+        }
+
+        return false
+    }
+
+    fun shouldHandlePostEnter(text: CharSequence, offset: Int, document: Document): Boolean {
+        val currentLineNum = document.getLineNumber(offset)
+
+        if (currentLineNum == 0) return false
+
+        val prevLineNum = currentLineNum - 1
+        val prevLineStart = document.getLineStartOffset(prevLineNum)
+        val prevLineEnd = document.getLineEndOffset(prevLineNum)
+        val prevLine = text.substring(prevLineStart, prevLineEnd).trim()
+
+        if (!prevLine.endsWith("(")) return false
+
+        if (currentLineNum + 1 >= document.lineCount) return false
+
+        val nextLineNum = currentLineNum + 1
+        val nextLineStart = document.getLineStartOffset(nextLineNum)
+        val nextLineEnd = document.getLineEndOffset(nextLineNum)
+        val nextLine = text.substring(nextLineStart, nextLineEnd).trim()
+
+        return nextLine.startsWith(")")
+    }
+}

--- a/src/main/kotlin/org/phellang/editor/PhelIndentationCalculator.kt
+++ b/src/main/kotlin/org/phellang/editor/PhelIndentationCalculator.kt
@@ -1,0 +1,22 @@
+package org.phellang.editor
+
+object PhelIndentationCalculator {
+
+    private const val INDENT_SIZE = 2
+
+    fun getIndentSize(line: String): Int {
+        var count = 0
+        for (char in line) {
+            when (char) {
+                ' ' -> count++
+                '\t' -> count += INDENT_SIZE
+                else -> break
+            }
+        }
+        return count
+    }
+
+    fun createIndent(spaces: Int): String = " ".repeat(spaces)
+
+    fun getNextIndentLevel(currentIndent: Int): Int = currentIndent + INDENT_SIZE
+}

--- a/src/main/kotlin/org/phellang/editor/PhelParenthesesMover.kt
+++ b/src/main/kotlin/org/phellang/editor/PhelParenthesesMover.kt
@@ -1,0 +1,54 @@
+package org.phellang.editor
+
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.editor.Editor
+
+object PhelParenthesesMover {
+
+    fun extractClosingParentheses(line: String): ParenthesesInfo {
+        var parenCount = 0
+        for (char in line) {
+            if (char == ')') {
+                parenCount++
+            } else {
+                break
+            }
+        }
+
+        val closingParens = ")".repeat(parenCount)
+        val remainingContent = line.substring(parenCount)
+
+        return ParenthesesInfo(closingParens, remainingContent, parenCount)
+    }
+
+    fun moveClosingParenthesesFromNextLine(
+        editor: Editor, document: Document, caretOffset: Int, indentText: String
+    ): Boolean {
+        val currentLineNum = document.getLineNumber(caretOffset)
+        val nextLineNum = currentLineNum + 1
+
+        if (nextLineNum >= document.lineCount) {
+            return false
+        }
+
+        val nextLineStart = document.getLineStartOffset(nextLineNum)
+        val nextLineEnd = document.getLineEndOffset(nextLineNum)
+        val nextLine = document.getText(com.intellij.openapi.util.TextRange(nextLineStart, nextLineEnd))
+
+        val trimmedNextLine = nextLine.trim()
+        if (!trimmedNextLine.startsWith(")")) {
+            return false
+        }
+
+        val parenInfo = extractClosingParentheses(trimmedNextLine)
+
+        document.replaceString(nextLineStart, nextLineEnd, parenInfo.remainingContent)
+
+        val insertText = "$indentText${parenInfo.closingParens}"
+        document.insertString(caretOffset, insertText)
+
+        editor.caretModel.moveToOffset(caretOffset + indentText.length)
+
+        return true
+    }
+}

--- a/src/main/kotlin/org/phellang/editor/PhelStringDetector.kt
+++ b/src/main/kotlin/org/phellang/editor/PhelStringDetector.kt
@@ -1,0 +1,27 @@
+package org.phellang.editor
+
+object PhelStringDetector {
+
+    fun isInsideString(text: CharSequence, offset: Int): Boolean {
+        var quoteCount = 0
+        var i = 0
+
+        while (i < offset && i < text.length) {
+            val c = text[i]
+            if (c == '"') {
+                var backslashCount = 0
+                var j = i - 1
+                while (j >= 0 && text[j] == '\\') {
+                    backslashCount++
+                    j--
+                }
+                if (backslashCount % 2 == 0) {
+                    quoteCount++
+                }
+            }
+            i++
+        }
+
+        return quoteCount % 2 == 1
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -70,6 +70,8 @@
                 implementationClass="org.phellang.PhelQuoteHandler"/>
         <typedHandler
                 implementation="org.phellang.PhelTypedHandler"/>
+        <enterHandlerDelegate
+                implementation="org.phellang.PhelEnterHandlerDelegate"/>
         <lang.findUsagesProvider
                 language="Phel"
                 implementationClass="org.phellang.language.psi.PhelFindUsagesProvider"/>


### PR DESCRIPTION
## 📚 Description

Having the following snippet ( **|** _means the carret placement_)
```phel
(defn print-something [var] (|))
```

I expect to get the following structure when pressing enter:
```phel
(defn print-something [var] (
  |))
```