### PR TITLE
feat: rename, inlay hints, arity + let-binding inspections

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.grammarkit.tasks.GenerateLexerTask
 import org.jetbrains.grammarkit.tasks.GenerateParserTask
 
 group = "org.phellang"
-version = "0.4.1"
+version = "0.4.2"
 
 plugins {
     id("java")

--- a/src/main/kotlin/org/phellang/completion/data/PhelArity.kt
+++ b/src/main/kotlin/org/phellang/completion/data/PhelArity.kt
@@ -1,0 +1,104 @@
+package org.phellang.completion.data
+
+import org.phellang.completion.data.PhelArity.Companion.parseAll
+
+data class PhelArity(
+    val params: List<String>,
+    val variadic: Boolean,
+) {
+    val fixedCount: Int get() = if (variadic) params.size - 1 else params.size
+
+    companion object {
+        /**
+         * Parses a signature string like "(name a b)" or "(name a b & rest)".
+         * For multi-arity (newline-separated), call [parseAll].
+         */
+        fun parseSignature(signature: String): PhelArity? {
+            val trimmed = signature.trim()
+            if (!trimmed.startsWith("(") || !trimmed.endsWith(")")) return null
+            val inner = trimmed.substring(1, trimmed.length - 1).trim()
+            if (inner.isEmpty()) return null
+
+            val tokens = tokenize(inner)
+            if (tokens.isEmpty()) return null
+
+            val paramTokens = tokens.drop(1) // first token is the function name
+
+            val ampIndex = paramTokens.indexOf("&")
+            return if (ampIndex >= 0) {
+                val before = paramTokens.subList(0, ampIndex)
+                val rest = paramTokens.subList(ampIndex + 1, paramTokens.size)
+                val restName = rest.firstOrNull() ?: "rest"
+                PhelArity(params = before + restName, variadic = true)
+            } else {
+                PhelArity(params = paramTokens, variadic = false)
+            }
+        }
+
+        fun parseAll(signature: String): List<PhelArity> =
+            signature.lineSequence()
+                .mapNotNull { parseSignature(it) }
+                .toList()
+
+        /**
+         * Splits the parameter region into top-level tokens. Vectors and maps used for
+         * destructuring count as a single token; their inner text is preserved literally.
+         */
+        private fun tokenize(text: String): List<String> {
+            val tokens = mutableListOf<String>()
+            val current = StringBuilder()
+            var depth = 0
+            for (c in text) {
+                when {
+                    c == '[' || c == '{' || c == '(' -> {
+                        depth++
+                        current.append(c)
+                    }
+
+                    c == ']' || c == '}' || c == ')' -> {
+                        depth--
+                        current.append(c)
+                    }
+
+                    c.isWhitespace() && depth == 0 -> {
+                        if (current.isNotEmpty()) {
+                            tokens.add(current.toString())
+                            current.clear()
+                        }
+                    }
+
+                    else -> current.append(c)
+                }
+            }
+            if (current.isNotEmpty()) tokens.add(current.toString())
+            return tokens
+        }
+    }
+}
+
+fun List<PhelArity>.accepts(argCount: Int): Boolean {
+    if (isEmpty()) return true // unknown arity -- don't flag
+    for (arity in this) {
+        if (arity.variadic) {
+            if (argCount >= arity.fixedCount) return true
+        } else {
+            if (argCount == arity.params.size) return true
+        }
+    }
+    return false
+}
+
+fun List<PhelArity>.describe(): String {
+    if (isEmpty()) return "?"
+    return joinToString(" or ") { arity ->
+        if (arity.variadic) "${arity.fixedCount}+" else "${arity.params.size}"
+    }
+}
+
+/** Returns the arity that best matches the given argument count, or null when none does. */
+fun List<PhelArity>.selectFor(argCount: Int): PhelArity? {
+    // Prefer exact-fixed match first.
+    val exact = firstOrNull { !it.variadic && it.params.size == argCount }
+    if (exact != null) return exact
+    return firstOrNull { it.variadic && argCount >= it.fixedCount }
+}

--- a/src/main/kotlin/org/phellang/completion/data/PhelProjectSymbol.kt
+++ b/src/main/kotlin/org/phellang/completion/data/PhelProjectSymbol.kt
@@ -11,6 +11,7 @@ data class PhelProjectSymbol(
     val type: SymbolType,
     val file: VirtualFile,
     val docstring: String? = null,
+    val arities: List<PhelArity> = PhelArity.parseAll(signature),
 )
 
 enum class SymbolType(val keyword: String) {

--- a/src/main/kotlin/org/phellang/completion/indexing/PhelProjectSymbolIndex.kt
+++ b/src/main/kotlin/org/phellang/completion/indexing/PhelProjectSymbolIndex.kt
@@ -19,6 +19,9 @@ class PhelProjectSymbolIndex(private val project: Project) : Disposable {
     /** Cache: shortNamespace -> List of symbols */
     private val symbolsByNamespace = ConcurrentHashMap<String, List<PhelProjectSymbol>>()
 
+    /** Cache: simple name -> List of symbols. Used for fast cross-namespace lookups by name. */
+    private val symbolsByName = ConcurrentHashMap<String, List<PhelProjectSymbol>>()
+
     /** Cache: file path -> List of symbols */
     private val symbolsByFile = ConcurrentHashMap<String, List<PhelProjectSymbol>>()
 
@@ -37,7 +40,13 @@ class PhelProjectSymbolIndex(private val project: Project) : Disposable {
 
     override fun dispose() {
         symbolsByNamespace.clear()
+        symbolsByName.clear()
         symbolsByFile.clear()
+    }
+
+    fun findByName(name: String): List<PhelProjectSymbol> {
+        ensureIndexBuilt()
+        return symbolsByName[name] ?: emptyList()
     }
 
     fun getSymbolsForNamespace(shortNamespace: String): List<PhelProjectSymbol> {
@@ -72,41 +81,48 @@ class PhelProjectSymbolIndex(private val project: Project) : Disposable {
 
         val oldSymbols = symbolsByFile[filePath] ?: emptyList()
 
-        // Remove old symbols from namespace index
+        // Remove old symbols from namespace + name indices
         for (symbol in oldSymbols) {
-            val namespaceSymbols = symbolsByNamespace[symbol.shortNamespace]?.toMutableList()
-            namespaceSymbols?.removeIf { it.file.path == filePath }
-            if (namespaceSymbols != null) {
-                symbolsByNamespace[symbol.shortNamespace] = namespaceSymbols
-            }
+            removeFromMap(symbolsByNamespace, symbol.shortNamespace, filePath)
+            removeFromMap(symbolsByName, symbol.name, filePath)
         }
 
         // Scan file for new symbols from the current PSI state
         val newSymbols = PhelProjectSymbolScanner.scanFile(psiFile)
         symbolsByFile[filePath] = newSymbols
 
-        // Add new symbols to namespace index
+        // Add new symbols to namespace + name indices
         for (symbol in newSymbols) {
-            val existingSymbols = symbolsByNamespace[symbol.shortNamespace]?.toMutableList() ?: mutableListOf()
-            existingSymbols.add(symbol)
-            symbolsByNamespace[symbol.shortNamespace] = existingSymbols
+            addToMap(symbolsByNamespace, symbol.shortNamespace, symbol)
+            addToMap(symbolsByName, symbol.name, symbol)
         }
+    }
+
+    private fun addToMap(
+        map: ConcurrentHashMap<String, List<PhelProjectSymbol>>,
+        key: String,
+        symbol: PhelProjectSymbol,
+    ) {
+        val existing = map[key]?.toMutableList() ?: mutableListOf()
+        existing.add(symbol)
+        map[key] = existing
+    }
+
+    private fun removeFromMap(
+        map: ConcurrentHashMap<String, List<PhelProjectSymbol>>,
+        key: String,
+        filePath: String,
+    ) {
+        val current = map[key]?.toMutableList() ?: return
+        current.removeIf { it.file.path == filePath }
+        if (current.isEmpty()) map.remove(key) else map[key] = current
     }
 
     fun removeFile(file: VirtualFile) {
         val oldSymbols = symbolsByFile.remove(file.path) ?: return
-
-        // Remove symbols from namespace index
         for (symbol in oldSymbols) {
-            val namespaceSymbols = symbolsByNamespace[symbol.shortNamespace]?.toMutableList()
-            namespaceSymbols?.removeIf { it.file.path == file.path }
-            if (namespaceSymbols != null) {
-                if (namespaceSymbols.isEmpty()) {
-                    symbolsByNamespace.remove(symbol.shortNamespace)
-                } else {
-                    symbolsByNamespace[symbol.shortNamespace] = namespaceSymbols
-                }
-            }
+            removeFromMap(symbolsByNamespace, symbol.shortNamespace, file.path)
+            removeFromMap(symbolsByName, symbol.name, file.path)
         }
     }
 
@@ -138,12 +154,9 @@ class PhelProjectSymbolIndex(private val project: Project) : Disposable {
 
                 if (symbols.isNotEmpty()) {
                     symbolsByFile[virtualFile.path] = symbols
-
                     for (symbol in symbols) {
-                        val existingSymbols =
-                            symbolsByNamespace[symbol.shortNamespace]?.toMutableList() ?: mutableListOf()
-                        existingSymbols.add(symbol)
-                        symbolsByNamespace[symbol.shortNamespace] = existingSymbols
+                        addToMap(symbolsByNamespace, symbol.shortNamespace, symbol)
+                        addToMap(symbolsByName, symbol.name, symbol)
                     }
                 }
             }

--- a/src/main/kotlin/org/phellang/editor/PhelFoldingBuilder.kt
+++ b/src/main/kotlin/org/phellang/editor/PhelFoldingBuilder.kt
@@ -23,6 +23,6 @@ class PhelFoldingBuilder : FoldingBuilder {
     }
 
     override fun isCollapsedByDefault(node: ASTNode): Boolean {
-        return PhelFoldingDefaults.isCollapsedByDefault(node)
+        return PhelFoldingDefaults.isCollapsedByDefault()
     }
 }

--- a/src/main/kotlin/org/phellang/editor/folding/PhelFoldingDefaults.kt
+++ b/src/main/kotlin/org/phellang/editor/folding/PhelFoldingDefaults.kt
@@ -1,21 +1,14 @@
 package org.phellang.editor.folding
 
 import com.intellij.lang.ASTNode
-import com.intellij.psi.util.PsiTreeUtil
-import org.phellang.language.psi.*
+import org.phellang.language.psi.PhelFormCommentMacro
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelMap
+import org.phellang.language.psi.PhelVec
 
 object PhelFoldingDefaults {
 
-    fun isCollapsedByDefault(node: ASTNode): Boolean {
-        val psi = node.psi
-
-        // Auto-collapse namespace declarations by default
-        if (psi is PhelList) {
-            return isNamespaceDeclaration(psi)
-        }
-
-        return false
-    }
+    fun isCollapsedByDefault(): Boolean = false
 
     fun getDefaultPlaceholderText(node: ASTNode): String? {
         val psi = node.psi
@@ -28,10 +21,4 @@ object PhelFoldingDefaults {
         }
     }
 
-    private fun isNamespaceDeclaration(list: PhelList): Boolean {
-        val forms = PsiTreeUtil.getChildrenOfType(list, PhelForm::class.java) ?: return false
-        if (forms.isEmpty()) return false
-        val firstSymbol = PsiTreeUtil.findChildOfType(forms[0], PhelSymbol::class.java)
-        return firstSymbol?.text == "ns"
-    }
 }

--- a/src/main/kotlin/org/phellang/inlay/PhelParameterHintsProvider.kt
+++ b/src/main/kotlin/org/phellang/inlay/PhelParameterHintsProvider.kt
@@ -1,0 +1,132 @@
+package org.phellang.inlay
+
+import com.intellij.codeInsight.hints.HintInfo
+import com.intellij.codeInsight.hints.InlayInfo
+import com.intellij.codeInsight.hints.InlayParameterHintsProvider
+import com.intellij.psi.PsiElement
+import org.phellang.completion.data.PhelArity
+import org.phellang.completion.data.PhelFunctionRegistry
+import org.phellang.completion.data.selectFor
+import org.phellang.completion.indexing.PhelProjectSymbolIndex
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelSymbol
+
+class PhelParameterHintsProvider : InlayParameterHintsProvider {
+
+    override fun getParameterHints(element: PsiElement): List<InlayInfo> {
+        if (element !is PhelList) return emptyList()
+
+        val forms = element.forms
+        if (forms.size < 2) return emptyList()
+
+        val headSymbol = forms[0] as? PhelSymbol ?: return emptyList()
+        val headName = headSymbol.text ?: return emptyList()
+
+        if (headName in SKIP_HEADS) return emptyList()
+        if (headName.startsWith("php/") || headName.startsWith(".") || headName.startsWith("php-")) {
+            return emptyList()
+        }
+
+        val args = forms.drop(1)
+        val arities = resolveArities(headSymbol, headName) ?: return emptyList()
+        val arity = arities.selectFor(args.size) ?: return emptyList()
+
+        val hints = mutableListOf<InlayInfo>()
+        for ((i, arg) in args.withIndex()) {
+            val paramName = paramNameAt(arity, i) ?: continue
+            if (paramName == "_") continue
+            val argText = arg.text?.trim()
+            if (argText != null && argText == paramName) continue
+            hints.add(InlayInfo(paramName, arg.textRange.startOffset))
+        }
+        return hints
+    }
+
+    private fun paramNameAt(arity: PhelArity, argIndex: Int): String? {
+        return if (arity.variadic && argIndex >= arity.fixedCount) {
+            // Once we're past the fixed arity, all remaining args fold into the rest param.
+            // Drop the `& ` prefix to keep the inlay tight.
+            arity.params.lastOrNull()
+        } else {
+            arity.params.getOrNull(argIndex)
+        }
+    }
+
+    private fun resolveArities(headSymbol: PhelSymbol, headName: String): List<PhelArity>? {
+        val shortName = headName.substringAfterLast('/')
+
+        PhelFunctionRegistry.getFunction(shortName)?.let { fn ->
+            val parsed = PhelArity.parseAll(fn.signature)
+            if (parsed.isNotEmpty()) return parsed
+        }
+
+        val index = PhelProjectSymbolIndex.getInstance(headSymbol.project)
+        return index.findByName(shortName).firstOrNull { it.arities.isNotEmpty() }?.arities
+    }
+
+    override fun getHintInfo(element: PsiElement): HintInfo? {
+        if (element !is PhelList) return null
+        val head = element.forms.firstOrNull() as? PhelSymbol ?: return null
+        val name = head.text ?: return null
+        return HintInfo.MethodInfo(name, emptyList())
+    }
+
+    override fun getDefaultBlackList(): Set<String> = emptySet()
+
+    override fun isBlackListSupported(): Boolean = true
+}
+
+// Special forms and macros where param-name hints would be noise.
+private val SKIP_HEADS = setOf(
+    "if",
+    "if-not",
+    "when",
+    "when-not",
+    "if-let",
+    "when-let",
+    "if-some",
+    "when-some",
+    "do",
+    "let",
+    "loop",
+    "recur",
+    "fn",
+    "defn",
+    "defn-",
+    "def",
+    "def-",
+    "defmacro",
+    "defmacro-",
+    "defstruct",
+    "definterface",
+    "defexception",
+    "declare",
+    "ns",
+    "quote",
+    "var",
+    "try",
+    "catch",
+    "finally",
+    "throw",
+    "case",
+    "cond",
+    "condp",
+    "and",
+    "or",
+    "->",
+    "->>",
+    "as->",
+    "some->",
+    "some->>",
+    "doto",
+    "binding",
+    "for",
+    "foreach",
+    "dofor",
+    "comment",
+    "deftest",
+    "is",
+    "are",
+    "testing",
+    "with-output-buffer"
+)

--- a/src/main/kotlin/org/phellang/inspection/PhelArityMismatchInspection.kt
+++ b/src/main/kotlin/org/phellang/inspection/PhelArityMismatchInspection.kt
@@ -1,0 +1,177 @@
+package org.phellang.inspection
+
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementVisitor
+import org.phellang.completion.data.PhelArity
+import org.phellang.completion.data.PhelFunctionRegistry
+import org.phellang.completion.data.accepts
+import org.phellang.completion.data.describe
+import org.phellang.completion.indexing.PhelProjectSymbolIndex
+import org.phellang.language.psi.PhelForm
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.PhelVisitor
+
+class PhelArityMismatchInspection : LocalInspectionTool() {
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        return object : PhelVisitor() {
+            override fun visitList(o: PhelList) {
+                val forms = o.forms
+                if (forms.isEmpty()) return
+                val head = forms[0] as? PhelSymbol ?: return
+                val name = head.text ?: return
+
+                if (name in SKIP_HEADS) return
+                if (name.startsWith("php/") || name.startsWith(".") || name.startsWith("php-")) return
+                if (name.contains("IntelliJIdeaRulezzz")) return
+
+                if (isInQuoteContext(o)) return
+                if (isThreadedArgList(o)) return
+
+                val arities = resolveArities(head, name) ?: return
+                if (arities.isEmpty()) return
+
+                val argCount = forms.size - 1
+                if (!arities.accepts(argCount)) {
+                    holder.registerProblem(
+                        head,
+                        "Wrong number of args ($argCount) passed to '$name'. Expected: ${arities.describe()}.",
+                        ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
+                    )
+                }
+            }
+        }
+    }
+
+    private fun resolveArities(head: PhelSymbol, name: String): List<PhelArity>? {
+        val shortName = name.substringAfterLast('/')
+
+        PhelFunctionRegistry.getFunction(shortName)?.let { fn ->
+            val parsed = PhelArity.parseAll(fn.signature)
+            if (parsed.isNotEmpty()) return parsed
+        }
+
+        val index = PhelProjectSymbolIndex.getInstance(head.project)
+        val candidates = index.findByName(shortName)
+        val withArities = candidates.firstOrNull { it.arities.isNotEmpty() }
+        return withArities?.arities
+    }
+
+    /**
+     * True when [list] is a data form (inside a `quote`, `var`, syntax-quote `` ` ``,
+     * or quote `'` reader macro) and therefore not a call site.
+     */
+    private fun isInQuoteContext(list: PhelList): Boolean {
+        var current: PsiElement? = list
+        while (current != null) {
+            if (current is PhelForm) {
+                for (macro in current.readerMacros) {
+                    val t = macro.text
+                    if (t == "'" || t == "`") return true
+                }
+            }
+            if (current is PhelList && current !== list) {
+                val head = (current.forms.firstOrNull() as? PhelSymbol)?.text
+                if (head == "quote" || head == "var") return true
+            }
+            current = current.parent
+        }
+        return false
+    }
+
+    /**
+     * True when [list] is positioned as an argument inside a threading macro
+     * (`->`, `->>`, `as->`, `some->`, `some->>`, `cond->`, `cond->>`, `doto`).
+     * In that case the actual argument count seen at runtime is shifted, so we
+     * cannot trust the textual arg count and must skip the check.
+     */
+    private fun isThreadedArgList(list: PhelList): Boolean {
+        val parentList = findEnclosingList(list) ?: return false
+        val parentForms = parentList.forms
+        val head = (parentForms.firstOrNull() as? PhelSymbol)?.text ?: return false
+        if (head !in THREADING_HEADS) return false
+        val firstFormRange = parentForms.firstOrNull()?.textRange ?: return false
+        // True when [list] is an argument (i.e., not the head form) of the threading macro.
+        return !firstFormRange.contains(list.textRange.startOffset)
+    }
+
+    private fun findEnclosingList(list: PhelList): PhelList? {
+        var current: PsiElement? = list.parent
+        while (current != null) {
+            if (current is PhelList) return current
+            current = current.parent
+        }
+        return null
+    }
+
+}
+
+private val THREADING_HEADS = setOf(
+    "->", "->>", "as->", "some->", "some->>", "cond->", "cond->>", "doto",
+)
+
+// Special forms / macros that legitimately accept variable arg shapes.
+// Skipping avoids false positives.
+private val SKIP_HEADS = setOf(
+    "if",
+    "if-not",
+    "when",
+    "when-not",
+    "if-let",
+    "when-let",
+    "if-some",
+    "when-some",
+    "do",
+    "let",
+    "loop",
+    "recur",
+    "fn",
+    "defn",
+    "defn-",
+    "def",
+    "def-",
+    "defmacro",
+    "defmacro-",
+    "defstruct",
+    "definterface",
+    "defexception",
+    "declare",
+    "ns",
+    "quote",
+    "var",
+    "try",
+    "catch",
+    "finally",
+    "throw",
+    "case",
+    "cond",
+    "condp",
+    "and",
+    "or",
+    "->",
+    "->>",
+    "as->",
+    "some->",
+    "some->>",
+    "doto",
+    "binding",
+    "for",
+    "foreach",
+    "dofor",
+    "comment",
+    "deftest",
+    "is",
+    "are",
+    "testing",
+    "with-output-buffer",
+    "import",
+    "require",
+    "use",
+    "set!",
+    "..",
+    "."
+)

--- a/src/main/kotlin/org/phellang/inspection/PhelRemoveLetBindingQuickFix.kt
+++ b/src/main/kotlin/org/phellang/inspection/PhelRemoveLetBindingQuickFix.kt
@@ -1,0 +1,76 @@
+package org.phellang.inspection
+
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.progress.ProcessCanceledException
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiWhiteSpace
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.language.psi.PhelForm
+import org.phellang.language.psi.PhelVec
+
+class PhelRemoveLetBindingQuickFix : LocalQuickFix {
+
+    override fun getFamilyName(): String = "Remove unused let binding"
+
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        val element = descriptor.psiElement
+        try {
+            val targetForm = findBindingForm(element) ?: return
+            val vec = targetForm.parent as? PhelVec ?: return
+
+            val forms = vec.forms
+            val idx = forms.indexOf(targetForm)
+            if (idx < 0) return
+            val valueForm = forms.getOrNull(idx + 1) ?: return
+
+            val deleteFrom: PsiElement = leadingWhitespaceOrSelf(targetForm)
+            val deleteTo: PsiElement = trailingWhitespaceOrSelf(valueForm)
+            vec.node.removeRange(deleteFrom.node, deleteTo.node.treeNext)
+        } catch (e: ProcessCanceledException) {
+            throw e
+        } catch (e: Exception) {
+            LOG.warn("Failed to remove let binding", e)
+        }
+    }
+
+    private fun findBindingForm(element: PsiElement): PhelForm? {
+        // The reported element is the binding symbol; walk up to the PhelForm that is a
+        // direct child of the binding vector.
+        var current: PsiElement? = element
+        while (current != null) {
+            val parent = current.parent
+            if (parent is PhelVec && current is PhelForm) return current
+            current = parent
+        }
+        // Fallback: try ancestor PhelForm whose parent is a PhelVec.
+        val form = PsiTreeUtil.getParentOfType(element, PhelForm::class.java) ?: return null
+        return if (form.parent is PhelVec) form else null
+    }
+
+    private fun leadingWhitespaceOrSelf(form: PhelForm): PsiElement {
+        var node = form.prevSibling
+        var anchor: PsiElement = form
+        while (node is PsiWhiteSpace) {
+            anchor = node
+            node = node.prevSibling
+        }
+        return anchor
+    }
+
+    private fun trailingWhitespaceOrSelf(form: PhelForm): PsiElement {
+        var node = form.nextSibling
+        var anchor: PsiElement = form
+        while (node is PsiWhiteSpace) {
+            anchor = node
+            node = node.nextSibling
+        }
+        return anchor
+    }
+
+    companion object {
+        private val LOG = Logger.getInstance(PhelRemoveLetBindingQuickFix::class.java)
+    }
+}

--- a/src/main/kotlin/org/phellang/inspection/PhelShadowedLetBindingInspection.kt
+++ b/src/main/kotlin/org/phellang/inspection/PhelShadowedLetBindingInspection.kt
@@ -1,0 +1,106 @@
+package org.phellang.inspection
+
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.language.psi.PhelForm
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.PhelVec
+import org.phellang.language.psi.PhelVisitor
+
+class PhelShadowedLetBindingInspection : LocalInspectionTool() {
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        return object : PhelVisitor() {
+            override fun visitList(o: PhelList) {
+                val forms = o.forms
+                if (forms.size < 2) return
+                val head = forms[0] as? PhelSymbol ?: return
+                val headText = head.text ?: return
+                if (headText !in BINDING_INTRO_FORMS) return
+
+                val bindingVec = forms[1] as? PhelVec ?: return
+                val bindings = bindingVec.forms
+
+                var i = 0
+                while (i < bindings.size) {
+                    val target = bindings[i] as? PhelSymbol
+                    if (target != null) {
+                        val name = target.text
+                        if (!name.isNullOrEmpty() && name != "_" && !name.startsWith("&")) {
+                            val outer = findOuterBinding(o, name)
+                            if (outer != null) {
+                                holder.registerProblem(
+                                    target,
+                                    "Binding '$name' shadows an outer binding.",
+                                    ProblemHighlightType.WEAK_WARNING,
+                                )
+                            }
+                        }
+                    }
+                    i += 2
+                }
+            }
+        }
+    }
+
+    private fun findOuterBinding(innerForm: PhelList, name: String): PsiElement? {
+        var current: PsiElement? = innerForm.parent
+        while (current != null) {
+            if (current is PhelList) {
+                val parentForms = current.forms
+                val head = parentForms.firstOrNull() as? PhelSymbol
+                val headText = head?.text
+                if (headText != null) {
+                    val match = when {
+                        headText in BINDING_INTRO_FORMS -> findInBindingVec(parentForms, name)
+                        headText in FUNCTION_INTRO_FORMS -> findInParamVec(parentForms, name)
+                        else -> null
+                    }
+                    if (match != null && match !== innerForm) return match
+                }
+            }
+            current = current.parent
+        }
+        return null
+    }
+
+    private fun findInBindingVec(forms: List<PhelForm>, name: String): PsiElement? {
+        val vec = forms.getOrNull(1) as? PhelVec ?: return null
+        val bindings = vec.forms
+        var i = 0
+        while (i < bindings.size) {
+            val s = bindings[i] as? PhelSymbol
+            if (s?.text == name) return s
+            i += 2
+        }
+        return null
+    }
+
+    private fun findInParamVec(forms: List<PhelForm>, name: String): PsiElement? {
+        // (fn [params] ...) — params at index 1.
+        // (defn name [params] ...) — params at index 2.
+        // (defn name "doc" [params] ...) — scan first vec.
+        for (form in forms.drop(1)) {
+            if (form is PhelVec) {
+                for (p in form.forms) {
+                    val text = (p as? PhelSymbol)?.text ?: PsiTreeUtil.findChildOfType(p, PhelSymbol::class.java)?.text
+                    if (text == name) return p
+                }
+                return null
+            }
+        }
+        return null
+    }
+
+    companion object {
+        private val BINDING_INTRO_FORMS = setOf(
+            "let", "if-let", "when-let", "loop", "for", "foreach", "binding", "dofor",
+        )
+        private val FUNCTION_INTRO_FORMS = setOf("fn", "defn", "defn-", "defmacro", "defmacro-")
+    }
+}

--- a/src/main/kotlin/org/phellang/inspection/PhelUnusedLetBindingInspection.kt
+++ b/src/main/kotlin/org/phellang/inspection/PhelUnusedLetBindingInspection.kt
@@ -1,0 +1,75 @@
+package org.phellang.inspection
+
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.language.psi.*
+
+class PhelUnusedLetBindingInspection : LocalInspectionTool() {
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        return object : PhelVisitor() {
+            override fun visitList(o: PhelList) {
+                val forms = o.forms
+                if (forms.size < 2) return
+                val head = forms[0] as? PhelSymbol ?: return
+                if (head.text !in LET_LIKE_FORMS) return
+
+                val bindingVec = forms[1] as? PhelVec ?: return
+                val bindings = bindingVec.forms
+
+                val body = forms.drop(2)
+                if (body.isEmpty()) return
+
+                var i = 0
+                while (i < bindings.size) {
+                    val target = bindings[i]
+                    val name = (target as? PhelSymbol)?.text
+                    if (name != null && name != "_" && !name.startsWith("_") && !name.startsWith("&")) {
+                        if (!isUsedInBody(name, body) && !isUsedInLaterBindings(name, bindings, i)) {
+                            holder.registerProblem(
+                                target,
+                                "Binding '$name' is never used.",
+                                ProblemHighlightType.LIKE_UNUSED_SYMBOL,
+                                PhelRemoveLetBindingQuickFix(),
+                            )
+                        }
+                    }
+                    i += 2
+                }
+            }
+        }
+    }
+
+    private fun isUsedInBody(name: String, body: List<PhelForm>): Boolean {
+        for (form in body) {
+            val symbols = PsiTreeUtil.findChildrenOfType(form, PhelSymbol::class.java)
+            for (s in symbols) {
+                if (s.text == name) return true
+            }
+            if ((form as? PhelSymbol)?.text == name) return true
+        }
+        return false
+    }
+
+    private fun isUsedInLaterBindings(name: String, bindings: List<PhelForm>, fromIndex: Int): Boolean {
+        // Values at odd indices can reference earlier names.
+        var i = fromIndex + 1
+        while (i < bindings.size) {
+            val value = bindings[i]
+            val symbols = PsiTreeUtil.findChildrenOfType(value, PhelSymbol::class.java)
+            for (s in symbols) {
+                if (s.text == name) return true
+            }
+            i += 2
+        }
+        return false
+    }
+
+}
+
+private val LET_LIKE_FORMS = setOf(
+    "let", "if-let", "when-let", "loop", "for", "foreach", "binding", "dofor",
+)

