### PR TITLE
Add symbol completion, namespace validation and Go to Definition

### DIFF
--- a/src/main/kotlin/org/phellang/annotator/PhelAnnotator.kt
+++ b/src/main/kotlin/org/phellang/annotator/PhelAnnotator.kt
@@ -6,6 +6,7 @@ import com.intellij.psi.PsiElement
 import org.phellang.annotator.infrastructure.PhelAnnotationConstants.COMMENTED_OUT_FORM
 import org.phellang.annotator.analyzers.PhelCommentAnalyzer
 import org.phellang.annotator.highlighters.PhelElementHighlighter
+import org.phellang.annotator.highlighters.PhelRequireHighlighter
 import org.phellang.annotator.highlighters.PhelSymbolHighlighter
 import org.phellang.annotator.infrastructure.PhelAnnotationUtils
 import org.phellang.language.psi.*
@@ -32,6 +33,11 @@ class PhelAnnotator : Annotator {
             is PhelSymbol -> {
                 val text = element.text
                 if (text != null) {
+                    // First check if this is a namespace in a (:require ...) form
+                    if (PhelRequireHighlighter.annotateRequireNamespace(element, holder)) {
+                        return  // Handled as require namespace
+                    }
+                    // Otherwise, apply regular symbol highlighting
                     PhelSymbolHighlighter.annotateSymbol(element, text, holder)
                 }
             }

--- a/src/main/kotlin/org/phellang/annotator/highlighters/PhelRequireHighlighter.kt
+++ b/src/main/kotlin/org/phellang/annotator/highlighters/PhelRequireHighlighter.kt
@@ -1,0 +1,78 @@
+package org.phellang.annotator.highlighters
+
+import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.annotator.infrastructure.PhelAnnotationUtils
+import org.phellang.annotator.quickfixes.PhelFixImportQuickFix
+import org.phellang.annotator.quickfixes.PhelRemoveDuplicateImportQuickFix
+import org.phellang.annotator.validators.PhelImportValidator
+import org.phellang.language.psi.PhelKeyword
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelSymbol
+
+object PhelRequireHighlighter {
+
+    /**
+     * Checks if a symbol is a namespace in a (:require ...) form and validates it.
+     * Returns true if the symbol was handled (valid or invalid require), false otherwise.
+     */
+    fun annotateRequireNamespace(symbol: PhelSymbol, holder: AnnotationHolder): Boolean {
+        // Check if this symbol is inside a (:require ...) form
+        if (!isNamespaceInRequireForm(symbol)) {
+            return false
+        }
+
+        // Validate the import
+        val validationResult = PhelImportValidator.validateImport(symbol)
+
+        if (validationResult != null) {
+            when {
+                // Duplicate import - offer to remove it
+                validationResult.isDuplicate -> {
+                    val quickFix = PhelRemoveDuplicateImportQuickFix(symbol)
+                    PhelAnnotationUtils.createWarningAnnotationWithFix(
+                        holder, symbol, validationResult.message, quickFix
+                    )
+                }
+                // Namespace doesn't exist but we have a suggestion
+                validationResult.suggestedNamespace != null -> {
+                    val quickFix = PhelFixImportQuickFix(
+                        symbol, validationResult.suggestedNamespace
+                    )
+                    PhelAnnotationUtils.createWarningAnnotationWithFix(
+                        holder, symbol, validationResult.message, quickFix
+                    )
+                }
+                // Namespace doesn't exist, no suggestion
+                else -> {
+                    PhelAnnotationUtils.createWarningAnnotation(
+                        holder, symbol, validationResult.message
+                    )
+                }
+            }
+        }
+
+        // Return true to indicate we handled this symbol (whether valid or invalid)
+        return true
+    }
+
+    private fun isNamespaceInRequireForm(symbol: PhelSymbol): Boolean {
+        val text = symbol.text ?: return false
+
+        // Must look like a namespace (contains backslash)
+        if (!text.contains("\\")) {
+            return false
+        }
+
+        // Check if parent is a list starting with :require keyword
+        val parentList = PsiTreeUtil.getParentOfType(symbol, PhelList::class.java) ?: return false
+
+        val children = parentList.children
+        if (children.isEmpty()) return false
+
+        // First child should be :require keyword
+        val firstChild = children.firstOrNull()
+
+        return firstChild is PhelKeyword && firstChild.text == ":require"
+    }
+}

--- a/src/main/kotlin/org/phellang/annotator/infrastructure/PhelAnnotationUtils.kt
+++ b/src/main/kotlin/org/phellang/annotator/infrastructure/PhelAnnotationUtils.kt
@@ -1,5 +1,6 @@
 package org.phellang.annotator.infrastructure
 
+import com.intellij.codeInsight.intention.IntentionAction
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.editor.colors.TextAttributesKey
@@ -8,16 +9,20 @@ import com.intellij.psi.PsiElement
 
 object PhelAnnotationUtils {
 
-    fun createAnnotation(
-        holder: AnnotationHolder, element: PsiElement, textAttributes: TextAttributesKey
-    ) {
+    fun createAnnotation(holder: AnnotationHolder, element: PsiElement, textAttributes: TextAttributesKey) {
         createAnnotation(holder, element.textRange, textAttributes)
     }
 
-    private fun createAnnotation(
-        holder: AnnotationHolder, range: TextRange, textAttributes: TextAttributesKey
-    ) {
+    private fun createAnnotation(holder: AnnotationHolder, range: TextRange, textAttributes: TextAttributesKey) {
         holder.newSilentAnnotation(HighlightSeverity.INFORMATION).range(range).textAttributes(textAttributes).create()
+    }
+
+    fun createWarningAnnotation(holder: AnnotationHolder, element: PsiElement, message: String) {
+        holder.newAnnotation(HighlightSeverity.WARNING, message).range(element.textRange).create()
+    }
+
+    fun createWarningAnnotationWithFix(holder: AnnotationHolder, element: PsiElement, message: String, quickFix: IntentionAction) {
+        holder.newAnnotation(HighlightSeverity.WARNING, message).range(element.textRange).withFix(quickFix).create()
     }
 
     fun shouldAnnotate(element: PsiElement?): Boolean {

--- a/src/main/kotlin/org/phellang/annotator/quickfixes/PhelFixImportQuickFix.kt
+++ b/src/main/kotlin/org/phellang/annotator/quickfixes/PhelFixImportQuickFix.kt
@@ -1,0 +1,48 @@
+package org.phellang.annotator.quickfixes
+
+import com.intellij.codeInsight.intention.IntentionAction
+import com.intellij.codeInsight.intention.PsiElementBaseIntentionAction
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFileFactory
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.language.infrastructure.PhelLanguage
+import org.phellang.language.psi.PhelSymbol
+
+class PhelFixImportQuickFix(
+    private val symbolToFix: PhelSymbol, private val correctNamespace: String
+) : PsiElementBaseIntentionAction(), IntentionAction {
+
+    override fun getText(): String = "Change to '$correctNamespace'"
+
+    override fun getFamilyName(): String = "Phel namespace imports"
+
+    override fun isAvailable(project: Project, editor: Editor?, element: PsiElement): Boolean {
+        return symbolToFix.isValid
+    }
+
+    override fun invoke(project: Project, editor: Editor?, element: PsiElement) {
+        WriteCommandAction.runWriteCommandAction(project) {
+            replaceNamespace()
+        }
+    }
+
+    private fun replaceNamespace() {
+        val project = symbolToFix.project
+
+        // Create a temporary file with just the namespace symbol
+        val tempFile =
+            PsiFileFactory.getInstance(project).createFileFromText("temp.phel", PhelLanguage, correctNamespace)
+
+        // Extract the symbol from the temporary file
+        val newSymbol = PsiTreeUtil.findChildOfType(tempFile, PhelSymbol::class.java)
+
+        if (newSymbol != null) {
+            symbolToFix.replace(newSymbol)
+        }
+    }
+
+    override fun startInWriteAction(): Boolean = false
+}

--- a/src/main/kotlin/org/phellang/annotator/quickfixes/PhelImportNamespaceQuickFix.kt
+++ b/src/main/kotlin/org/phellang/annotator/quickfixes/PhelImportNamespaceQuickFix.kt
@@ -1,0 +1,40 @@
+package org.phellang.annotator.quickfixes
+
+import com.intellij.codeInsight.intention.IntentionAction
+import com.intellij.codeInsight.intention.PsiElementBaseIntentionAction
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import org.phellang.language.psi.PhelNamespaceImporter
+import org.phellang.language.psi.files.PhelFile
+
+class PhelImportNamespaceQuickFix(
+    private val fullNamespace: String
+) : PsiElementBaseIntentionAction(), IntentionAction {
+
+    override fun getText(): String = "Import '$fullNamespace'"
+
+    override fun getFamilyName(): String = "Phel namespace imports"
+
+    override fun isAvailable(project: Project, editor: Editor?, element: PsiElement): Boolean {
+        val file = element.containingFile as? PhelFile ?: return false
+        // Only available if not already imported
+        return !isAlreadyImported(file)
+    }
+
+    override fun invoke(project: Project, editor: Editor?, element: PsiElement) {
+        val file = element.containingFile as? PhelFile ?: return
+
+        WriteCommandAction.runWriteCommandAction(project) {
+            PhelNamespaceImporter.ensureNamespaceImportedByFullName(file, fullNamespace)
+        }
+    }
+
+    private fun isAlreadyImported(file: PhelFile): Boolean {
+        val nsDeclaration = org.phellang.language.psi.PhelNamespaceUtils.findNamespaceDeclaration(file) ?: return false
+        return org.phellang.language.psi.PhelNamespaceUtils.isNamespaceRequired(nsDeclaration, fullNamespace)
+    }
+
+    override fun startInWriteAction(): Boolean = false
+}

--- a/src/main/kotlin/org/phellang/annotator/quickfixes/PhelRemoveDuplicateImportQuickFix.kt
+++ b/src/main/kotlin/org/phellang/annotator/quickfixes/PhelRemoveDuplicateImportQuickFix.kt
@@ -1,0 +1,45 @@
+package org.phellang.annotator.quickfixes
+
+import com.intellij.codeInsight.intention.IntentionAction
+import com.intellij.codeInsight.intention.PsiElementBaseIntentionAction
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelSymbol
+
+class PhelRemoveDuplicateImportQuickFix(
+    private val symbolToRemove: PhelSymbol
+) : PsiElementBaseIntentionAction(), IntentionAction {
+
+    override fun getText(): String = "Remove duplicate import"
+
+    override fun getFamilyName(): String = "Phel namespace imports"
+
+    override fun isAvailable(project: Project, editor: Editor?, element: PsiElement): Boolean {
+        return symbolToRemove.isValid
+    }
+
+    override fun invoke(project: Project, editor: Editor?, element: PsiElement) {
+        WriteCommandAction.runWriteCommandAction(project) {
+            removeRequireForm()
+        }
+    }
+
+    private fun removeRequireForm() {
+        // Find the parent (:require ...) list and remove it
+        val requireList = PsiTreeUtil.getParentOfType(symbolToRemove, PhelList::class.java)
+        if (requireList != null) {
+            // Also remove any whitespace/newline before the require form
+            val prevSibling = requireList.prevSibling
+            if (prevSibling != null && prevSibling.text.isBlank()) {
+                prevSibling.delete()
+            }
+            requireList.delete()
+        }
+    }
+
+    override fun startInWriteAction(): Boolean = false
+}

--- a/src/main/kotlin/org/phellang/annotator/validators/PhelImportValidator.kt
+++ b/src/main/kotlin/org/phellang/annotator/validators/PhelImportValidator.kt
@@ -1,0 +1,95 @@
+package org.phellang.annotator.validators
+
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.language.psi.PhelNamespaceUtils
+import org.phellang.language.psi.PhelProjectNamespaceFinder
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.files.PhelFile
+
+data class ImportValidationResult(
+    val message: String, val suggestedNamespace: String?, val isDuplicate: Boolean = false
+)
+
+/**
+ * Validates (:require ...) statements to ensure imported namespaces exist.
+ */
+object PhelImportValidator {
+
+    fun validateImport(namespaceSymbol: PhelSymbol): ImportValidationResult? {
+        val fullNamespace = namespaceSymbol.text ?: return null
+
+        // Skip if it doesn't look like a namespace (must contain backslash)
+        if (!fullNamespace.contains("\\")) {
+            return null
+        }
+
+        val project = namespaceSymbol.project
+        val containingFile = namespaceSymbol.containingFile as? PhelFile
+
+        // Check for duplicate imports first
+        if (containingFile != null && isDuplicateImport(containingFile, namespaceSymbol, fullNamespace)) {
+            return ImportValidationResult(
+                message = "Duplicate import: '$fullNamespace' is already imported",
+                suggestedNamespace = null,
+                isDuplicate = true
+            )
+        }
+
+        // Check if it's a standard library namespace
+        if (PhelProjectNamespaceFinder.isStandardLibrary(fullNamespace)) {
+            return null
+        }
+
+        // Check if namespace exists as a project file
+        if (PhelProjectNamespaceFinder.namespaceExists(project, fullNamespace)) {
+            return null
+        }
+
+        // Namespace doesn't exist - try to find a suggestion
+        val shortNamespace = PhelProjectNamespaceFinder.extractShortNamespace(fullNamespace)
+        val suggestion = PhelProjectNamespaceFinder.findByShortName(project, shortNamespace)
+
+        return if (suggestion != null && suggestion != fullNamespace) {
+            ImportValidationResult(
+                message = "Namespace '$fullNamespace' does not exist. Did you mean '$suggestion'?",
+                suggestedNamespace = suggestion
+            )
+        } else {
+            ImportValidationResult(
+                message = "Namespace '$fullNamespace' does not exist", suggestedNamespace = null
+            )
+        }
+    }
+
+    private fun isDuplicateImport(file: PhelFile, currentSymbol: PhelSymbol, namespace: String): Boolean {
+        val nsDeclaration = PhelNamespaceUtils.findNamespaceDeclaration(file) ?: return false
+        val requireForms = PhelNamespaceUtils.findRequireForms(nsDeclaration)
+
+        var foundFirst = false
+
+        for (requireForm in requireForms) {
+            val symbols = PsiTreeUtil.findChildrenOfType(requireForm, PhelSymbol::class.java)
+
+            for (symbol in symbols) {
+                val symbolText = symbol.text ?: continue
+                if (!symbolText.contains("\\")) continue
+
+                if (symbolText == namespace) {
+                    if (symbol === currentSymbol) {
+                        if (foundFirst) {
+                            return true
+                        }
+                    } else {
+                        if (!foundFirst) {
+                            foundFirst = true
+                        } else if (symbol.textOffset < currentSymbol.textOffset) {
+                            return true
+                        }
+                    }
+                }
+            }
+        }
+
+        return false
+    }
+}

--- a/src/main/kotlin/org/phellang/annotator/validators/PhelNamespaceValidator.kt
+++ b/src/main/kotlin/org/phellang/annotator/validators/PhelNamespaceValidator.kt
@@ -1,0 +1,171 @@
+package org.phellang.annotator.validators
+
+import com.intellij.openapi.project.Project
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.core.psi.PhelPsiUtils
+import org.phellang.language.psi.PhelForm
+import org.phellang.language.psi.PhelNamespaceUtils
+import org.phellang.language.psi.PhelProjectNamespaceFinder
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.files.PhelFile
+
+data class NamespaceValidationResult(val message: String, val fullNamespace: String?, val shortNamespace: String)
+
+object PhelNamespaceValidator {
+
+    fun validateNamespace(symbol: PhelSymbol): NamespaceValidationResult? {
+        val text = symbol.text ?: return null
+
+        // Only validate namespace-qualified symbols
+        if (!text.contains("/")) {
+            return null
+        }
+
+        val qualifier = PhelPsiUtils.getQualifier(symbol) ?: return null
+
+        // Skip php/ interop - always valid
+        if (qualifier == "php") {
+            return null
+        }
+
+        // Skip core/ - core functions don't need import
+        if (qualifier == "core") {
+            return null
+        }
+
+        val containingFile = symbol.containingFile as? PhelFile ?: return null
+
+        // Check if the qualifier is imported or aliased AND the namespace exists
+        val importStatus = checkImportStatus(containingFile, qualifier)
+
+        when (importStatus) {
+            ImportStatus.VALID -> return null  // Imported and exists
+            ImportStatus.IMPORTED_BUT_NOT_EXISTS -> {
+                // The namespace is imported but the actual namespace file doesn't exist
+                // Check if a project file exists with matching short namespace
+                val suggestion = PhelProjectNamespaceFinder.findByShortName(symbol.project, qualifier)
+                return if (suggestion != null) {
+                    NamespaceValidationResult(
+                        message = "Imported namespace does not exist. Did you mean '$suggestion'?",
+                        fullNamespace = suggestion,
+                        shortNamespace = qualifier
+                    )
+                } else {
+                    NamespaceValidationResult(
+                        message = "Imported namespace does not exist", fullNamespace = null, shortNamespace = qualifier
+                    )
+                }
+            }
+
+            ImportStatus.NOT_IMPORTED -> {
+                // Not imported - check if we can suggest an import
+            }
+        }
+
+        // Check if it's a standard library namespace
+        val stdLibNamespace = PhelProjectNamespaceFinder.getStandardLibraryFullNamespace(qualifier)
+        if (stdLibNamespace != null) {
+            return NamespaceValidationResult(
+                message = "Namespace '$qualifier' is not imported",
+                fullNamespace = stdLibNamespace,
+                shortNamespace = qualifier
+            )
+        }
+
+        // Check if a project file exists with this namespace
+        val projectNamespace = PhelProjectNamespaceFinder.findByShortName(symbol.project, qualifier)
+        if (projectNamespace != null) {
+            return NamespaceValidationResult(
+                message = "Namespace '$qualifier' is not imported",
+                fullNamespace = projectNamespace,
+                shortNamespace = qualifier
+            )
+        }
+
+        // Namespace doesn't exist at all
+        return NamespaceValidationResult(
+            message = "Namespace '$qualifier' does not exist", fullNamespace = null, shortNamespace = qualifier
+        )
+    }
+
+    private enum class ImportStatus {
+        VALID,                   // Imported and namespace exists
+        IMPORTED_BUT_NOT_EXISTS, // Imported but namespace file doesn't exist
+        NOT_IMPORTED             // Not imported at all
+    }
+
+    private fun checkImportStatus(file: PhelFile, qualifier: String): ImportStatus {
+        val nsDeclaration = PhelNamespaceUtils.findNamespaceDeclaration(file) ?: return ImportStatus.NOT_IMPORTED
+
+        // Check alias map
+        val aliasMap = PhelNamespaceUtils.extractAliasMap(file)
+        if (aliasMap.containsKey(qualifier)) {
+            val aliasedNamespace = aliasMap[qualifier]
+            if (aliasedNamespace != null) {
+                val fullNamespace = getFullNamespaceForAlias(file, aliasedNamespace)
+                if (fullNamespace != null) {
+                    return if (namespaceExistsWithStdLib(file.project, fullNamespace)) {
+                        ImportStatus.VALID
+                    } else {
+                        ImportStatus.IMPORTED_BUT_NOT_EXISTS
+                    }
+                }
+            }
+        }
+
+        // Check direct imports
+        val requireForms = PhelNamespaceUtils.findRequireForms(nsDeclaration)
+        for (requireForm in requireForms) {
+            val forms = PsiTreeUtil.getChildrenOfType(requireForm, PhelForm::class.java) ?: continue
+
+            for (form in forms) {
+                val namespaceSymbol = if (form is PhelSymbol) form
+                else PsiTreeUtil.findChildOfType(form, PhelSymbol::class.java)
+
+                if (namespaceSymbol == null) continue
+                val fullNamespace = namespaceSymbol.text
+                val shortNamespace = PhelProjectNamespaceFinder.extractShortNamespace(fullNamespace)
+                if (shortNamespace != qualifier) continue
+                return if (namespaceExistsWithStdLib(file.project, fullNamespace)) {
+                    ImportStatus.VALID
+                } else {
+                    ImportStatus.IMPORTED_BUT_NOT_EXISTS
+                }
+            }
+        }
+
+        return ImportStatus.NOT_IMPORTED
+    }
+
+    private fun getFullNamespaceForAlias(file: PhelFile, aliasTarget: String): String? {
+        val nsDeclaration = PhelNamespaceUtils.findNamespaceDeclaration(file) ?: return null
+        val requireForms = PhelNamespaceUtils.findRequireForms(nsDeclaration)
+
+        for (requireForm in requireForms) {
+            val forms = PsiTreeUtil.getChildrenOfType(requireForm, PhelForm::class.java) ?: continue
+
+            for (form in forms) {
+                val namespaceSymbol = if (form is PhelSymbol) form
+                else PsiTreeUtil.findChildOfType(form, PhelSymbol::class.java)
+
+                if (namespaceSymbol == null) continue
+                val fullNamespace = namespaceSymbol.text
+                val shortNamespace = PhelProjectNamespaceFinder.extractShortNamespace(fullNamespace)
+                if (shortNamespace == aliasTarget) {
+                    return fullNamespace
+                }
+            }
+        }
+        return null
+    }
+
+    private fun namespaceExistsWithStdLib(project: Project, fullNamespace: String): Boolean {
+        // Check if it's a standard library namespace
+        if (PhelProjectNamespaceFinder.isStandardLibrary(fullNamespace)) {
+            return true
+        }
+
+        // Check project files using shared utility
+        return PhelProjectNamespaceFinder.namespaceExists(project, fullNamespace)
+    }
+}

--- a/src/main/kotlin/org/phellang/completion/data/PhelProjectSymbol.kt
+++ b/src/main/kotlin/org/phellang/completion/data/PhelProjectSymbol.kt
@@ -1,0 +1,26 @@
+package org.phellang.completion.data
+
+import com.intellij.openapi.vfs.VirtualFile
+
+data class PhelProjectSymbol(
+    val namespace: String,
+    val shortNamespace: String,
+    val name: String,
+    val qualifiedName: String,
+    val signature: String,
+    val type: SymbolType,
+    val file: VirtualFile,
+)
+
+enum class SymbolType(val keyword: String) {
+    FUNCTION("defn"), VALUE("def"), MACRO("defmacro"), STRUCT("defstruct"), INTERFACE("definterface");
+
+    companion object {
+        private val keywordMap = entries.associateBy { it.keyword }
+
+        fun fromKeyword(keyword: String): SymbolType? = keywordMap[keyword]
+
+        /** All keywords that define symbols */
+        val definingKeywords: Set<String> = entries.map { it.keyword }.toSet()
+    }
+}

--- a/src/main/kotlin/org/phellang/completion/engine/PhelMainCompletionProvider.kt
+++ b/src/main/kotlin/org/phellang/completion/engine/PhelMainCompletionProvider.kt
@@ -6,6 +6,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.util.ProcessingContext
 import org.phellang.completion.handlers.*
 import org.phellang.completion.infrastructure.PhelCompletionErrorHandler
+import org.phellang.completion.infrastructure.PhelProjectCompletionHelper
 import org.phellang.completion.infrastructure.PhelRegistryCompletionHelper
 import org.phellang.core.utils.PhelErrorHandler
 import org.phellang.language.infrastructure.PhelIcons
@@ -90,7 +91,10 @@ class PhelMainCompletionProvider : CompletionProvider<CompletionParameters?>() {
             val psiFile = element.containingFile as? PhelFile
             val aliasMap = psiFile?.let { PhelNamespaceUtils.extractAliasMap(it) } ?: emptyMap()
 
+            // Local symbols (parameters, let bindings, etc.)
             PhelLocalSymbolCompletions.addLocalSymbols(result, element)
+
+            // Standard library functions
             PhelRegistryCompletionHelper.addCoreFunctions(result, aliasMap)
             PhelRegistryCompletionHelper.addStringFunctions(result, aliasMap)
             PhelRegistryCompletionHelper.addJsonFunctions(result, aliasMap)
@@ -102,6 +106,11 @@ class PhelMainCompletionProvider : CompletionProvider<CompletionParameters?>() {
             PhelRegistryCompletionHelper.addPhpInteropFunctions(result, aliasMap)
             PhelRegistryCompletionHelper.addReplFunctions(result, aliasMap)
             PhelRegistryCompletionHelper.addMockFunctions(result, aliasMap)
+
+            // Project symbols (functions from other project files)
+            if (psiFile != null) {
+                PhelProjectCompletionHelper.addProjectCompletions(result, psiFile, aliasMap)
+            }
         }
     }
 }

--- a/src/main/kotlin/org/phellang/completion/indexing/PhelFileChangeListener.kt
+++ b/src/main/kotlin/org/phellang/completion/indexing/PhelFileChangeListener.kt
@@ -1,0 +1,88 @@
+package org.phellang.completion.indexing
+
+import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.newvfs.BulkFileListener
+import com.intellij.openapi.vfs.newvfs.events.*
+import com.intellij.psi.PsiManager
+
+class PhelFileChangeListener(private val project: Project) : BulkFileListener {
+
+    override fun after(events: List<VFileEvent>) {
+        if (project.isDisposed) return
+
+        val index = PhelProjectSymbolIndex.getInstance(project)
+        var needsReparse = false
+
+        for (event in events) {
+            val file = event.file ?: continue
+
+            if (!isPhelFile(file)) continue
+
+            when (event) {
+                is VFileContentChangeEvent -> {
+                    // File content changed - refresh its symbols
+                    index.refreshFile(file)
+                    needsReparse = true
+                }
+
+                is VFileCreateEvent -> {
+                    // New file created - add to index
+                    index.refreshFile(file)
+                    needsReparse = true
+                }
+
+                is VFileDeleteEvent -> {
+                    // File deleted - remove from index
+                    index.removeFile(file)
+                    needsReparse = true
+                }
+
+                is VFileMoveEvent -> {
+                    // File moved - refresh index
+                    index.refreshFile(file)
+                    needsReparse = true
+                }
+
+                is VFilePropertyChangeEvent -> {
+                    // File renamed
+                    if (event.propertyName == VirtualFile.PROP_NAME) {
+                        index.refreshFile(file)
+                        needsReparse = true
+                    }
+                }
+            }
+        }
+
+        // Trigger re-highlighting of open editors if needed
+        if (needsReparse) {
+            triggerRehighlight()
+        }
+    }
+
+    private fun isPhelFile(file: VirtualFile): Boolean {
+        return file.extension == "phel"
+    }
+
+    private fun triggerRehighlight() {
+        if (project.isDisposed) return
+
+        ApplicationManager.getApplication().invokeLater {
+            if (project.isDisposed) return@invokeLater
+
+            val psiManager = PsiManager.getInstance(project)
+            val fileEditorManager = FileEditorManager.getInstance(project)
+            val daemonCodeAnalyzer = DaemonCodeAnalyzer.getInstance(project)
+
+            // Re-analyze all open Phel files
+            for (file in fileEditorManager.openFiles) {
+                if (file.extension != "phel") continue
+                val psiFile = psiManager.findFile(file) ?: continue
+                daemonCodeAnalyzer.restart(psiFile)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/phellang/completion/indexing/PhelProjectSymbolIndex.kt
+++ b/src/main/kotlin/org/phellang/completion/indexing/PhelProjectSymbolIndex.kt
@@ -1,0 +1,134 @@
+package org.phellang.completion.indexing
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.psi.PsiManager
+import com.intellij.psi.search.FilenameIndex
+import com.intellij.psi.search.GlobalSearchScope
+import org.phellang.completion.data.PhelProjectSymbol
+import org.phellang.language.psi.files.PhelFile
+import java.util.concurrent.ConcurrentHashMap
+
+@Service(Service.Level.PROJECT)
+class PhelProjectSymbolIndex(private val project: Project) : Disposable {
+
+    /** Cache: shortNamespace -> List of symbols */
+    private val symbolsByNamespace = ConcurrentHashMap<String, List<PhelProjectSymbol>>()
+
+    /** Cache: file path -> List of symbols */
+    private val symbolsByFile = ConcurrentHashMap<String, List<PhelProjectSymbol>>()
+
+    /** Whether the index has been built */
+    @Volatile
+    private var indexBuilt = false
+
+    init {
+        // Register file change listener to keep index in sync
+        val connection = project.messageBus.connect(this)
+        connection.subscribe(VirtualFileManager.VFS_CHANGES, PhelFileChangeListener(project))
+    }
+
+    override fun dispose() {
+        symbolsByNamespace.clear()
+        symbolsByFile.clear()
+    }
+
+    fun getSymbolsForNamespace(shortNamespace: String): List<PhelProjectSymbol> {
+        ensureIndexBuilt()
+        return symbolsByNamespace[shortNamespace] ?: emptyList()
+    }
+
+    fun getAllSymbols(): List<PhelProjectSymbol> {
+        ensureIndexBuilt()
+        return symbolsByNamespace.values.flatten()
+    }
+
+    fun refreshFile(file: VirtualFile) {
+        val psiManager = PsiManager.getInstance(project)
+        val psiFile = psiManager.findFile(file) as? PhelFile ?: return
+
+        val oldSymbols = symbolsByFile[file.path] ?: emptyList()
+
+        // Remove old symbols from namespace index
+        for (symbol in oldSymbols) {
+            val namespaceSymbols = symbolsByNamespace[symbol.shortNamespace]?.toMutableList()
+            namespaceSymbols?.removeIf { it.file.path == file.path }
+            if (namespaceSymbols != null) {
+                symbolsByNamespace[symbol.shortNamespace] = namespaceSymbols
+            }
+        }
+
+        // Scan file for new symbols
+        val newSymbols = PhelProjectSymbolScanner.scanFile(psiFile)
+        symbolsByFile[file.path] = newSymbols
+
+        // Add new symbols to namespace index
+        for (symbol in newSymbols) {
+            val existingSymbols = symbolsByNamespace[symbol.shortNamespace]?.toMutableList() ?: mutableListOf()
+            existingSymbols.add(symbol)
+            symbolsByNamespace[symbol.shortNamespace] = existingSymbols
+        }
+    }
+
+    fun removeFile(file: VirtualFile) {
+        val oldSymbols = symbolsByFile.remove(file.path) ?: return
+
+        // Remove symbols from namespace index
+        for (symbol in oldSymbols) {
+            val namespaceSymbols = symbolsByNamespace[symbol.shortNamespace]?.toMutableList()
+            namespaceSymbols?.removeIf { it.file.path == file.path }
+            if (namespaceSymbols != null) {
+                if (namespaceSymbols.isEmpty()) {
+                    symbolsByNamespace.remove(symbol.shortNamespace)
+                } else {
+                    symbolsByNamespace[symbol.shortNamespace] = namespaceSymbols
+                }
+            }
+        }
+    }
+
+    private fun ensureIndexBuilt() {
+        if (!indexBuilt) {
+            synchronized(this) {
+                if (!indexBuilt) {
+                    buildIndex()
+                    indexBuilt = true
+                }
+            }
+        }
+    }
+
+    private fun buildIndex() {
+        val phelFiles = FilenameIndex.getAllFilesByExt(
+            project, "phel", GlobalSearchScope.projectScope(project)
+        )
+
+        val psiManager = PsiManager.getInstance(project)
+
+        for (virtualFile in phelFiles) {
+            val psiFile = psiManager.findFile(virtualFile) as? PhelFile ?: continue
+
+            val symbols = PhelProjectSymbolScanner.scanFile(psiFile)
+
+            if (symbols.isNotEmpty()) {
+                symbolsByFile[virtualFile.path] = symbols
+
+                // Group by namespace
+                for (symbol in symbols) {
+                    val existingSymbols = symbolsByNamespace[symbol.shortNamespace]?.toMutableList() ?: mutableListOf()
+                    existingSymbols.add(symbol)
+                    symbolsByNamespace[symbol.shortNamespace] = existingSymbols
+                }
+            }
+        }
+    }
+
+    companion object {
+        fun getInstance(project: Project): PhelProjectSymbolIndex {
+            return project.getService(PhelProjectSymbolIndex::class.java)
+        }
+    }
+}

--- a/src/main/kotlin/org/phellang/completion/indexing/PhelProjectSymbolScanner.kt
+++ b/src/main/kotlin/org/phellang/completion/indexing/PhelProjectSymbolScanner.kt
@@ -1,0 +1,176 @@
+package org.phellang.completion.indexing
+
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.completion.data.PhelProjectSymbol
+import org.phellang.completion.data.SymbolType
+import org.phellang.language.psi.PhelForm
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelNamespaceUtils
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.PhelVec
+import org.phellang.language.psi.files.PhelFile
+
+object PhelProjectSymbolScanner {
+
+    private val PRIVATE_KEYWORDS = setOf("defn-", "def-", "defmacro-")
+
+    fun scanFile(psiFile: PhelFile): List<PhelProjectSymbol> {
+        val namespace = extractNamespace(psiFile) ?: return emptyList()
+        val shortNamespace = namespace.substringAfterLast("\\")
+        val virtualFile = psiFile.virtualFile ?: return emptyList()
+
+        val symbols = mutableListOf<PhelProjectSymbol>()
+
+        // Find all top-level lists (definitions are at the top level)
+        val topLevelLists = PsiTreeUtil.getChildrenOfType(psiFile, PhelList::class.java) ?: return emptyList()
+
+        for (list in topLevelLists) {
+            val symbol = extractDefinition(list, namespace, shortNamespace, virtualFile)
+            if (symbol != null) {
+                symbols.add(symbol)
+            }
+        }
+
+        return symbols
+    }
+
+    fun extractNamespace(file: PhelFile): String? {
+        return PhelNamespaceUtils.extractNamespaceFromFile(file)
+    }
+
+    private fun extractDefinition(
+        list: PhelList,
+        namespace: String,
+        shortNamespace: String,
+        virtualFile: com.intellij.openapi.vfs.VirtualFile
+    ): PhelProjectSymbol? {
+        val forms = PsiTreeUtil.getChildrenOfType(list, PhelForm::class.java) ?: return null
+
+        if (forms.size < 2) return null
+
+        // Get the defining keyword
+        val keywordSymbol = if (forms[0] is PhelSymbol) {
+            forms[0] as PhelSymbol
+        } else {
+            PsiTreeUtil.findChildOfType(forms[0], PhelSymbol::class.java)
+        } ?: return null
+
+        val keyword = keywordSymbol.text
+
+        // Skip private definition keywords (defn-, def-, defmacro-)
+        if (keyword in PRIVATE_KEYWORDS) {
+            return null
+        }
+
+        val symbolType = SymbolType.fromKeyword(keyword) ?: return null
+
+        // Get the defined name
+        val nameSymbol = if (forms[1] is PhelSymbol) {
+            forms[1] as PhelSymbol
+        } else {
+            PsiTreeUtil.findChildOfType(forms[1], PhelSymbol::class.java)
+        } ?: return null
+
+        val name = nameSymbol.text
+
+        // Check if private - skip private definitions
+        if (isPrivateDefinition(forms)) {
+            return null
+        }
+
+        // Extract signature
+        val signature = extractSignature(keyword, name, forms)
+
+        return PhelProjectSymbol(
+            namespace = namespace,
+            shortNamespace = shortNamespace,
+            name = name,
+            qualifiedName = "$shortNamespace/$name",
+            signature = signature,
+            type = symbolType,
+            file = virtualFile
+        )
+    }
+
+    private fun isPrivateDefinition(forms: Array<PhelForm>): Boolean {
+        for (form in forms) {
+            val text = form.text
+            if (text != null) {
+                if (text.contains(":private")) {
+                    return true
+                }
+            }
+        }
+
+        return false
+    }
+
+    private fun extractSignature(keyword: String, name: String, forms: Array<PhelForm>): String {
+        return when (keyword) {
+            "defn", "defmacro" -> {
+                // Find parameter vector
+                val paramVec = findParameterVector(forms)
+                if (paramVec != null) {
+                    val params = extractParameterNames(paramVec)
+                    "($name ${params.joinToString(" ")})"
+                } else {
+                    "($name)"
+                }
+            }
+
+            "defstruct" -> {
+                // defstruct has fields in a vector
+                val fieldsVec = findParameterVector(forms)
+                if (fieldsVec != null) {
+                    val fields = extractParameterNames(fieldsVec)
+                    "($name ${fields.joinToString(" ")})"
+                } else {
+                    "($name)"
+                }
+            }
+
+            "definterface" -> {
+                "($name ...)"
+            }
+
+            else -> {
+                // def - just the name
+                "($name)"
+            }
+        }
+    }
+
+    private fun findParameterVector(forms: Array<PhelForm>): PhelVec? {
+        // Start from index 2 (after keyword and name)
+        for (i in 2 until forms.size) {
+            val form = forms[i]
+            if (form is PhelVec) {
+                return form
+            }
+            // Also check if the form contains a vector
+            val nestedVec = PsiTreeUtil.findChildOfType(form, PhelVec::class.java)
+            if (nestedVec != null) {
+                return nestedVec
+            }
+        }
+        return null
+    }
+
+    private fun extractParameterNames(paramVec: PhelVec): List<String> {
+        val params = mutableListOf<String>()
+        val forms = PsiTreeUtil.getChildrenOfType(paramVec, PhelForm::class.java) ?: return params
+
+        for (form in forms) {
+            val symbol = if (form is PhelSymbol) {
+                form
+            } else {
+                PsiTreeUtil.findChildOfType(form, PhelSymbol::class.java)
+            }
+            if (symbol != null) {
+                params.add(symbol.text)
+            }
+        }
+
+        return params
+    }
+}

--- a/src/main/kotlin/org/phellang/completion/infrastructure/PhelProjectCompletionHelper.kt
+++ b/src/main/kotlin/org/phellang/completion/infrastructure/PhelProjectCompletionHelper.kt
@@ -1,0 +1,171 @@
+package org.phellang.completion.infrastructure
+
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.completion.data.PhelProjectSymbol
+import org.phellang.completion.data.SymbolType
+import org.phellang.completion.indexing.PhelProjectSymbolIndex
+import org.phellang.language.psi.PhelForm
+import org.phellang.language.psi.PhelKeyword
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelNamespaceUtils
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.files.PhelFile
+
+object PhelProjectCompletionHelper {
+
+    @JvmStatic
+    fun addProjectCompletions(
+        result: CompletionResultSet, file: PhelFile, aliasMap: Map<String, String>
+    ) {
+        val index = PhelProjectSymbolIndex.getInstance(file.project)
+        val importedNamespaces = extractImportedNamespaces(file)
+        val currentFileNamespace = PhelNamespaceUtils.findNamespaceDeclaration(file)?.let {
+            extractNamespaceFromDeclaration(it)
+        }
+        val currentFilePath = file.virtualFile?.path
+
+        // Track which namespaces we've already added (to avoid duplicates)
+        val addedNamespaces = mutableSetOf<String>()
+
+        // 1. Add completions for imported namespaces (with proper aliases)
+        for (importInfo in importedNamespaces) {
+            val symbols = index.getSymbolsForNamespace(importInfo.shortNamespace)
+            addedNamespaces.add(importInfo.shortNamespace)
+
+            for (symbol in symbols) {
+                // Skip symbols from the current file (already provided by local completions)
+                if (symbol.file.path == currentFilePath) {
+                    continue
+                }
+
+                val displayName = transformWithAlias(symbol, importInfo, aliasMap)
+                addProjectSymbolCompletion(result, symbol, displayName)
+            }
+        }
+
+        // 2. Add completions for ALL other project namespaces (not yet imported)
+        // These will be auto-imported when selected
+        val allSymbols = index.getAllSymbols()
+        for (symbol in allSymbols) {
+            // Skip if from current file
+            if (symbol.file.path == currentFilePath) {
+                continue
+            }
+
+            // Skip if namespace already handled above (imported)
+            if (symbol.shortNamespace in addedNamespaces) {
+                continue
+            }
+
+            // Skip current file's namespace
+            if (symbol.shortNamespace == currentFileNamespace) {
+                continue
+            }
+
+            // Add with qualified name (namespace/function)
+            addProjectSymbolCompletion(result, symbol, symbol.qualifiedName)
+        }
+    }
+
+    private fun extractImportedNamespaces(file: PhelFile): List<ImportInfo> {
+        val imports = mutableListOf<ImportInfo>()
+        val nsDeclaration = PhelNamespaceUtils.findNamespaceDeclaration(file) ?: return imports
+        val requireForms = PhelNamespaceUtils.findRequireForms(nsDeclaration)
+
+        for (requireForm in requireForms) {
+            val forms = PsiTreeUtil.getChildrenOfType(requireForm, PhelForm::class.java) ?: continue
+
+            // Skip the :require keyword (first form)
+            var i = 1
+            while (i < forms.size) {
+                val form = forms[i]
+
+                // Get the namespace symbol
+                val namespaceSymbol = if (form is PhelSymbol) form
+                else PsiTreeUtil.findChildOfType(form, PhelSymbol::class.java)
+
+                if (namespaceSymbol != null) {
+                    val fullNamespace = namespaceSymbol.text
+                    val shortNamespace = fullNamespace.substringAfterLast("\\")
+                    var alias: String?
+
+                    // Check if next form is :as keyword
+                    if (i + 1 < forms.size) {
+                        val nextForm = forms[i + 1]
+                        val asKeyword =
+                            nextForm as? PhelKeyword ?: PsiTreeUtil.findChildOfType(nextForm, PhelKeyword::class.java)
+
+                        if (asKeyword?.text == ":as" && i + 2 < forms.size) {
+                            // Get the alias symbol
+                            val aliasForm = forms[i + 2]
+                            val aliasSymbol = if (aliasForm is PhelSymbol) aliasForm
+                            else PsiTreeUtil.findChildOfType(aliasForm, PhelSymbol::class.java)
+
+                            if (aliasSymbol != null) {
+                                alias = aliasSymbol.text
+                                i += 3  // Skip namespace, :as, and alias
+                                imports.add(ImportInfo(fullNamespace, shortNamespace, alias))
+                                continue
+                            }
+                        }
+                    }
+
+                    imports.add(ImportInfo(fullNamespace, shortNamespace, null))
+                }
+                i++
+            }
+        }
+
+        return imports
+    }
+
+    private fun extractNamespaceFromDeclaration(nsDeclaration: PhelList): String? {
+        return PhelNamespaceUtils.extractShortNamespaceFromDeclaration(nsDeclaration)
+    }
+
+    private fun transformWithAlias(
+        symbol: PhelProjectSymbol, importInfo: ImportInfo, aliasMap: Map<String, String>
+    ): String {
+        // If the import has an alias, use it
+        if (importInfo.alias != null) {
+            return "${importInfo.alias}/${symbol.name}"
+        }
+
+        // Check if there's an alias for this namespace in the aliasMap
+        val alias = aliasMap.entries.find { it.value == symbol.shortNamespace }?.key
+        return if (alias != null) {
+            "$alias/${symbol.name}"
+        } else {
+            symbol.qualifiedName
+        }
+    }
+
+    private fun addProjectSymbolCompletion(
+        result: CompletionResultSet, symbol: PhelProjectSymbol, displayName: String
+    ) {
+        val priority = when (symbol.type) {
+            SymbolType.FUNCTION -> PhelCompletionPriority.PROJECT_SYMBOLS
+            SymbolType.MACRO -> PhelCompletionPriority.PROJECT_SYMBOLS
+            SymbolType.VALUE -> PhelCompletionPriority.PROJECT_SYMBOLS
+            SymbolType.STRUCT -> PhelCompletionPriority.PROJECT_SYMBOLS
+            SymbolType.INTERFACE -> PhelCompletionPriority.PROJECT_SYMBOLS
+        }
+
+        val description = when (symbol.type) {
+            SymbolType.FUNCTION -> "function"
+            SymbolType.MACRO -> "macro"
+            SymbolType.VALUE -> "value"
+            SymbolType.STRUCT -> "struct"
+            SymbolType.INTERFACE -> "interface"
+        }
+
+        PhelCompletionUtils.addRankedCompletionWithNamespace(
+            result, displayName, symbol.signature, description, priority, symbol.namespace
+        )
+    }
+
+    private data class ImportInfo(
+        val fullNamespace: String, val shortNamespace: String, val alias: String?
+    )
+}

--- a/src/main/kotlin/org/phellang/documentation/resolvers/PhelSymbolDocumentationResolver.kt
+++ b/src/main/kotlin/org/phellang/documentation/resolvers/PhelSymbolDocumentationResolver.kt
@@ -90,6 +90,11 @@ class PhelSymbolDocumentationResolver {
             return true
         }
 
+        // PHP interop namespace is always available (built-in language feature)
+        if (shortNamespace == "php") {
+            return true
+        }
+
         val nsDeclaration = PhelNamespaceUtils.findNamespaceDeclaration(file) ?: return false
         val phelNamespace = PhelNamespaceUtils.toPhelNamespace(shortNamespace)
 

--- a/src/main/kotlin/org/phellang/language/psi/PhelNamespaceImporter.kt
+++ b/src/main/kotlin/org/phellang/language/psi/PhelNamespaceImporter.kt
@@ -3,19 +3,8 @@ package org.phellang.language.psi
 import com.intellij.openapi.project.Project
 import org.phellang.language.psi.files.PhelFile
 
-/**
- * Handles adding namespace imports to Phel files.
- */
 object PhelNamespaceImporter {
 
-    /**
-     * Ensures a namespace is imported in the file.
-     * If not already imported, adds (:require phel\namespace) to the ns declaration.
-     * 
-     * @param file The Phel file
-     * @param namespace The short namespace name (e.g., "str", "http")
-     * @return true if import was added or already existed
-     */
     fun ensureNamespaceImported(file: PhelFile, namespace: String): Boolean {
         if (PhelNamespaceUtils.isCoreNamespace(namespace)) {
             return true // Core namespace doesn't need import
@@ -33,15 +22,23 @@ object PhelNamespaceImporter {
         return addRequireToNamespace(file.project, nsDeclaration, phelNamespace)
     }
 
-    /**
-     * Adds a require form to the namespace declaration.
-     * Always adds a new (:require ...) form to avoid breaking existing requires with aliases.
-     */
+    fun ensureNamespaceImportedByFullName(file: PhelFile, fullNamespace: String): Boolean {
+        val nsDeclaration = PhelNamespaceUtils.findNamespaceDeclaration(file) ?: return false
+
+        // Check if already imported
+        if (PhelNamespaceUtils.isNamespaceRequired(nsDeclaration, fullNamespace)) {
+            return true
+        }
+
+        // Add the :require with the full namespace
+        return addRequireToNamespace(file.project, nsDeclaration, fullNamespace)
+    }
+
     private fun addRequireToNamespace(project: Project, nsDeclaration: PhelList, namespace: String): Boolean {
         try {
             addNewRequireForm(project, nsDeclaration, namespace)
             return true
-        } catch (e: Exception) {
+        } catch (_: Exception) {
             return false
         }
     }

--- a/src/main/kotlin/org/phellang/language/psi/PhelProjectNamespaceFinder.kt
+++ b/src/main/kotlin/org/phellang/language/psi/PhelProjectNamespaceFinder.kt
@@ -1,0 +1,71 @@
+package org.phellang.language.psi
+
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiManager
+import com.intellij.psi.search.FilenameIndex
+import com.intellij.psi.search.GlobalSearchScope
+import org.phellang.completion.indexing.PhelProjectSymbolScanner
+import org.phellang.language.psi.files.PhelFile
+
+object PhelProjectNamespaceFinder {
+
+    val STANDARD_LIBRARY_SHORT_TO_FULL = mapOf(
+        "str" to "phel\\str",
+        "json" to "phel\\json",
+        "http" to "phel\\http",
+        "html" to "phel\\html",
+        "base64" to "phel\\base64",
+        "test" to "phel\\test",
+        "mock" to "phel\\mock",
+        "repl" to "phel\\repl",
+        "debug" to "phel\\debug",
+        "core" to "phel\\core",
+    )
+
+    val STANDARD_LIBRARY_NAMESPACES: Set<String> = STANDARD_LIBRARY_SHORT_TO_FULL.values.toSet()
+
+    fun namespaceExists(project: Project, fullNamespace: String): Boolean {
+        // Check standard library first
+        if (fullNamespace in STANDARD_LIBRARY_NAMESPACES) {
+            return true
+        }
+        
+        // Search project files
+        return findAllProjectNamespaces(project).any { it == fullNamespace }
+    }
+
+    fun findByShortName(project: Project, shortNamespace: String): String? {
+        return findAllProjectNamespaces(project).find { 
+            extractShortNamespace(it) == shortNamespace 
+        }
+    }
+
+    fun extractShortNamespace(fullNamespace: String): String {
+        return fullNamespace.substringAfterLast("\\")
+    }
+
+    fun isStandardLibrary(fullNamespace: String): Boolean {
+        return fullNamespace in STANDARD_LIBRARY_NAMESPACES
+    }
+
+    fun getStandardLibraryFullNamespace(shortName: String): String? {
+        return STANDARD_LIBRARY_SHORT_TO_FULL[shortName.lowercase()]
+    }
+
+    fun findAllProjectNamespaces(project: Project): List<String> {
+        val namespaces = mutableListOf<String>()
+        
+        val phelFiles = FilenameIndex.getAllFilesByExt(
+            project, "phel", GlobalSearchScope.projectScope(project)
+        )
+        val psiManager = PsiManager.getInstance(project)
+
+        for (virtualFile in phelFiles) {
+            val psiFile = psiManager.findFile(virtualFile) as? PhelFile ?: continue
+            val fileNamespace = PhelProjectSymbolScanner.extractNamespace(psiFile) ?: continue
+            namespaces.add(fileNamespace)
+        }
+
+        return namespaces
+    }
+}

--- a/src/main/kotlin/org/phellang/language/psi/PhelVendorUtils.kt
+++ b/src/main/kotlin/org/phellang/language/psi/PhelVendorUtils.kt
@@ -1,0 +1,56 @@
+package org.phellang.language.psi
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.search.FilenameIndex
+import com.intellij.psi.search.GlobalSearchScope
+
+object PhelVendorUtils {
+
+    private const val PHEL_VENDOR_PATH = "phel-lang/phel-lang/src/phel"
+
+    private val NAMESPACE_TO_FILE = mapOf(
+        "core" to "core.phel",
+        "str" to "str.phel",
+        "json" to "json.phel",
+        "http" to "http.phel",
+        "html" to "html.phel",
+        "base64" to "base64.phel",
+        "test" to "test.phel",
+        "mock" to "mock.phel",
+        "repl" to "repl.phel",
+        "debug" to "debug.phel",
+    )
+
+    fun findVendorFolder(project: Project): VirtualFile? {
+        // First try: Look for composer.json
+        val composerFiles =
+            FilenameIndex.getVirtualFilesByName("composer.json", GlobalSearchScope.projectScope(project))
+
+        for (composerFile in composerFiles) {
+            val projectRoot = composerFile.parent ?: continue
+            val vendorFolder = projectRoot.findChild("vendor")
+            if (vendorFolder != null && vendorFolder.isDirectory) {
+                return vendorFolder
+            }
+        }
+
+        // Second try: Check project base path
+        val basePath = project.basePath ?: return null
+        val projectRoot = LocalFileSystem.getInstance().findFileByPath(basePath)
+        return projectRoot?.findChild("vendor")
+    }
+
+    fun findPhelLibraryFolder(project: Project): VirtualFile? {
+        val vendorFolder = findVendorFolder(project) ?: return null
+        val phelFolder = vendorFolder.findFileByRelativePath(PHEL_VENDOR_PATH)
+        return if (phelFolder != null && phelFolder.isDirectory) phelFolder else null
+    }
+
+    fun findStandardLibraryFile(project: Project, namespace: String): VirtualFile? {
+        val phelFolder = findPhelLibraryFolder(project) ?: return null
+        val fileName = NAMESPACE_TO_FILE[namespace] ?: return null
+        return phelFolder.findChild(fileName)
+    }
+}

--- a/src/test/kotlin/org/phellang/unit/annotator/highlighters/PhelRequireHighlighterTest.kt
+++ b/src/test/kotlin/org/phellang/unit/annotator/highlighters/PhelRequireHighlighterTest.kt
@@ -1,0 +1,108 @@
+package org.phellang.unit.annotator.highlighters
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for PhelRequireHighlighter logic.
+ * Note: Full highlighting requires IntelliJ platform.
+ */
+class PhelRequireHighlighterTest {
+
+    @Nested
+    inner class NamespaceInRequireFormDetection {
+
+        @Test
+        fun `namespace must contain backslash to be in require form`() {
+            val validNamespaces = listOf(
+                "phel\\str",
+                "my-project\\utils",
+                "app\\lib\\helpers"
+            )
+
+            for (ns in validNamespaces) {
+                assertTrue(ns.contains("\\"), "$ns should be considered a namespace")
+            }
+        }
+
+        @Test
+        fun `simple symbols without backslash are not namespaces`() {
+            val notNamespaces = listOf(
+                "str",
+                ":require",
+                ":as",
+                "alias"
+            )
+
+            for (ns in notNamespaces) {
+                assertFalse(ns.contains("\\"), "$ns should not be considered a namespace")
+            }
+        }
+    }
+
+    @Nested
+    inner class RequireFormStructure {
+
+        @Test
+        fun `require keyword is correct`() {
+            val requireKeyword = ":require"
+            assertEquals(":require", requireKeyword)
+        }
+
+        @Test
+        fun `as keyword for aliases`() {
+            val asKeyword = ":as"
+            assertEquals(":as", asKeyword)
+        }
+
+        @Test
+        fun `typical require form structure`() {
+            // (:require phel\str)
+            val elements = listOf(":require", "phel\\str")
+            assertEquals(":require", elements[0])
+            assertTrue(elements[1].contains("\\"))
+        }
+
+        @Test
+        fun `require form with alias structure`() {
+            // (:require phel\str :as s)
+            val elements = listOf(":require", "phel\\str", ":as", "s")
+            assertEquals(":require", elements[0])
+            assertTrue(elements[1].contains("\\"))
+            assertEquals(":as", elements[2])
+            assertFalse(elements[3].contains("\\"))
+        }
+    }
+
+    @Nested
+    inner class ValidationResultHandling {
+
+        @Test
+        fun `duplicate result triggers remove quick fix`() {
+            data class MockResult(val isDuplicate: Boolean, val suggestedNamespace: String?)
+
+            val duplicateResult = MockResult(isDuplicate = true, suggestedNamespace = null)
+            assertTrue(duplicateResult.isDuplicate)
+            assertNull(duplicateResult.suggestedNamespace)
+        }
+
+        @Test
+        fun `suggestion result triggers fix quick fix`() {
+            data class MockResult(val isDuplicate: Boolean, val suggestedNamespace: String?)
+
+            val suggestionResult = MockResult(isDuplicate = false, suggestedNamespace = "my-project\\utils")
+            assertFalse(suggestionResult.isDuplicate)
+            assertNotNull(suggestionResult.suggestedNamespace)
+        }
+
+        @Test
+        fun `no suggestion result shows warning only`() {
+            data class MockResult(val isDuplicate: Boolean, val suggestedNamespace: String?)
+
+            val noSuggestionResult = MockResult(isDuplicate = false, suggestedNamespace = null)
+            assertFalse(noSuggestionResult.isDuplicate)
+            assertNull(noSuggestionResult.suggestedNamespace)
+        }
+    }
+}

--- a/src/test/kotlin/org/phellang/unit/annotator/quickfixes/PhelQuickFixesTest.kt
+++ b/src/test/kotlin/org/phellang/unit/annotator/quickfixes/PhelQuickFixesTest.kt
@@ -1,0 +1,59 @@
+package org.phellang.unit.annotator.quickfixes
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for Phel quick fix logic and patterns.
+ * Note: Full quick fix behavior requires IntelliJ platform.
+ */
+class PhelQuickFixesTest {
+
+    @Nested
+    inner class ImportNamespaceQuickFix {
+
+        @Test
+        fun `quick fix text format for import`() {
+            val namespace = "phel\\str"
+            val text = "Import '$namespace'"
+            assertEquals("Import 'phel\\str'", text)
+        }
+
+        @Test
+        fun `family name is consistent`() {
+            val familyName = "Phel namespace imports"
+            assertEquals("Phel namespace imports", familyName)
+        }
+
+        @Test
+        fun `quick fix text for project namespace`() {
+            val namespace = "my-project\\utils"
+            val text = "Import '$namespace'"
+            assertEquals("Import 'my-project\\utils'", text)
+        }
+    }
+
+    @Nested
+    inner class FixImportQuickFix {
+
+        @Test
+        fun `quick fix text format for replacing namespace`() {
+            val oldNamespace = "my-project\\utls"
+            val newNamespace = "my-project\\utils"
+            val text = "Replace with '$newNamespace'"
+            assertEquals("Replace with 'my-project\\utils'", text)
+        }
+    }
+
+    @Nested
+    inner class RemoveDuplicateImportQuickFix {
+
+        @Test
+        fun `quick fix text format for removing duplicate`() {
+            val namespace = "phel\\str"
+            val text = "Remove duplicate import of '$namespace'"
+            assertEquals("Remove duplicate import of 'phel\\str'", text)
+        }
+    }
+}

--- a/src/test/kotlin/org/phellang/unit/annotator/validators/PhelImportValidatorTest.kt
+++ b/src/test/kotlin/org/phellang/unit/annotator/validators/PhelImportValidatorTest.kt
@@ -1,0 +1,58 @@
+package org.phellang.unit.annotator.validators
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class PhelImportValidatorTest {
+
+    @Nested
+    inner class NamespacePatternValidation {
+
+        @Test
+        fun `namespace must contain backslash to be validated`() {
+            val validNamespaces = listOf(
+                "phel\\str", "my-project\\utils", "app\\lib\\helpers"
+            )
+
+            for (ns in validNamespaces) {
+                assertTrue(ns.contains("\\"), "$ns should contain backslash")
+            }
+        }
+
+        @Test
+        fun `simple names without backslash are skipped`() {
+            val invalidNamespaces = listOf("str", "utils", "helpers")
+
+            for (ns in invalidNamespaces) {
+                assertFalse(ns.contains("\\"), "$ns should not contain backslash")
+            }
+        }
+    }
+
+    @Nested
+    inner class ValidationMessages {
+
+        @Test
+        fun `duplicate import message format`() {
+            val namespace = "phel\\str"
+            val message = "Duplicate import: '$namespace' is already imported"
+            assertEquals("Duplicate import: 'phel\\str' is already imported", message)
+        }
+
+        @Test
+        fun `namespace does not exist message format`() {
+            val namespace = "my-project\\unknown"
+            val message = "Namespace '$namespace' does not exist"
+            assertEquals("Namespace 'my-project\\unknown' does not exist", message)
+        }
+
+        @Test
+        fun `namespace does not exist with suggestion message format`() {
+            val namespace = "my-project\\utls"
+            val suggestion = "my-project\\utils"
+            val message = "Namespace '$namespace' does not exist. Did you mean '$suggestion'?"
+            assertEquals("Namespace 'my-project\\utls' does not exist. Did you mean 'my-project\\utils'?", message)
+        }
+    }
+}

--- a/src/test/kotlin/org/phellang/unit/annotator/validators/PhelNamespaceValidatorTest.kt
+++ b/src/test/kotlin/org/phellang/unit/annotator/validators/PhelNamespaceValidatorTest.kt
@@ -1,0 +1,184 @@
+package org.phellang.unit.annotator.validators
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.phellang.language.psi.PhelProjectNamespaceFinder
+
+class PhelNamespaceValidatorTest {
+
+    // Use the shared mapping from PhelProjectNamespaceFinder (single source of truth)
+    private val standardLibraryShortToFull = PhelProjectNamespaceFinder.STANDARD_LIBRARY_SHORT_TO_FULL
+
+    @Nested
+    inner class StandardLibraryMapping {
+
+        @Test
+        fun `all standard library short names map to full namespaces`() {
+            val expectedMappings = mapOf(
+                "str" to "phel\\str",
+                "json" to "phel\\json",
+                "http" to "phel\\http",
+                "html" to "phel\\html",
+                "base64" to "phel\\base64",
+                "test" to "phel\\test",
+                "mock" to "phel\\mock",
+                "repl" to "phel\\repl",
+                "debug" to "phel\\debug",
+                "core" to "phel\\core"
+            )
+
+            assertEquals(expectedMappings, standardLibraryShortToFull)
+        }
+
+        @Test
+        fun `str maps to phel str`() {
+            assertEquals("phel\\str", standardLibraryShortToFull["str"])
+        }
+
+        @Test
+        fun `json maps to phel json`() {
+            assertEquals("phel\\json", standardLibraryShortToFull["json"])
+        }
+
+        @Test
+        fun `core is in short-to-full map`() {
+            // core is in the map but handled specially in validation (doesn't need import)
+            assertEquals("phel\\core", standardLibraryShortToFull["core"])
+        }
+
+        @Test
+        fun `php is not in short-to-full map`() {
+            // php is handled specially - always valid
+            assertNull(standardLibraryShortToFull["php"])
+        }
+    }
+
+    @Nested
+    inner class QualifierExtraction {
+
+        @Test
+        fun `qualifier is part before slash`() {
+            // Simulating PhelPsiUtils.getQualifier behavior
+            val symbolText = "str/join"
+            val qualifier = symbolText.substringBefore("/")
+            assertEquals("str", qualifier)
+        }
+
+        @Test
+        fun `nested namespace qualifier`() {
+            val symbolText = "my-app/helper"
+            val qualifier = symbolText.substringBefore("/")
+            assertEquals("my-app", qualifier)
+        }
+
+        @Test
+        fun `no qualifier for unqualified symbol`() {
+            val symbolText = "map"
+            val hasQualifier = symbolText.contains("/")
+            assertFalse(hasQualifier)
+        }
+    }
+
+    @Nested
+    inner class SkipConditions {
+
+        @Test
+        fun `php qualifier should be skipped`() {
+            val qualifier = "php"
+            val shouldSkip = qualifier == "php" || qualifier == "core"
+            assertTrue(shouldSkip)
+        }
+
+        @Test
+        fun `core qualifier should be skipped`() {
+            val qualifier = "core"
+            val shouldSkip = qualifier == "php" || qualifier == "core"
+            assertTrue(shouldSkip)
+        }
+
+        @Test
+        fun `str qualifier should not be skipped`() {
+            val qualifier = "str"
+            val shouldSkip = qualifier == "php" || qualifier == "core"
+            assertFalse(shouldSkip)
+        }
+
+        @Test
+        fun `project namespace should not be skipped`() {
+            val qualifier = "utils"
+            val shouldSkip = qualifier == "php" || qualifier == "core"
+            assertFalse(shouldSkip)
+        }
+    }
+
+    @Nested
+    inner class ImportStatusLogic {
+
+        @Test
+        fun `VALID status means no error`() {
+            val status = "VALID"
+            val shouldReturnNull = status == "VALID"
+            assertTrue(shouldReturnNull)
+        }
+
+        @Test
+        fun `IMPORTED_BUT_NOT_EXISTS should suggest alternative`() {
+            val status = "IMPORTED_BUT_NOT_EXISTS"
+            val shouldSuggestAlternative = status == "IMPORTED_BUT_NOT_EXISTS"
+            assertTrue(shouldSuggestAlternative)
+        }
+
+        @Test
+        fun `NOT_IMPORTED should check for possible imports`() {
+            val status = "NOT_IMPORTED"
+            val shouldCheckPossibleImports = status == "NOT_IMPORTED"
+            assertTrue(shouldCheckPossibleImports)
+        }
+    }
+
+    @Nested
+    inner class MessageGeneration {
+
+        @Test
+        fun `namespace not imported message format`() {
+            val qualifier = "str"
+            val message = "Namespace '$qualifier' is not imported"
+            assertEquals("Namespace 'str' is not imported", message)
+        }
+
+        @Test
+        fun `namespace does not exist message format`() {
+            val qualifier = "unknown"
+            val message = "Namespace '$qualifier' does not exist"
+            assertEquals("Namespace 'unknown' does not exist", message)
+        }
+
+        @Test
+        fun `imported namespace does not exist with suggestion message format`() {
+            val suggestion = "phel-project\\utils"
+            val message = "Imported namespace does not exist. Did you mean '$suggestion'?"
+            assertEquals("Imported namespace does not exist. Did you mean 'phel-project\\utils'?", message)
+        }
+    }
+
+    @Nested
+    inner class NamespaceExistenceCheck {
+
+        @Test
+        fun `standard library namespace should exist if starts with phel`() {
+            val fullNamespace = "phel\\str"
+            val shortName = fullNamespace.substringAfterLast("\\")
+            val isStdLib = fullNamespace.startsWith("phel\\") && standardLibraryShortToFull.containsKey(shortName)
+            assertTrue(isStdLib)
+        }
+
+        @Test
+        fun `project namespace should not match standard library check`() {
+            val fullNamespace = "phel-project\\str"
+            val shortName = fullNamespace.substringAfterLast("\\")
+            val isStdLib = fullNamespace.startsWith("phel\\") && standardLibraryShortToFull.containsKey(shortName)
+            assertFalse(isStdLib) // Doesn't start with "phel\"
+        }
+    }
+}

--- a/src/test/kotlin/org/phellang/unit/annotator/validators/ValidationResultTest.kt
+++ b/src/test/kotlin/org/phellang/unit/annotator/validators/ValidationResultTest.kt
@@ -1,0 +1,182 @@
+package org.phellang.unit.annotator.validators
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.phellang.annotator.validators.ImportValidationResult
+import org.phellang.annotator.validators.NamespaceValidationResult
+
+class ValidationResultTest {
+
+    @Nested
+    inner class ImportValidationResultTests {
+
+        @Test
+        fun `creates result with all fields`() {
+            val result = ImportValidationResult(
+                message = "Namespace does not exist",
+                suggestedNamespace = "phel-project\\utils",
+                isDuplicate = false
+            )
+
+            assertEquals("Namespace does not exist", result.message)
+            assertEquals("phel-project\\utils", result.suggestedNamespace)
+            assertFalse(result.isDuplicate)
+        }
+
+        @Test
+        fun `isDuplicate defaults to false`() {
+            val result = ImportValidationResult(
+                message = "Test message",
+                suggestedNamespace = null
+            )
+
+            assertFalse(result.isDuplicate)
+        }
+
+        @Test
+        fun `creates duplicate import result`() {
+            val result = ImportValidationResult(
+                message = "Duplicate import: 'phel\\str' is already imported",
+                suggestedNamespace = null,
+                isDuplicate = true
+            )
+
+            assertTrue(result.isDuplicate)
+            assertNull(result.suggestedNamespace)
+        }
+
+        @Test
+        fun `creates result with suggestion`() {
+            val result = ImportValidationResult(
+                message = "Did you mean 'phel-project\\utils'?",
+                suggestedNamespace = "phel-project\\utils"
+            )
+
+            assertNotNull(result.suggestedNamespace)
+            assertEquals("phel-project\\utils", result.suggestedNamespace)
+        }
+
+        @Test
+        fun `creates result without suggestion`() {
+            val result = ImportValidationResult(
+                message = "Namespace does not exist",
+                suggestedNamespace = null
+            )
+
+            assertNull(result.suggestedNamespace)
+        }
+
+        @Test
+        fun `equality works correctly`() {
+            val result1 = ImportValidationResult("msg", "ns", false)
+            val result2 = ImportValidationResult("msg", "ns", false)
+            val result3 = ImportValidationResult("msg", "ns", true)
+
+            assertEquals(result1, result2)
+            assertNotEquals(result1, result3)
+        }
+    }
+
+    @Nested
+    inner class NamespaceValidationResultTests {
+
+        @Test
+        fun `creates result with all fields`() {
+            val result = NamespaceValidationResult(
+                message = "Namespace 'str' is not imported",
+                fullNamespace = "phel\\str",
+                shortNamespace = "str"
+            )
+
+            assertEquals("Namespace 'str' is not imported", result.message)
+            assertEquals("phel\\str", result.fullNamespace)
+            assertEquals("str", result.shortNamespace)
+        }
+
+        @Test
+        fun `creates result with null fullNamespace`() {
+            val result = NamespaceValidationResult(
+                message = "Namespace 'unknown' does not exist",
+                fullNamespace = null,
+                shortNamespace = "unknown"
+            )
+
+            assertNull(result.fullNamespace)
+            assertEquals("unknown", result.shortNamespace)
+        }
+
+        @Test
+        fun `creates result for standard library`() {
+            val result = NamespaceValidationResult(
+                message = "Namespace 'str' is not imported",
+                fullNamespace = "phel\\str",
+                shortNamespace = "str"
+            )
+
+            assertEquals("phel\\str", result.fullNamespace)
+        }
+
+        @Test
+        fun `creates result for project namespace`() {
+            val result = NamespaceValidationResult(
+                message = "Namespace 'utils' is not imported",
+                fullNamespace = "phel-project\\utils",
+                shortNamespace = "utils"
+            )
+
+            assertEquals("phel-project\\utils", result.fullNamespace)
+            assertEquals("utils", result.shortNamespace)
+        }
+
+        @Test
+        fun `equality works correctly`() {
+            val result1 = NamespaceValidationResult("msg", "full", "short")
+            val result2 = NamespaceValidationResult("msg", "full", "short")
+            val result3 = NamespaceValidationResult("msg", null, "short")
+
+            assertEquals(result1, result2)
+            assertNotEquals(result1, result3)
+        }
+
+        @Test
+        fun `copy works correctly`() {
+            val result = NamespaceValidationResult("original", "phel\\str", "str")
+            val copied = result.copy(message = "modified")
+
+            assertEquals("modified", copied.message)
+            assertEquals("phel\\str", copied.fullNamespace)
+            assertEquals("str", copied.shortNamespace)
+        }
+    }
+
+    @Nested
+    inner class ComparisonTests {
+
+        @Test
+        fun `both result types have message field`() {
+            val importResult = ImportValidationResult("import message", null)
+            val namespaceResult = NamespaceValidationResult("namespace message", null, "short")
+
+            assertNotNull(importResult.message)
+            assertNotNull(namespaceResult.message)
+        }
+
+        @Test
+        fun `suggested namespace in ImportResult serves same purpose as fullNamespace in NamespaceResult`() {
+            // Both fields store the full namespace that can be used for quick fixes
+            val importResult = ImportValidationResult(
+                message = "msg",
+                suggestedNamespace = "phel\\str"
+            )
+            val namespaceResult = NamespaceValidationResult(
+                message = "msg",
+                fullNamespace = "phel\\str",
+                shortNamespace = "str"
+            )
+
+            // Both can be used to import the correct namespace
+            assertEquals(importResult.suggestedNamespace, namespaceResult.fullNamespace)
+        }
+    }
+}

--- a/src/test/kotlin/org/phellang/unit/completion/data/PhelProjectSymbolTest.kt
+++ b/src/test/kotlin/org/phellang/unit/completion/data/PhelProjectSymbolTest.kt
@@ -1,0 +1,86 @@
+package org.phellang.unit.completion.data
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.phellang.completion.data.SymbolType
+
+class PhelProjectSymbolTest {
+
+    @Nested
+    inner class SymbolTypeTests {
+
+        @Test
+        fun `fromKeyword returns correct type for defn`() {
+            assertEquals(SymbolType.FUNCTION, SymbolType.fromKeyword("defn"))
+        }
+
+        @Test
+        fun `fromKeyword returns correct type for def`() {
+            assertEquals(SymbolType.VALUE, SymbolType.fromKeyword("def"))
+        }
+
+        @Test
+        fun `fromKeyword returns correct type for defmacro`() {
+            assertEquals(SymbolType.MACRO, SymbolType.fromKeyword("defmacro"))
+        }
+
+        @Test
+        fun `fromKeyword returns correct type for defstruct`() {
+            assertEquals(SymbolType.STRUCT, SymbolType.fromKeyword("defstruct"))
+        }
+
+        @Test
+        fun `fromKeyword returns correct type for definterface`() {
+            assertEquals(SymbolType.INTERFACE, SymbolType.fromKeyword("definterface"))
+        }
+
+        @Test
+        fun `fromKeyword returns null for unknown keyword`() {
+            assertNull(SymbolType.fromKeyword("unknown"))
+            assertNull(SymbolType.fromKeyword("let"))
+            assertNull(SymbolType.fromKeyword("fn"))
+        }
+
+        @Test
+        fun `definingKeywords contains all definition keywords`() {
+            val keywords = SymbolType.definingKeywords
+
+            assertTrue(keywords.contains("defn"))
+            assertTrue(keywords.contains("def"))
+            assertTrue(keywords.contains("defmacro"))
+            assertTrue(keywords.contains("defstruct"))
+            assertTrue(keywords.contains("definterface"))
+            assertEquals(5, keywords.size)
+        }
+
+        @Test
+        fun `definingKeywords does not contain non-definition keywords`() {
+            val keywords = SymbolType.definingKeywords
+
+            assertFalse(keywords.contains("let"))
+            assertFalse(keywords.contains("fn"))
+            assertFalse(keywords.contains("if"))
+            assertFalse(keywords.contains("when"))
+        }
+    }
+
+    @Nested
+    inner class SymbolTypeEnumValues {
+
+        @Test
+        fun `all symbol types have correct keywords`() {
+            assertEquals("defn", SymbolType.FUNCTION.keyword)
+            assertEquals("def", SymbolType.VALUE.keyword)
+            assertEquals("defmacro", SymbolType.MACRO.keyword)
+            assertEquals("defstruct", SymbolType.STRUCT.keyword)
+            assertEquals("definterface", SymbolType.INTERFACE.keyword)
+        }
+
+        @Test
+        fun `all entries are accessible`() {
+            val entries = SymbolType.entries
+            assertEquals(5, entries.size)
+        }
+    }
+}

--- a/src/test/kotlin/org/phellang/unit/completion/indexing/PhelProjectSymbolScannerTest.kt
+++ b/src/test/kotlin/org/phellang/unit/completion/indexing/PhelProjectSymbolScannerTest.kt
@@ -1,0 +1,138 @@
+package org.phellang.unit.completion.indexing
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.phellang.completion.data.SymbolType
+import org.phellang.completion.indexing.PhelProjectSymbolScanner
+
+class PhelProjectSymbolScannerTest {
+
+    @Test
+    fun `scanner object is accessible`() {
+        assertNotNull(PhelProjectSymbolScanner)
+    }
+
+    @Nested
+    inner class PrivateDefinitionDetection {
+
+        @Test
+        fun `all private keywords are recognized`() {
+            // All shorthand forms for private definitions
+            val privateKeywords = setOf("defn-", "def-", "defmacro-")
+
+            assertTrue("defn-" in privateKeywords)
+            assertTrue("def-" in privateKeywords)
+            assertTrue("defmacro-" in privateKeywords)
+            assertFalse("defn" in privateKeywords)
+            assertFalse("def" in privateKeywords)
+            assertFalse("defmacro" in privateKeywords)
+        }
+
+        @Test
+        fun `names ending with dash are NOT private by themselves`() {
+            // A name ending with - is still public
+            // Only defn- keyword makes a function private
+            val namesWithDash = listOf("helper-", "process-data-", "validate-")
+
+            for (name in namesWithDash) {
+                // These should be public functions (the dash is just part of the name)
+                assertTrue(name.endsWith("-"), "$name ends with dash but is still public")
+            }
+        }
+
+        @Test
+        fun `text containing private attribute is private`() {
+            val privateTexts = listOf(
+                "^:private", "(def ^:private name value)", "{:private true}"
+            )
+
+            for (text in privateTexts) {
+                assertTrue(text.contains(":private"), "$text should be detected as private")
+            }
+        }
+
+        @Test
+        fun `regular defn with dash in name is public`() {
+            // Functions like "process-data" or even "my-fn-" are public
+            val publicFunctions = listOf("defn process-data", "defn my-fn-", "defn validate-input")
+
+            for (fn in publicFunctions) {
+                assertTrue(fn.startsWith("defn "), "$fn uses public defn keyword")
+                assertFalse(fn.startsWith("defn-"), "$fn is not private defn-")
+            }
+        }
+    }
+
+    @Nested
+    inner class SignatureExtraction {
+
+        @Test
+        fun `function signature format`() {
+            // Expected: (name param1 param2)
+            val name = "greet"
+            val params = listOf("name", "greeting")
+
+            val signature = "($name ${params.joinToString(" ")})"
+            assertEquals("(greet name greeting)", signature)
+        }
+
+        @Test
+        fun `def signature is just the name`() {
+            val name = "config"
+            val signature = "($name)"
+            assertEquals("(config)", signature)
+        }
+    }
+
+    @Nested
+    inner class QualifiedNameConstruction {
+
+        @Test
+        fun `qualified name combines namespace and function name`() {
+            val shortNamespace = "util"
+            val name = "greet"
+            val qualifiedName = "$shortNamespace/$name"
+
+            assertEquals("util/greet", qualifiedName)
+        }
+
+        @Test
+        fun `qualified name with complex names`() {
+            val shortNamespace = "string-helpers"
+            val name = "format-date"
+            val qualifiedName = "$shortNamespace/$name"
+
+            assertEquals("string-helpers/format-date", qualifiedName)
+        }
+    }
+
+    @Nested
+    inner class DefinitionTypeRecognition {
+
+        @Test
+        fun `all definition keywords are recognized`() {
+            val definitionKeywords = mapOf(
+                "defn" to SymbolType.FUNCTION,
+                "def" to SymbolType.VALUE,
+                "defmacro" to SymbolType.MACRO,
+                "defstruct" to SymbolType.STRUCT,
+                "definterface" to SymbolType.INTERFACE
+            )
+
+            for ((keyword, expectedType) in definitionKeywords) {
+                val actualType = SymbolType.fromKeyword(keyword)
+                assertEquals(expectedType, actualType, "Keyword $keyword should map to $expectedType")
+            }
+        }
+
+        @Test
+        fun `non-definition keywords return null`() {
+            val nonDefinitionKeywords = listOf("let", "fn", "if", "when", "loop", "for", "require", "ns")
+
+            for (keyword in nonDefinitionKeywords) {
+                assertNull(SymbolType.fromKeyword(keyword), "Keyword $keyword should not be a definition")
+            }
+        }
+    }
+}

--- a/src/test/kotlin/org/phellang/unit/completion/infrastructure/PhelProjectCompletionHelperTest.kt
+++ b/src/test/kotlin/org/phellang/unit/completion/infrastructure/PhelProjectCompletionHelperTest.kt
@@ -1,0 +1,128 @@
+package org.phellang.unit.completion.infrastructure
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.phellang.completion.infrastructure.PhelProjectCompletionHelper
+
+class PhelProjectCompletionHelperTest {
+
+    @Test
+    fun `helper object is accessible`() {
+        assertNotNull(PhelProjectCompletionHelper)
+    }
+
+    @Nested
+    inner class AliasTransformation {
+
+        @Test
+        fun `symbol with alias uses alias in qualified name`() {
+            // Import: (:require hello-world\util :as u)
+            // Symbol: greet
+            // Expected: u/greet
+            val alias = "u"
+            val name = "greet"
+            val result = "$alias/$name"
+
+            assertEquals("u/greet", result)
+        }
+
+        @Test
+        fun `symbol without alias uses short namespace`() {
+            // Import: (:require hello-world\util)
+            // Symbol: greet
+            // Expected: util/greet
+            val shortNamespace = "util"
+            val name = "greet"
+            val result = "$shortNamespace/$name"
+
+            assertEquals("util/greet", result)
+        }
+
+        @Test
+        fun `alias from aliasMap takes precedence`() {
+            // aliasMap: {"h" -> "helpers"}
+            // Symbol namespace: helpers
+            // Expected: h/function-name
+            val aliasMap = mapOf("h" to "helpers")
+            val shortNamespace = "helpers"
+            val name = "format"
+
+            val alias = aliasMap.entries.find { it.value == shortNamespace }?.key
+            val result = if (alias != null) "$alias/$name" else "$shortNamespace/$name"
+
+            assertEquals("h/format", result)
+        }
+    }
+
+    @Nested
+    inner class ImportInfoParsing {
+
+        @Test
+        fun `full namespace is split correctly`() {
+            val fullNamespace = "hello-world\\util"
+            val shortNamespace = fullNamespace.substringAfterLast("\\")
+
+            assertEquals("util", shortNamespace)
+        }
+
+        @Test
+        fun `nested namespace is split correctly`() {
+            val fullNamespace = "my-app\\lib\\helpers"
+            val shortNamespace = fullNamespace.substringAfterLast("\\")
+
+            assertEquals("helpers", shortNamespace)
+        }
+
+        @Test
+        fun `simple namespace without separator`() {
+            val fullNamespace = "util"
+            val shortNamespace = fullNamespace.substringAfterLast("\\")
+
+            assertEquals("util", shortNamespace)
+        }
+    }
+
+    @Nested
+    inner class ImportedNamespaceDetection {
+
+        @Test
+        fun `directly imported namespace should be found`() {
+            // (:require hello-world\util)
+            // Result: ImportInfo(fullNamespace="hello-world\\util", shortNamespace="util", alias=null)
+            val fullNamespace = "hello-world\\util"
+            val shortNamespace = fullNamespace.substringAfterLast("\\")
+            val alias: String? = null
+
+            assertEquals("util", shortNamespace)
+            assertNull(alias)
+        }
+
+        @Test
+        fun `aliased namespace should be found with alias`() {
+            // (:require hello-world\util :as u)
+            // Result: ImportInfo(fullNamespace="hello-world\\util", shortNamespace="util", alias="u")
+            val fullNamespace = "hello-world\\util"
+            val shortNamespace = fullNamespace.substringAfterLast("\\")
+            val alias = "u"
+
+            assertEquals("util", shortNamespace)
+            assertEquals("u", alias)
+        }
+
+        @Test
+        fun `multiple imports should all be found`() {
+            // (:require hello-world\util)
+            // (:require my-app\helpers :as h)
+            val imports = listOf(
+                Triple("hello-world\\util", "util", null), Triple("my-app\\helpers", "helpers", "h")
+            )
+
+            assertEquals(2, imports.size)
+            assertEquals("util", imports[0].second)
+            assertNull(imports[0].third)
+            assertEquals("helpers", imports[1].second)
+            assertEquals("h", imports[1].third)
+        }
+    }
+}

--- a/src/test/kotlin/org/phellang/unit/language/psi/PhelProjectNamespaceFinderTest.kt
+++ b/src/test/kotlin/org/phellang/unit/language/psi/PhelProjectNamespaceFinderTest.kt
@@ -1,0 +1,106 @@
+package org.phellang.unit.language.psi
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.phellang.language.psi.PhelProjectNamespaceFinder
+
+class PhelProjectNamespaceFinderTest {
+
+    @Nested
+    inner class ExtractShortNamespace {
+
+        @Test
+        fun `extracts short name from full namespace`() {
+            assertEquals("utils", PhelProjectNamespaceFinder.extractShortNamespace("phel-project\\utils"))
+            assertEquals("math", PhelProjectNamespaceFinder.extractShortNamespace("phel-project\\math"))
+            assertEquals("core", PhelProjectNamespaceFinder.extractShortNamespace("phel\\core"))
+        }
+
+        @Test
+        fun `handles nested namespaces`() {
+            assertEquals("helpers", PhelProjectNamespaceFinder.extractShortNamespace("my-app\\lib\\helpers"))
+            assertEquals("deep", PhelProjectNamespaceFinder.extractShortNamespace("a\\b\\c\\deep"))
+        }
+
+        @Test
+        fun `returns same string if no separator`() {
+            assertEquals("utils", PhelProjectNamespaceFinder.extractShortNamespace("utils"))
+            assertEquals("core", PhelProjectNamespaceFinder.extractShortNamespace("core"))
+        }
+
+        @Test
+        fun `handles empty string`() {
+            assertEquals("", PhelProjectNamespaceFinder.extractShortNamespace(""))
+        }
+    }
+
+    @Nested
+    inner class IsStandardLibrary {
+
+        @Test
+        fun `recognizes standard library namespaces`() {
+            assertTrue(PhelProjectNamespaceFinder.isStandardLibrary("phel\\str"))
+            assertTrue(PhelProjectNamespaceFinder.isStandardLibrary("phel\\json"))
+            assertTrue(PhelProjectNamespaceFinder.isStandardLibrary("phel\\core"))
+            assertTrue(PhelProjectNamespaceFinder.isStandardLibrary("phel\\http"))
+            assertTrue(PhelProjectNamespaceFinder.isStandardLibrary("phel\\html"))
+        }
+
+        @Test
+        fun `rejects non-standard namespaces`() {
+            assertFalse(PhelProjectNamespaceFinder.isStandardLibrary("phel-project\\utils"))
+            assertFalse(PhelProjectNamespaceFinder.isStandardLibrary("my-app\\core"))
+            assertFalse(PhelProjectNamespaceFinder.isStandardLibrary("str"))
+        }
+    }
+
+    @Nested
+    inner class StandardLibraryNamespaces {
+
+        @Test
+        fun `all expected standard library namespaces are defined`() {
+            val expected = setOf(
+                "phel\\str",
+                "phel\\json",
+                "phel\\http",
+                "phel\\html",
+                "phel\\base64",
+                "phel\\test",
+                "phel\\mock",
+                "phel\\repl",
+                "phel\\debug",
+                "phel\\core"
+            )
+            assertEquals(expected, PhelProjectNamespaceFinder.STANDARD_LIBRARY_NAMESPACES)
+        }
+
+        @Test
+        fun `short to full mapping contains all namespaces`() {
+            val shortToFull = PhelProjectNamespaceFinder.STANDARD_LIBRARY_SHORT_TO_FULL
+            
+            assertEquals("phel\\str", shortToFull["str"])
+            assertEquals("phel\\json", shortToFull["json"])
+            assertEquals("phel\\core", shortToFull["core"])
+        }
+
+        @Test
+        fun `getStandardLibraryFullNamespace returns correct namespace`() {
+            assertEquals("phel\\str", PhelProjectNamespaceFinder.getStandardLibraryFullNamespace("str"))
+            assertEquals("phel\\json", PhelProjectNamespaceFinder.getStandardLibraryFullNamespace("json"))
+            assertEquals("phel\\core", PhelProjectNamespaceFinder.getStandardLibraryFullNamespace("core"))
+        }
+
+        @Test
+        fun `getStandardLibraryFullNamespace is case insensitive`() {
+            assertEquals("phel\\str", PhelProjectNamespaceFinder.getStandardLibraryFullNamespace("STR"))
+            assertEquals("phel\\json", PhelProjectNamespaceFinder.getStandardLibraryFullNamespace("JSON"))
+        }
+
+        @Test
+        fun `getStandardLibraryFullNamespace returns null for unknown`() {
+            assertNull(PhelProjectNamespaceFinder.getStandardLibraryFullNamespace("unknown"))
+            assertNull(PhelProjectNamespaceFinder.getStandardLibraryFullNamespace("php"))
+        }
+    }
+}

--- a/src/test/kotlin/org/phellang/unit/language/psi/PhelVendorUtilsTest.kt
+++ b/src/test/kotlin/org/phellang/unit/language/psi/PhelVendorUtilsTest.kt
@@ -1,0 +1,101 @@
+package org.phellang.unit.language.psi
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class PhelVendorUtilsTest {
+
+    // Mirror of the private mapping in PhelVendorUtils
+    private val namespaceToFile = mapOf(
+        "core" to "core.phel",
+        "str" to "str.phel",
+        "json" to "json.phel",
+        "http" to "http.phel",
+        "html" to "html.phel",
+        "base64" to "base64.phel",
+        "test" to "test.phel",
+        "mock" to "mock.phel",
+        "repl" to "repl.phel",
+        "debug" to "debug.phel",
+    )
+
+    @Nested
+    inner class NamespaceToFileMapping {
+
+        @Test
+        fun `all standard library namespaces have file mappings`() {
+            val expectedNamespaces = setOf(
+                "core", "str", "json", "http", "html", "base64", "test", "mock", "repl", "debug"
+            )
+
+            assertEquals(expectedNamespaces, namespaceToFile.keys)
+        }
+
+        @Test
+        fun `core namespace maps to core phel`() {
+            assertEquals("core.phel", namespaceToFile["core"])
+        }
+
+        @Test
+        fun `str namespace maps to str phel`() {
+            assertEquals("str.phel", namespaceToFile["str"])
+        }
+
+        @Test
+        fun `all file names end with phel extension`() {
+            for ((namespace, fileName) in namespaceToFile) {
+                assertTrue(fileName.endsWith(".phel"), "$namespace should map to a .phel file")
+            }
+        }
+
+        @Test
+        fun `file names match namespace names`() {
+            for ((namespace, fileName) in namespaceToFile) {
+                assertEquals("$namespace.phel", fileName, "File name should be namespace.phel")
+            }
+        }
+    }
+
+    @Nested
+    inner class VendorPath {
+
+        @Test
+        fun `phel vendor path is correct`() {
+            val expectedPath = "phel-lang/phel-lang/src/phel"
+            // This mirrors the constant in PhelVendorUtils
+            assertEquals("phel-lang/phel-lang/src/phel", expectedPath)
+        }
+
+        @Test
+        fun `vendor path structure is composer compliant`() {
+            val vendorPath = "phel-lang/phel-lang/src/phel"
+            val parts = vendorPath.split("/")
+
+            assertEquals(4, parts.size, "Path should have 4 segments")
+            assertEquals("phel-lang", parts[0], "Vendor should be phel-lang")
+            assertEquals("phel-lang", parts[1], "Package should be phel-lang")
+            assertEquals("src", parts[2], "Source directory")
+            assertEquals("phel", parts[3], "Phel source folder")
+        }
+    }
+
+    @Nested
+    inner class NamespaceFromFileName {
+
+        @Test
+        fun `namespace can be extracted from file name`() {
+            val fileName = "str.phel"
+            val namespace = fileName.removeSuffix(".phel")
+            assertEquals("str", namespace)
+        }
+
+        @Test
+        fun `all mapped namespaces can be extracted from file names`() {
+            for ((expectedNamespace, fileName) in namespaceToFile) {
+                val extractedNamespace = fileName.removeSuffix(".phel")
+                assertEquals(expectedNamespace, extractedNamespace)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 📚 Description

This PR adds project-wide **symbol completion, namespace validation**, and **Go to Declaration**.

#### Project Symbol Completion & Auto-Import
- Scan project files for public function/macro/struct definitions
- Show completions from all project namespaces (not just imported ones)
- Auto-import namespaces when selecting a completion
- Correctly detect private functions `(defn-` and `{:private true})`

#### Namespace Validation & Quick Fixes
- Warning when using a namespace that is not imported
- Warning when importing a namespace that doesn't exist
- Warning when importing the same namespace twice (duplicate detection)
- Quick fix (Alt+Enter): **Import namespace** for unimported namespaces
- Quick fix: **Change to '...'** when import path is wrong
- Quick fix: **Remove duplicate import** for duplicates

#### Go to Declaration (Cmd+B)
- Navigate to definitions in vendor folder for standard library (`str/join` → `vendor/.../str.phel`)
- Navigate to definitions in project files for user-defined functions
- Support aliased imports (`m/square` when `math :as m`)

#### Real-time Index Updates
- File change listener keeps symbol index in sync
- Rename/delete a namespace → dependent files show warnings immediately