### PR TITLE
feat: function params are not marked as fn if they match to a phel fu…

### DIFF
--- a/src/main/kotlin/org/phellang/annotator/highlighters/PhelSymbolHighlighter.kt
+++ b/src/main/kotlin/org/phellang/annotator/highlighters/PhelSymbolHighlighter.kt
@@ -26,12 +26,6 @@ object PhelSymbolHighlighter {
     fun annotateSymbol(symbol: PhelSymbol, text: String, holder: AnnotationHolder) {
         if (!PhelAnnotationUtils.isValidText(text)) return
 
-        // Check for deprecated functions first - applies strikethrough
-        if (PhelFunctionRegistry.isDeprecated(text)) {
-            PhelAnnotationUtils.createAnnotation(holder, symbol, DEPRECATED_SYMBOL)
-            return
-        }
-
         // Variadic parameter marker (&) - check before other parameter checks
         if (text == "&") {
             if (PhelSymbolAnalyzer.isInParameterVector(symbol)) {
@@ -40,12 +34,20 @@ object PhelSymbolHighlighter {
             }
         }
 
-        // Function parameters and let bindings (check early, before other classifications)
+        // Function parameters and let bindings shadow same-named core fns. Classify
+        // them first so the deprecated check below does not paint local bindings
+        // with strikethrough.
         if (PhelSymbolAnalyzer.isParameterReference(symbol)
             || PhelSymbolAnalyzer.isFunctionParameter(symbol)
             || PhelSymbolAnalyzer.isLetBinding(symbol)
         ) {
             PhelAnnotationUtils.createAnnotation(holder, symbol, FUNCTION_PARAMETER)
+            return
+        }
+
+        // Deprecated core functions - applies strikethrough.
+        if (PhelFunctionRegistry.isDeprecated(text)) {
+            PhelAnnotationUtils.createAnnotation(holder, symbol, DEPRECATED_SYMBOL)
             return
         }
 

--- a/src/main/kotlin/org/phellang/completion/engine/PhelLocalSymbolCompletions.kt
+++ b/src/main/kotlin/org/phellang/completion/engine/PhelLocalSymbolCompletions.kt
@@ -10,7 +10,6 @@ import com.intellij.psi.PsiManager
 import org.phellang.language.infrastructure.PhelFileType
 import org.phellang.completion.infrastructure.PhelCompletionErrorHandler
 import org.phellang.completion.infrastructure.PhelCompletionPriority
-import org.phellang.language.psi.utils.SymbolCategory
 import org.phellang.completion.infrastructure.PhelCompletionUtils
 import org.phellang.core.psi.PhelSymbolAnalyzer
 import org.phellang.core.utils.PhelErrorHandler
@@ -21,6 +20,8 @@ import org.phellang.language.psi.PhelSymbol
 import org.phellang.language.psi.PhelVec
 import org.phellang.language.psi.impl.PhelAccessImpl
 import javax.swing.Icon
+
+private val FUNCTION_INTRO_FORMS = setOf("fn", "defn", "defn-", "defmacro", "defmacro-")
 
 object PhelLocalSymbolCompletions {
     val PARAMETER_ICON = AllIcons.Nodes.Parameter
@@ -88,7 +89,7 @@ object PhelLocalSymbolCompletions {
                     if (firstChild is PhelSymbol || firstChild is PhelAccessImpl) {
                         val functionType = firstChild.text
 
-                        if (PhelSymbolAnalyzer.isSymbolType(functionType, SymbolCategory.SPECIAL_FORMS)) {
+                        if (functionType in FUNCTION_INTRO_FORMS) {
                             val paramVec = PhelSymbolAnalyzer.findParameterVector(current) ?: break
                             // Extract parameters from the vector
                             val paramChildren = paramVec.children

--- a/src/main/kotlin/org/phellang/inlay/PhelParameterHintsProvider.kt
+++ b/src/main/kotlin/org/phellang/inlay/PhelParameterHintsProvider.kt
@@ -8,8 +8,10 @@ import org.phellang.completion.data.PhelArity
 import org.phellang.completion.data.PhelFunctionRegistry
 import org.phellang.completion.data.selectFor
 import org.phellang.completion.indexing.PhelProjectSymbolIndex
+import org.phellang.language.psi.PhelForm
 import org.phellang.language.psi.PhelList
 import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.PhelVec
 
 class PhelParameterHintsProvider : InlayParameterHintsProvider {
 
@@ -26,6 +28,7 @@ class PhelParameterHintsProvider : InlayParameterHintsProvider {
         if (headName.startsWith("php/") || headName.startsWith(".") || headName.startsWith("php-")) {
             return emptyList()
         }
+        if (resolvesToLocalBinding(headSymbol, headName)) return emptyList()
 
         val args = forms.drop(1)
         val arities = resolveArities(headSymbol, headName) ?: return emptyList()
@@ -64,6 +67,46 @@ class PhelParameterHintsProvider : InlayParameterHintsProvider {
         return index.findByName(shortName).firstOrNull { it.arities.isNotEmpty() }?.arities
     }
 
+    /** True when [name] resolves to an enclosing let/loop binding or fn parameter. */
+    private fun resolvesToLocalBinding(head: PhelSymbol, name: String): Boolean {
+        var current: PsiElement? = head.parent
+        while (current != null) {
+            if (current is PhelList) {
+                val forms = current.forms
+                val parentHead = (forms.firstOrNull() as? PhelSymbol)?.text
+                if (parentHead != null) {
+                    if (parentHead in BINDING_INTRO_FORMS && bindingVecContains(forms, name)) return true
+                    if (parentHead in FUNCTION_INTRO_FORMS && paramVecContains(forms, name)) return true
+                }
+            }
+            current = current.parent
+        }
+        return false
+    }
+
+    private fun bindingVecContains(forms: List<PhelForm>, name: String): Boolean {
+        val vec = forms.getOrNull(1) as? PhelVec ?: return false
+        val bindings = vec.forms
+        var i = 0
+        while (i < bindings.size) {
+            if ((bindings[i] as? PhelSymbol)?.text == name) return true
+            i += 2
+        }
+        return false
+    }
+
+    private fun paramVecContains(forms: List<PhelForm>, name: String): Boolean {
+        for (form in forms.drop(1)) {
+            if (form is PhelVec) {
+                for (p in form.forms) {
+                    if ((p as? PhelSymbol)?.text == name) return true
+                }
+                return false
+            }
+        }
+        return false
+    }
+
     override fun getHintInfo(element: PsiElement): HintInfo? {
         if (element !is PhelList) return null
         val head = element.forms.firstOrNull() as? PhelSymbol ?: return null
@@ -75,6 +118,12 @@ class PhelParameterHintsProvider : InlayParameterHintsProvider {
 
     override fun isBlackListSupported(): Boolean = true
 }
+
+private val BINDING_INTRO_FORMS = setOf(
+    "let", "if-let", "when-let", "loop", "for", "foreach", "binding", "dofor",
+)
+
+private val FUNCTION_INTRO_FORMS = setOf("fn", "defn", "defn-", "defmacro", "defmacro-")
 
 // Special forms and macros where param-name hints would be noise.
 private val SKIP_HEADS = setOf(

--- a/src/main/kotlin/org/phellang/inspection/PhelArityMismatchInspection.kt
+++ b/src/main/kotlin/org/phellang/inspection/PhelArityMismatchInspection.kt
@@ -10,6 +10,7 @@ import org.phellang.completion.data.PhelFunctionRegistry
 import org.phellang.completion.data.accepts
 import org.phellang.completion.data.describe
 import org.phellang.completion.indexing.PhelProjectSymbolIndex
+import org.phellang.core.psi.PhelSymbolAnalyzer
 import org.phellang.language.psi.PhelForm
 import org.phellang.language.psi.PhelList
 import org.phellang.language.psi.PhelSymbol
@@ -31,6 +32,7 @@ class PhelArityMismatchInspection : LocalInspectionTool() {
 
                 if (isInQuoteContext(o)) return
                 if (isThreadedArgList(o)) return
+                if (resolvesToLocalBinding(head, name)) return
 
                 val arities = resolveArities(head, name) ?: return
                 if (arities.isEmpty()) return
@@ -108,11 +110,61 @@ class PhelArityMismatchInspection : LocalInspectionTool() {
         return null
     }
 
+    /**
+     * True when [name] resolves to a local binding (let/loop/for/binding, or `fn`/`defn`
+     * parameter) visible at [head]. Such a name shadows any same-named core fn, so
+     * the registry arity must not be applied.
+     */
+    private fun resolvesToLocalBinding(head: PhelSymbol, name: String): Boolean {
+        var current: PsiElement? = head.parent
+        while (current != null) {
+            if (current is PhelList) {
+                val parentForms = current.forms
+                val parentHead = (parentForms.firstOrNull() as? PhelSymbol)?.text
+                if (parentHead != null) {
+                    if (parentHead in BINDING_INTRO_FORMS && bindingVecContains(parentForms, name)) return true
+                    if (parentHead in FUNCTION_INTRO_FORMS && paramVecContains(parentForms, name)) return true
+                }
+            }
+            current = current.parent
+        }
+        return false
+    }
+
+    private fun bindingVecContains(forms: List<PhelForm>, name: String): Boolean {
+        val vec = forms.getOrNull(1) as? org.phellang.language.psi.PhelVec ?: return false
+        val bindings = vec.forms
+        var i = 0
+        while (i < bindings.size) {
+            if ((bindings[i] as? PhelSymbol)?.text == name) return true
+            i += 2
+        }
+        return false
+    }
+
+    private fun paramVecContains(forms: List<PhelForm>, name: String): Boolean {
+        for (form in forms.drop(1)) {
+            if (form is org.phellang.language.psi.PhelVec) {
+                for (p in form.forms) {
+                    if ((p as? PhelSymbol)?.text == name) return true
+                }
+                return false
+            }
+        }
+        return false
+    }
+
 }
 
 private val THREADING_HEADS = setOf(
     "->", "->>", "as->", "some->", "some->>", "cond->", "cond->>", "doto",
 )
+
+private val BINDING_INTRO_FORMS = setOf(
+    "let", "if-let", "when-let", "loop", "for", "foreach", "binding", "dofor",
+)
+
+private val FUNCTION_INTRO_FORMS = setOf("fn", "defn", "defn-", "defmacro", "defmacro-")
 
 // Special forms / macros that legitimately accept variable arg shapes.
 // Skipping avoids false positives.

--- a/src/main/kotlin/org/phellang/inspection/deprecated/PhelDeprecatedFunctionInspection.kt
+++ b/src/main/kotlin/org/phellang/inspection/deprecated/PhelDeprecatedFunctionInspection.kt
@@ -6,6 +6,7 @@ import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.PsiElementVisitor
 import org.phellang.completion.data.DeprecationInfo
 import org.phellang.completion.data.PhelFunctionRegistry
+import org.phellang.core.psi.PhelSymbolAnalyzer
 import org.phellang.language.psi.PhelSymbol
 import org.phellang.language.psi.PhelVisitor
 
@@ -15,6 +16,15 @@ class PhelDeprecatedFunctionInspection : LocalInspectionTool() {
         return object : PhelVisitor() {
             override fun visitSymbol(symbol: PhelSymbol) {
                 val text = symbol.text ?: return
+
+                // Skip binding occurrences and references to local bindings.
+                // A name introduced by a fn/defn parameter vector or a let-like
+                // binding shadows any same-named core fn; usages of that local
+                // must not be flagged as a deprecated core-fn reference.
+                if (PhelSymbolAnalyzer.isParameterReference(symbol)) return
+                if (PhelSymbolAnalyzer.isFunctionParameter(symbol)) return
+                if (PhelSymbolAnalyzer.isLetBinding(symbol)) return
+                if (PhelSymbolAnalyzer.isDefinition(symbol)) return
 
                 if (PhelFunctionRegistry.isDeprecated(text)) {
                     val deprecation = getDeprecationInfo(text)


### PR DESCRIPTION
## 📚 Description

`id` function parameter is not marked anymore as the `id` function.

Also, the body references the function parameters.

<img width="532" height="154" alt="image" src="https://github.com/user-attachments/assets/bb9d73b7-0682-4111-a02e-140f66a8cdba" />