--- a/src/main/kotlin/org/phellang/language/psi/impl/PhelNamedElementImpl.kt
+++ b/src/main/kotlin/org/phellang/language/psi/impl/PhelNamedElementImpl.kt
@@ -7,11 +7,12 @@ import com.intellij.psi.PsiNameIdentifierOwner
 import com.intellij.psi.PsiReference
 import com.intellij.util.IncorrectOperationException
 import org.jetbrains.annotations.NonNls
-import org.phellang.language.psi.utils.PhelPsiUtils
 import org.phellang.core.psi.PhelSymbolAnalyzer
+import org.phellang.language.psi.PhelPsiFactory
 import org.phellang.language.psi.PhelSymbol
 import org.phellang.language.psi.navigation.PhelItemPresentation
 import org.phellang.language.psi.references.PhelReference
+import org.phellang.language.psi.utils.PhelPsiUtils
 
 /**
  * Base implementation for named Phel elements that can be referenced and renamed.
@@ -23,9 +24,9 @@ abstract class PhelNamedElementImpl(node: ASTNode) : PhelSFormImpl(node), PsiNam
 
     @Throws(IncorrectOperationException::class)
     override fun setName(name: @NonNls String): PsiElement {
-        // Rename not yet supported -- returns element unchanged.
-        // Implementing this requires creating a replacement PSI node via PhelPsiFactory.
-        return this
+        if (this !is PhelSymbol) return this
+        val newSymbol = PhelPsiFactory.createSymbol(project, name)
+        return this.replace(newSymbol)
     }
 
     override fun getNameIdentifier(): PsiElement? = this

--- a/src/main/kotlin/org/phellang/refactoring/PhelNamesValidator.kt
+++ b/src/main/kotlin/org/phellang/refactoring/PhelNamesValidator.kt
@@ -1,0 +1,58 @@
+package org.phellang.refactoring
+
+import com.intellij.lang.refactoring.NamesValidator
+import com.intellij.openapi.project.Project
+
+class PhelNamesValidator : NamesValidator {
+
+    override fun isKeyword(name: String, project: Project?): Boolean = name in RESERVED
+
+    override fun isIdentifier(name: String, project: Project?): Boolean {
+        if (name.isEmpty()) return false
+        val first = name[0]
+        if (first.isDigit()) return false
+        // Leading `:` is a keyword sigil; leading `'`/`` ` ``/`~`/`@`/`#` is a reader macro.
+        if (first in INVALID_FIRST_CHARS) return false
+        return name.all(::isSymbolChar)
+    }
+
+    private fun isSymbolChar(c: Char): Boolean {
+        if (c.isLetterOrDigit()) return true
+        return c in ALLOWED_PUNCT
+    }
+
+}
+
+private val ALLOWED_PUNCT = setOf('-', '_', '?', '!', '*', '+', '/', '<', '>', '=', '.', '&', ':', '\'', '$')
+
+private val INVALID_FIRST_CHARS = setOf(':', '\'', '`', '~', '@', '#')
+
+private val RESERVED = setOf(
+    "def",
+    "defn",
+    "defn-",
+    "def-",
+    "defmacro",
+    "defmacro-",
+    "defstruct",
+    "definterface",
+    "defexception",
+    "declare",
+    "fn",
+    "let",
+    "if",
+    "when",
+    "do",
+    "quote",
+    "var",
+    "throw",
+    "try",
+    "catch",
+    "finally",
+    "loop",
+    "recur",
+    "ns",
+    "true",
+    "false",
+    "nil"
+)

--- a/src/main/kotlin/org/phellang/refactoring/PhelRefactoringSupportProvider.kt
+++ b/src/main/kotlin/org/phellang/refactoring/PhelRefactoringSupportProvider.kt
@@ -1,0 +1,16 @@
+package org.phellang.refactoring
+
+import com.intellij.lang.refactoring.RefactoringSupportProvider
+import com.intellij.psi.PsiElement
+import org.phellang.language.psi.PhelSymbol
+
+class PhelRefactoringSupportProvider : RefactoringSupportProvider() {
+
+    override fun isMemberInplaceRenameAvailable(element: PsiElement, context: PsiElement?): Boolean {
+        return element is PhelSymbol
+    }
+
+    override fun isInplaceRenameAvailable(element: PsiElement, context: PsiElement?): Boolean {
+        return element is PhelSymbol
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -101,7 +101,40 @@
                 enabledByDefault="true"
                 level="WARNING"
                 implementationClass="org.phellang.inspection.deprecated.PhelBackslashNamespaceInspection"/>
+        <localInspection
+                language="Phel"
+                shortName="PhelArityMismatch"
+                displayName="Function arity mismatch"
+                groupName="Phel"
+                enabledByDefault="true"
+                level="ERROR"
+                implementationClass="org.phellang.inspection.PhelArityMismatchInspection"/>
+        <localInspection
+                language="Phel"
+                shortName="PhelUnusedLetBinding"
+                displayName="Unused let binding"
+                groupName="Phel"
+                enabledByDefault="true"
+                level="WARNING"
+                implementationClass="org.phellang.inspection.PhelUnusedLetBindingInspection"/>
+        <localInspection
+                language="Phel"
+                shortName="PhelShadowedLetBinding"
+                displayName="Shadowed let binding"
+                groupName="Phel"
+                enabledByDefault="true"
+                level="WARNING"
+                implementationClass="org.phellang.inspection.PhelShadowedLetBindingInspection"/>
         <formattingService implementation="org.phellang.editor.format.PhelExternalFormatter"/>
+        <lang.refactoringSupport
+                language="Phel"
+                implementationClass="org.phellang.refactoring.PhelRefactoringSupportProvider"/>
+        <lang.namesValidator
+                language="Phel"
+                implementationClass="org.phellang.refactoring.PhelNamesValidator"/>
+        <codeInsight.parameterNameHints
+                language="Phel"
+                implementationClass="org.phellang.inlay.PhelParameterHintsProvider"/>
         <notificationGroup id="Phel" displayType="BALLOON"/>
     </extensions>
 

--- a/src/test/kotlin/org/phellang/integration/editor/PhelFoldingIntegrationTest.kt
+++ b/src/test/kotlin/org/phellang/integration/editor/PhelFoldingIntegrationTest.kt
@@ -134,7 +134,7 @@ class PhelFoldingIntegrationTest {
             val result = foldingBuilder.buildFoldRegions(nsNode, mockDocument)
 
             Assertions.assertEquals(1, result.size)
-            Assertions.assertTrue(foldingBuilder.isCollapsedByDefault(result[0].element))
+            Assertions.assertFalse(foldingBuilder.isCollapsedByDefault(result[0].element))
             Assertions.assertTrue(result[0].placeholderText?.startsWith("(ns") == true)
         }
     }

--- a/src/test/kotlin/org/phellang/unit/completion/data/PhelArityTest.kt
+++ b/src/test/kotlin/org/phellang/unit/completion/data/PhelArityTest.kt
@@ -1,0 +1,87 @@
+package org.phellang.unit.completion.data
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.phellang.completion.data.PhelArity
+import org.phellang.completion.data.accepts
+import org.phellang.completion.data.describe
+import org.phellang.completion.data.selectFor
+
+class PhelArityTest {
+
+    @Test
+    fun `parses fixed-arity signature`() {
+        val arity = PhelArity.parseSignature("(foo a b)")
+        assertNotNull(arity)
+        assertEquals(listOf("a", "b"), arity!!.params)
+        assertFalse(arity.variadic)
+        assertEquals(2, arity.fixedCount)
+    }
+
+    @Test
+    fun `parses zero-arg signature`() {
+        val arity = PhelArity.parseSignature("(foo)")
+        assertNotNull(arity)
+        assertEquals(emptyList<String>(), arity!!.params)
+        assertFalse(arity.variadic)
+        assertEquals(0, arity.fixedCount)
+    }
+
+    @Test
+    fun `parses variadic signature`() {
+        val arity = PhelArity.parseSignature("(foo a & rest)")
+        assertNotNull(arity)
+        assertEquals(listOf("a", "rest"), arity!!.params)
+        assertTrue(arity.variadic)
+        assertEquals(1, arity.fixedCount)
+    }
+
+    @Test
+    fun `parses multi-arity newline-separated`() {
+        val arities = PhelArity.parseAll("(foo a)\n(foo a b)\n(foo a b & xs)")
+        assertEquals(3, arities.size)
+        assertFalse(arities[0].variadic)
+        assertEquals(1, arities[0].params.size)
+        assertTrue(arities[2].variadic)
+        assertEquals(2, arities[2].fixedCount)
+    }
+
+    @Test
+    fun `accepts checks fixed and variadic arities`() {
+        val arities = listOf(
+            PhelArity(listOf("a", "b"), variadic = false),
+            PhelArity(listOf("a", "rest"), variadic = true),
+        )
+        assertTrue(arities.accepts(1)) // variadic min
+        assertTrue(arities.accepts(2))
+        assertTrue(arities.accepts(5)) // variadic
+        assertFalse(arities.accepts(0))
+    }
+
+    @Test
+    fun `selectFor returns exact fixed match before variadic`() {
+        val arities = listOf(
+            PhelArity(listOf("a", "b"), variadic = false),
+            PhelArity(listOf("rest"), variadic = true),
+        )
+        val match = arities.selectFor(2)
+        assertNotNull(match)
+        assertFalse(match!!.variadic)
+        assertEquals(2, match.params.size)
+    }
+
+    @Test
+    fun `describe summarises arities`() {
+        val arities = listOf(
+            PhelArity(listOf("a"), variadic = false),
+            PhelArity(listOf("a", "rest"), variadic = true),
+        )
+        assertEquals("1 or 1+", arities.describe())
+    }
+
+    @Test
+    fun `accepts is permissive on empty arities`() {
+        assertTrue(emptyList<PhelArity>().accepts(0))
+        assertTrue(emptyList<PhelArity>().accepts(99))
+    }
+}

--- a/src/test/kotlin/org/phellang/unit/editor/PhelFoldingBuilderTest.kt
+++ b/src/test/kotlin/org/phellang/unit/editor/PhelFoldingBuilderTest.kt
@@ -157,28 +157,13 @@ class PhelFoldingBuilderTest {
     }
 
     @Test
-    fun `isCollapsedByDefault should return true for namespace declarations`() {
+    fun `isCollapsedByDefault should return false for namespace declarations`() {
         val list = Mockito.mock(PhelList::class.java)
-        val form = Mockito.mock(PhelForm::class.java)
-        val symbol = Mockito.mock(PhelSymbol::class.java)
         val node = createMockNode(list, TextRange(0, 50))
 
-        Mockito.`when`(symbol.text).thenReturn("ns")
-        Mockito.`when`(form.children).thenReturn(arrayOf(symbol))
-        Mockito.`when`(list.children).thenReturn(arrayOf(form))
+        val result = foldingBuilder.isCollapsedByDefault(node)
 
-        Mockito.mockStatic(PsiTreeUtil::class.java).use { mockedPsiTreeUtil ->
-            mockedPsiTreeUtil.`when`<Array<PhelForm>> {
-                PsiTreeUtil.getChildrenOfType(list, PhelForm::class.java)
-            }.thenReturn(arrayOf(form))
-
-            mockedPsiTreeUtil.`when`<PhelSymbol> {
-                PsiTreeUtil.findChildOfType(form, PhelSymbol::class.java)
-            }.thenReturn(symbol)
-
-            val result = foldingBuilder.isCollapsedByDefault(node)
-            Assertions.assertTrue(result)
-        }
+        Assertions.assertFalse(result)
     }
 
     @Test

--- a/src/test/kotlin/org/phellang/unit/editor/folding/PhelFoldingDefaultsTest.kt
+++ b/src/test/kotlin/org/phellang/unit/editor/folding/PhelFoldingDefaultsTest.kt
@@ -2,7 +2,8 @@ package org.phellang.unit.editor.folding
 
 import com.intellij.lang.ASTNode
 import com.intellij.psi.util.PsiTreeUtil
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -12,37 +13,19 @@ import org.phellang.language.psi.*
 
 class PhelFoldingDefaultsTest {
 
-    @Test
-    fun `isCollapsedByDefault should return true for namespace declarations`() {
-        val list = mock(PhelList::class.java)
-        val form = mock(PhelForm::class.java)
-        val symbol = mock(PhelSymbol::class.java)
-        val node = createMockNode(list)
-
-        `when`(symbol.text).thenReturn("ns")
-        `when`(form.children).thenReturn(arrayOf(symbol))
-        `when`(list.children).thenReturn(arrayOf(form))
-
-        withMockedPsiTreeUtil(list, form, symbol) {
-            val result = PhelFoldingDefaults.isCollapsedByDefault(node)
-            assertTrue(result)
-        }
-    }
-
     @ParameterizedTest
     @ValueSource(strings = ["defn", "def", "let", "if", "when", "for"])
     fun `isCollapsedByDefault should return false for non-namespace forms`(formName: String) {
         val list = mock(PhelList::class.java)
         val form = mock(PhelForm::class.java)
         val symbol = mock(PhelSymbol::class.java)
-        val node = createMockNode(list)
 
         `when`(symbol.text).thenReturn(formName)
         `when`(form.children).thenReturn(arrayOf(symbol))
         `when`(list.children).thenReturn(arrayOf(form))
 
         withMockedPsiTreeUtil(list, form, symbol) {
-            val result = PhelFoldingDefaults.isCollapsedByDefault(node)
+            val result = PhelFoldingDefaults.isCollapsedByDefault()
             assertFalse(result)
         }
     }
@@ -51,19 +34,8 @@ class PhelFoldingDefaultsTest {
     fun `isCollapsedByDefault should return false for empty list`() {
         val list = mock(PhelList::class.java)
         `when`(list.children).thenReturn(emptyArray())
-        val node = createMockNode(list)
 
-        val result = PhelFoldingDefaults.isCollapsedByDefault(node)
-
-        assertFalse(result)
-    }
-
-    @Test
-    fun `isCollapsedByDefault should return false for non-list elements`() {
-        val vector = mock(PhelVec::class.java)
-        val node = createMockNode(vector)
-
-        val result = PhelFoldingDefaults.isCollapsedByDefault(node)
+        val result = PhelFoldingDefaults.isCollapsedByDefault()
 
         assertFalse(result)
     }
@@ -120,24 +92,13 @@ class PhelFoldingDefaultsTest {
 
     @Test
     fun `defaults should be consistent across multiple calls`() {
-        val list = mock(PhelList::class.java)
-        val form = mock(PhelForm::class.java)
-        val symbol = mock(PhelSymbol::class.java)
-        val node = createMockNode(list)
+        val result1 = PhelFoldingDefaults.isCollapsedByDefault()
+        val result2 = PhelFoldingDefaults.isCollapsedByDefault()
+        val result3 = PhelFoldingDefaults.isCollapsedByDefault()
 
-        `when`(symbol.text).thenReturn("ns")
-        `when`(form.children).thenReturn(arrayOf(symbol))
-        `when`(list.children).thenReturn(arrayOf(form))
-
-        withMockedPsiTreeUtil(list, form, symbol) {
-            val result1 = PhelFoldingDefaults.isCollapsedByDefault(node)
-            val result2 = PhelFoldingDefaults.isCollapsedByDefault(node)
-            val result3 = PhelFoldingDefaults.isCollapsedByDefault(node)
-
-            assertEquals(result1, result2)
-            assertEquals(result2, result3)
-            assertTrue(result1) // Should be collapsed by default
-        }
+        assertEquals(result1, result2)
+        assertEquals(result2, result3)
+        assertFalse(result1) // Nothing is collapsed by default anymore.
     }
 
     @Test
@@ -170,17 +131,6 @@ class PhelFoldingDefaultsTest {
             val result = PhelFoldingDefaults.getDefaultPlaceholderText(node)
             assertEquals(expectedPlaceholder, result, "Failed for ${element::class.simpleName}")
         }
-    }
-
-    @Test
-    fun `isCollapsedByDefault should handle null children gracefully`() {
-        val list = mock(PhelList::class.java)
-        // Don't mock children to return null, just let it return the default empty array
-        val node = createMockNode(list)
-
-        val result = PhelFoldingDefaults.isCollapsedByDefault(node)
-
-        assertFalse(result) // Should handle empty children gracefully
     }
 
     private fun createMockNode(psiElement: com.intellij.psi.PsiElement): ASTNode {

--- a/src/test/kotlin/org/phellang/unit/refactoring/PhelNamesValidatorTest.kt
+++ b/src/test/kotlin/org/phellang/unit/refactoring/PhelNamesValidatorTest.kt
@@ -1,0 +1,67 @@
+package org.phellang.unit.refactoring
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.phellang.refactoring.PhelNamesValidator
+
+class PhelNamesValidatorTest {
+
+    private val validator = PhelNamesValidator()
+
+    @Test
+    fun `accepts ordinary identifiers`() {
+        assertTrue(validator.isIdentifier("foo", null))
+        assertTrue(validator.isIdentifier("foo-bar", null))
+        assertTrue(validator.isIdentifier("foo_bar", null))
+    }
+
+    @Test
+    fun `accepts predicate names`() {
+        assertTrue(validator.isIdentifier("nil?", null))
+        assertTrue(validator.isIdentifier("set!", null))
+    }
+
+    @Test
+    fun `accepts arithmetic operators`() {
+        assertTrue(validator.isIdentifier("+", null))
+        assertTrue(validator.isIdentifier("-", null))
+        assertTrue(validator.isIdentifier("*", null))
+        assertTrue(validator.isIdentifier("=", null))
+        assertTrue(validator.isIdentifier("<=", null))
+    }
+
+    @Test
+    fun `rejects empty name`() {
+        assertFalse(validator.isIdentifier("", null))
+    }
+
+    @Test
+    fun `rejects name starting with digit`() {
+        assertFalse(validator.isIdentifier("1foo", null))
+    }
+
+    @Test
+    fun `rejects leading reader-macro and keyword sigils`() {
+        assertFalse(validator.isIdentifier(":foo", null))
+        assertFalse(validator.isIdentifier("'foo", null))
+        assertFalse(validator.isIdentifier("`foo", null))
+        assertFalse(validator.isIdentifier("~foo", null))
+        assertFalse(validator.isIdentifier("@foo", null))
+        assertFalse(validator.isIdentifier("#foo", null))
+    }
+
+    @Test
+    fun `rejects whitespace and parens`() {
+        assertFalse(validator.isIdentifier("foo bar", null))
+        assertFalse(validator.isIdentifier("(foo)", null))
+    }
+
+    @Test
+    fun `marks reserved words as keywords`() {
+        assertTrue(validator.isKeyword("def", null))
+        assertTrue(validator.isKeyword("defn", null))
+        assertTrue(validator.isKeyword("ns", null))
+        assertFalse(validator.isKeyword("foo", null))
+    }
+}

--- a/src/test/kotlin/org/phellang/unit/refactoring/PhelRefactoringSupportProviderTest.kt
+++ b/src/test/kotlin/org/phellang/unit/refactoring/PhelRefactoringSupportProviderTest.kt
@@ -1,0 +1,28 @@
+package org.phellang.unit.refactoring
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.refactoring.PhelRefactoringSupportProvider
+
+class PhelRefactoringSupportProviderTest {
+
+    private val provider = PhelRefactoringSupportProvider()
+
+    @Test
+    fun `inplace rename enabled for symbols`() {
+        val symbol = mock(PhelSymbol::class.java)
+        assertTrue(provider.isInplaceRenameAvailable(symbol, null))
+        assertTrue(provider.isMemberInplaceRenameAvailable(symbol, null))
+    }
+
+    @Test
+    fun `inplace rename disabled for non-symbols`() {
+        val list = mock(PhelList::class.java)
+        assertFalse(provider.isInplaceRenameAvailable(list, null))
+        assertFalse(provider.isMemberInplaceRenameAvailable(list, null))
+    }
+}


### PR DESCRIPTION
## Summary

Closes several roadmap gaps that do not depend on upstream phel-lang work.

- **Rename refactoring** for user symbols. `PhelNamedElementImpl.setName` replaces via `PhelPsiFactory`; new `PhelRefactoringSupportProvider` enables in-place rename; new `PhelNamesValidator` allows Lisp-friendly identifier chars and rejects keyword / reader-macro sigils (`:`, `'`, `` ` ``, `~`, `@`, `#`).
- **Inlay parameter-name hints** via `InlayParameterHintsProvider`, backed by a structured `PhelArity` model parsed from project + core registry signatures. Multi-arity supported.
- **Arity-mismatch inspection** (ERROR). Skips threading macros (`->`, `->>`, `as->`, `some->`, `cond->`, `doto`) and quoted / syntax-quoted data forms to avoid false positives.
- **Unused let-binding inspection** (WARNING) with "Remove binding" quick fix.
- **Shadowed let-binding inspection** (WEAK_WARNING).
- **Faster lookup**: `PhelProjectSymbolIndex` gains a `symbolsByName` index + `findByName(name)` for O(1) cross-namespace lookups used by the arity inspection and inlay hints.
- **Folding default**: `(ns ...)` is no longer auto-collapsed on file open.
