### PR TITLE
Update to IntelliJ 2025.3 version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -145,12 +145,13 @@ tasks {
             ides {
                 create("IC", "2024.2.5")
                 create("IC", "2024.3.1")
+                create("IC", "2025.3")
             }
         }
 
         patchPluginXml {
             sinceBuild.set("242")
-            untilBuild.set("252.*")
+            untilBuild.set("253.*")
         }
 
         signPlugin {


### PR DESCRIPTION
## 📚 Description

IntelliJ released version `2025.3` today, update the plugin to make it compatible.