### PR TITLE
Fix short set "#{}" highlight

### DIFF
--- a/src/main/kotlin/org/phellang/annotator/PhelAnnotator.kt
+++ b/src/main/kotlin/org/phellang/annotator/PhelAnnotator.kt
@@ -39,10 +39,6 @@ class PhelAnnotator : Annotator {
             is PhelShortFn -> {
                 PhelElementHighlighter.annotateShortFunction(element, holder)
             }
-
-            is PhelSet -> {
-                PhelElementHighlighter.annotateSet(element, holder)
-            }
         }
     }
 }

--- a/src/main/kotlin/org/phellang/annotator/highlighters/PhelElementHighlighter.kt
+++ b/src/main/kotlin/org/phellang/annotator/highlighters/PhelElementHighlighter.kt
@@ -20,10 +20,4 @@ object PhelElementHighlighter {
             PhelAnnotationUtils.createAnnotation(holder, shortFn, SHORT_FUNCTION)
         }
     }
-
-    fun annotateSet(set: PhelSet, holder: AnnotationHolder) {
-        if (PhelAnnotationUtils.shouldAnnotate(set)) {
-            PhelAnnotationUtils.createAnnotation(holder, set, COLLECTION_TYPE)
-        }
-    }
 }

--- a/src/main/kotlin/org/phellang/syntax/classification/PhelTokenClassifier.kt
+++ b/src/main/kotlin/org/phellang/syntax/classification/PhelTokenClassifier.kt
@@ -25,6 +25,8 @@ object PhelTokenClassifier {
             isParentheses(tokenType) -> TokenCategory.PARENTHESES
             isBrackets(tokenType) -> TokenCategory.BRACKETS
             isBraces(tokenType) -> TokenCategory.BRACES
+            isSetOpener(tokenType) -> TokenCategory.BRACES
+            isShortFnOpener(tokenType) -> TokenCategory.PARENTHESES
             isQuote(tokenType) -> TokenCategory.QUOTE
             isSyntaxQuote(tokenType) -> TokenCategory.SYNTAX_QUOTE
             isUnquote(tokenType) -> TokenCategory.UNQUOTE
@@ -77,6 +79,14 @@ object PhelTokenClassifier {
 
     fun isBraces(tokenType: IElementType): Boolean {
         return tokenType == PhelTypes.BRACE1 || tokenType == PhelTypes.BRACE2
+    }
+
+    fun isSetOpener(tokenType: IElementType): Boolean {
+        return tokenType == PhelTypes.HASH_BRACE
+    }
+
+    fun isShortFnOpener(tokenType: IElementType): Boolean {
+        return tokenType == PhelTypes.FN_SHORT
     }
 
     fun isQuote(tokenType: IElementType): Boolean {

--- a/src/test/kotlin/org/phellang/unit/syntax/classification/PhelTokenClassifierTest.kt
+++ b/src/test/kotlin/org/phellang/unit/syntax/classification/PhelTokenClassifierTest.kt
@@ -1,10 +1,10 @@
 package org.phellang.unit.syntax.classification
 
 import com.intellij.psi.TokenType
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.EnumSource
 import org.phellang.language.psi.PhelTypes
 import org.phellang.syntax.classification.PhelTokenClassifier
 import org.phellang.syntax.classification.PhelTokenClassifier.TokenCategory
@@ -56,6 +56,7 @@ class PhelTokenClassifierTest {
         // Parentheses
         assertEquals(TokenCategory.PARENTHESES, PhelTokenClassifier.classifyToken(PhelTypes.PAREN1))
         assertEquals(TokenCategory.PARENTHESES, PhelTokenClassifier.classifyToken(PhelTypes.PAREN2))
+        assertEquals(TokenCategory.PARENTHESES, PhelTokenClassifier.classifyToken(PhelTypes.FN_SHORT))
 
         // Brackets
         assertEquals(TokenCategory.BRACKETS, PhelTokenClassifier.classifyToken(PhelTypes.BRACKET1))
@@ -64,6 +65,7 @@ class PhelTokenClassifierTest {
         // Braces
         assertEquals(TokenCategory.BRACES, PhelTokenClassifier.classifyToken(PhelTypes.BRACE1))
         assertEquals(TokenCategory.BRACES, PhelTokenClassifier.classifyToken(PhelTypes.BRACE2))
+        assertEquals(TokenCategory.BRACES, PhelTokenClassifier.classifyToken(PhelTypes.HASH_BRACE))
     }
 
     @Test
@@ -206,5 +208,20 @@ class PhelTokenClassifierTest {
         assertFalse(PhelTokenClassifier.isComma(testToken))
         assertFalse(PhelTokenClassifier.isSymbol(testToken))
         assertFalse(PhelTokenClassifier.isBadCharacter(testToken))
+    }
+
+    @Test
+    fun `set and short function openers should have dedicated check methods`() {
+        // Compound tokens have semantic check methods
+        assertTrue(PhelTokenClassifier.isSetOpener(PhelTypes.HASH_BRACE), "isSetOpener should recognize #{")
+        assertTrue(PhelTokenClassifier.isShortFnOpener(PhelTypes.FN_SHORT), "isShortFnOpener should recognize |(")
+        
+        // But they classify as their visual equivalents for styling
+        assertEquals(TokenCategory.BRACES, PhelTokenClassifier.classifyToken(PhelTypes.HASH_BRACE))
+        assertEquals(TokenCategory.PARENTHESES, PhelTokenClassifier.classifyToken(PhelTypes.FN_SHORT))
+        
+        // And they're NOT regular delimiters
+        assertFalse(PhelTokenClassifier.isBraces(PhelTypes.HASH_BRACE), "#{ is a set opener, not a regular brace")
+        assertFalse(PhelTokenClassifier.isParentheses(PhelTypes.FN_SHORT), "|( is a short fn opener, not a regular paren")
     }
 }


### PR DESCRIPTION
## 📚 Description

The short set `#{}` was not working before. This PR aims to fix the color on it 👇🏼 

<img width="335" height="339" alt="image" src="https://github.com/user-attachments/assets/b0d07d09-ce12-408f-9de4-00edee5b9373" />

Closes https://github.com/phel-lang/phel-intellij-plugin/issues/75
