### PR TITLE
Set correct placement of new lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [![Build Status](https://img.shields.io/badge/status-active-brightgreen.svg)]()
 [![IntelliJ Platform](https://img.shields.io/badge/platform-IntelliJ-blue.svg)]()
+[![Version](https://img.shields.io/jetbrains/plugin/v/28459.svg)](https://plugins.jetbrains.com/plugin/28459)
+[![Downloads](https://img.shields.io/jetbrains/plugin/d/28459.svg)](https://plugins.jetbrains.com/plugin/28459)
+
+[![Plugin Icon](src/main/resources/META-INF/pluginIcon.svg)](https://plugins.jetbrains.com/plugin/28459-phel-lang)
 
 This plugin provides comprehensive IDE support for the [Phel programming language](https://phel-lang.org/) in JetBrains IDEs (IntelliJ IDEA, PhpStorm, WebStorm, etc.).
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "org.phellang"
-version = "0.1.6"
+version = "0.1.8"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/org/phellang/PhelQuoteHandler.kt
+++ b/src/main/kotlin/org/phellang/PhelQuoteHandler.kt
@@ -5,28 +5,20 @@ import com.intellij.openapi.editor.highlighter.HighlighterIterator
 import com.intellij.psi.tree.TokenSet
 import org.phellang.language.psi.PhelTypes
 
-/**
- * Quote handler for Phel language - provides smart quote handling
- * Handles auto-closing and navigation within string literals
- */
 class PhelQuoteHandler : SimpleTokenSetQuoteHandler(STRING_LITERALS) {
     override fun isClosingQuote(iterator: HighlighterIterator, offset: Int): Boolean {
-        // Check if this quote closes a string literal
         if (STRING_LITERALS.contains(iterator.tokenType)) {
             val end = iterator.end
 
-            // If we're at the end of a string token, this is a closing quote
             return offset == end - 1
         }
         return false
     }
 
     override fun isOpeningQuote(iterator: HighlighterIterator, offset: Int): Boolean {
-        // Check if this quote opens a string literal
         if (STRING_LITERALS.contains(iterator.tokenType)) {
             val start = iterator.start
 
-            // If we're at the start of a string token, this is an opening quote
             return offset == start
         }
         return false

--- a/src/main/kotlin/org/phellang/completion/handlers/DefTemplateInsertHandler.kt
+++ b/src/main/kotlin/org/phellang/completion/handlers/DefTemplateInsertHandler.kt
@@ -11,7 +11,7 @@ class DefTemplateInsertHandler : InsertHandler<LookupElement?> {
             val editor = context.editor
             val document = editor.document
 
-            val template = "(def name value)"
+            val template = "(def name)"
             document.replaceString(context.startOffset, context.tailOffset, template)
 
             val nameStart = context.startOffset + 5 // Position after "(def "

--- a/src/main/kotlin/org/phellang/completion/handlers/DefnTemplateInsertHandler.kt
+++ b/src/main/kotlin/org/phellang/completion/handlers/DefnTemplateInsertHandler.kt
@@ -11,7 +11,7 @@ class DefnTemplateInsertHandler : InsertHandler<LookupElement?> {
             val editor = context.editor
             val document = editor.document
 
-            val template = "(defn name [args]\n  body)"
+            val template = "(defn name [])"
             document.replaceString(context.startOffset, context.tailOffset, template)
 
             val nameStart = context.startOffset + 6 // Position after "(defn "

--- a/src/main/kotlin/org/phellang/completion/handlers/FnTemplateInsertHandler.kt
+++ b/src/main/kotlin/org/phellang/completion/handlers/FnTemplateInsertHandler.kt
@@ -11,10 +11,10 @@ class FnTemplateInsertHandler : InsertHandler<LookupElement?> {
             val editor = context.editor
             val document = editor.document
 
-            val template = "(fn [args] body)"
+            val template = "(fn [args])"
             document.replaceString(context.startOffset, context.tailOffset, template)
 
-            val argsStart = context.startOffset + 4 // Position after "(fn ["
+            val argsStart = context.startOffset + 5 // Position after "(fn ["
             editor.caretModel.moveToOffset(argsStart)
             editor.selectionModel.setSelection(argsStart, argsStart + 4) // Select "args"
         }

--- a/src/main/kotlin/org/phellang/completion/handlers/IfTemplateInsertHandler.kt
+++ b/src/main/kotlin/org/phellang/completion/handlers/IfTemplateInsertHandler.kt
@@ -11,7 +11,7 @@ class IfTemplateInsertHandler : InsertHandler<LookupElement?> {
             val editor = context.editor
             val document = editor.document
 
-            val template = "(if condition then else)"
+            val template = "(if condition)"
             document.replaceString(context.startOffset, context.tailOffset, template)
 
             val conditionStart = context.startOffset + 4 // Position after "(if "

--- a/src/main/kotlin/org/phellang/completion/handlers/LetTemplateInsertHandler.kt
+++ b/src/main/kotlin/org/phellang/completion/handlers/LetTemplateInsertHandler.kt
@@ -11,7 +11,7 @@ class LetTemplateInsertHandler : InsertHandler<LookupElement?> {
             val editor = context.editor
             val document = editor.document
 
-            val template = "(let [bindings]\n  body)"
+            val template = "(let [bindings])"
             document.replaceString(context.startOffset, context.tailOffset, template)
 
             val bindingsStart = context.startOffset + 6 // Position after "(let ["

--- a/src/main/kotlin/org/phellang/completion/handlers/NamespacedInsertHandler.kt
+++ b/src/main/kotlin/org/phellang/completion/handlers/NamespacedInsertHandler.kt
@@ -5,10 +5,6 @@ import com.intellij.codeInsight.completion.InsertionContext
 import com.intellij.codeInsight.lookup.LookupElement
 import org.phellang.core.utils.PhelErrorHandler
 
-/**
- * Custom insert handler for namespaced completions to prevent text duplication.
- * Handles completions containing '/' by properly replacing the typed prefix.
- */
 class NamespacedInsertHandler : InsertHandler<LookupElement?> {
     override fun handleInsert(context: InsertionContext, item: LookupElement) {
         PhelErrorHandler.safeOperation {

--- a/src/main/kotlin/org/phellang/editor/PhelEnterHandlerDelegate.kt
+++ b/src/main/kotlin/org/phellang/editor/PhelEnterHandlerDelegate.kt
@@ -1,0 +1,87 @@
+package org.phellang.editor
+
+import com.intellij.codeInsight.editorActions.enter.EnterHandlerDelegate
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.actionSystem.EditorActionHandler
+import com.intellij.openapi.util.Ref
+import com.intellij.psi.PsiFile
+import org.phellang.PhelFileType
+import org.phellang.editor.indentation.PhelIndentationCalculator
+
+class PhelEnterHandlerDelegate : EnterHandlerDelegate {
+
+    override fun preprocessEnter(
+        file: PsiFile,
+        editor: Editor,
+        caretOffsetRef: Ref<Int>,
+        caretAdvanceRef: Ref<Int>,
+        dataContext: DataContext,
+        originalHandler: EditorActionHandler?
+    ): EnterHandlerDelegate.Result {
+        // Only handle Phel files
+        if (file.fileType != PhelFileType.INSTANCE) {
+            return EnterHandlerDelegate.Result.Continue
+        }
+
+        val document = editor.document
+        val caretOffset = caretOffsetRef.get()
+
+        val currentLineNumber = document.getLineNumber(caretOffset)
+        val currentLineStart = document.getLineStartOffset(currentLineNumber)
+        val textBeforeCaret = document.text.substring(currentLineStart, caretOffset)
+        val currentLineText = document.text.substring(currentLineStart, document.getLineEndOffset(currentLineNumber))
+
+        val indentationCalculator = PhelIndentationCalculator()
+        val indentationLevel = indentationCalculator.calculateIndentationLevel(
+            document, currentLineNumber, textBeforeCaret
+        )
+
+        val currentIndentationSpaces = currentLineText.takeWhile { it.isWhitespace() }.length
+        val currentIndentationLevel = currentIndentationSpaces / 2 // Assuming 2 spaces per level
+
+        val additionalIndentationLevel = indentationLevel - currentIndentationLevel
+        val indentationSpaces = " ".repeat(maxOf(0, additionalIndentationLevel) * 2) // 2 spaces per level
+
+        originalHandler?.execute(editor, editor.caretModel.currentCaret, dataContext)
+
+        val caretPosition = editor.caretModel.offset
+        val shouldAddClosingParen = shouldAddClosingParenthesis(document, caretPosition, textBeforeCaret)
+
+        if (indentationSpaces.isNotEmpty()) {
+            document.insertString(caretPosition, indentationSpaces)
+            val newCaretPosition = caretPosition + indentationSpaces.length
+
+            if (shouldAddClosingParen) {
+                val closingIndent = " ".repeat(currentIndentationSpaces)
+                document.insertString(newCaretPosition, "\n$closingIndent)")
+            }
+
+            editor.caretModel.moveToOffset(newCaretPosition)
+        }
+
+        return EnterHandlerDelegate.Result.Stop
+    }
+
+    override fun postProcessEnter(
+        file: PsiFile, editor: Editor, dataContext: DataContext
+    ): EnterHandlerDelegate.Result {
+        return EnterHandlerDelegate.Result.Continue
+    }
+
+    private fun shouldAddClosingParenthesis(document: Document, caretPosition: Int, textBeforeCaret: String): Boolean {
+        val trimmedText = textBeforeCaret.trimEnd()
+        if (!trimmedText.endsWith('(')) {
+            return false
+        }
+
+        val textAfterCaret = if (caretPosition < document.textLength) {
+            document.text.substring(caretPosition).trimStart()
+        } else {
+            ""
+        }
+
+        return !textAfterCaret.startsWith(')')
+    }
+}

--- a/src/main/kotlin/org/phellang/editor/indentation/PhelIndentationCalculator.kt
+++ b/src/main/kotlin/org/phellang/editor/indentation/PhelIndentationCalculator.kt
@@ -1,0 +1,31 @@
+package org.phellang.editor.indentation
+
+import com.intellij.openapi.editor.Document
+
+class PhelIndentationCalculator {
+
+    fun calculateIndentationLevel(
+        document: Document, currentLineNumber: Int, textBeforeCaret: String
+    ): Int {
+        val lineAnalyzer = PhelLineAnalyzer(document)
+
+        val totalNestingLevel = calculateTotalNestingLevel(lineAnalyzer, currentLineNumber, textBeforeCaret)
+
+        return maxOf(0, totalNestingLevel)
+    }
+
+    private fun calculateTotalNestingLevel(
+        lineAnalyzer: PhelLineAnalyzer, upToLine: Int, textBeforeCaret: String
+    ): Int {
+        var nestingLevel = 0
+
+        for (lineNumber in 0 until upToLine) {
+            val lineText = lineAnalyzer.getLineText(lineNumber)
+            nestingLevel += lineAnalyzer.getParenthesesBalance(lineText)
+        }
+
+        nestingLevel += lineAnalyzer.getParenthesesBalance(textBeforeCaret)
+
+        return nestingLevel
+    }
+}

--- a/src/main/kotlin/org/phellang/editor/indentation/PhelLineAnalyzer.kt
+++ b/src/main/kotlin/org/phellang/editor/indentation/PhelLineAnalyzer.kt
@@ -1,0 +1,73 @@
+package org.phellang.editor.indentation
+
+import com.intellij.openapi.editor.Document
+
+class PhelLineAnalyzer(private val document: Document) {
+
+    fun getLineText(lineNumber: Int): String {
+        if (lineNumber < 0 || lineNumber >= document.lineCount) {
+            return ""
+        }
+        val lineStart = document.getLineStartOffset(lineNumber)
+        val lineEnd = document.getLineEndOffset(lineNumber)
+        return document.text.substring(lineStart, lineEnd)
+    }
+
+    fun countOpenParentheses(text: String): Int {
+        return countParentheses(text, '(')
+    }
+
+    fun countCloseParentheses(text: String): Int {
+        return countParentheses(text, ')')
+    }
+
+    fun getParenthesesBalance(text: String): Int {
+        return countOpenParentheses(text) - countCloseParentheses(text)
+    }
+
+    private fun countParentheses(text: String, targetChar: Char): Int {
+        var count = 0
+        var inString = false
+        var inComment = false
+        var i = 0
+
+        while (i < text.length) {
+            val char = text[i]
+
+            when {
+                char == ';' && !inString -> {
+                    inComment = true
+                }
+
+                char == '"' && !inComment -> {
+                    if (!inString) {
+                        inString = true
+                    } else {
+                        // Check if it's escaped
+                        val backslashCount = countPrecedingBackslashes(text, i)
+                        if (backslashCount % 2 == 0) {
+                            inString = false
+                        }
+                    }
+                }
+
+                char == targetChar && !inString && !inComment -> {
+                    count++
+                }
+            }
+            i++
+        }
+
+        return count
+    }
+
+    private fun countPrecedingBackslashes(text: String, position: Int): Int {
+        var count = 0
+        var i = position - 1
+        while (i >= 0 && text[i] == '\\') {
+            count++
+            i--
+        }
+        return count
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -76,6 +76,8 @@
         <lang.foldingBuilder
                 language="Phel"
                 implementationClass="org.phellang.folding.PhelFoldingBuilder"/>
+        <enterHandlerDelegate
+                implementation="org.phellang.editor.PhelEnterHandlerDelegate"/>
         <internalFileTemplate name="Phel_File.phel"/>
     </extensions>
 


### PR DESCRIPTION
## 📚 Description

Having the following snippet ( **|** _means the carret placement_)
```phel
(defn print-something [var] (|))
```

I expect to get the following structure when pressing enter:
```phel
(defn print-something [var]
  (|))
```