### PR TITLE
feat: recognise PHP interop shorthands and resolve :use'd classes

### DIFF
--- a/.claude/rules/phel-language.md
+++ b/.claude/rules/phel-language.md
@@ -30,6 +30,21 @@ Phel is a functional programming language that transpiles to PHP. It is a dialec
 - Instance calls: `(php/-> object method)`
 - Operators: `php/+`, `php/-`, `php/&&`, `php/||`, `php/!==`, `php/@`, `php/^`, `php/~`
 
+### Interop shorthands
+
+Terse forms that expand to verbose `php/*`:
+
+| Shorthand                 | Expands to                         |
+|---------------------------|------------------------------------|
+| `(ClassName. args)`       | `(php/new ClassName args)`         |
+| `(new ClassName args)`    | `(php/new ClassName args)`         |
+| `(.method obj args)`      | `(php/-> obj (method args))`       |
+| `(.-field obj)`           | `(php/-> obj field)`               |
+| `(ClassName/method args)` | `(php/:: ClassName (method args))` |
+| `ClassName/MEMBER`        | `(php/:: ClassName MEMBER)`        |
+
+Classes are brought into scope via `(:use \DateTime \Exception)` in the `ns` form.
+
 ## File Structure
 - Every file starts with `(ns namespace\name)`
 - Top-level forms: `def`, `defn`, `defmacro`, comments

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.grammarkit.tasks.GenerateLexerTask
 import org.jetbrains.grammarkit.tasks.GenerateParserTask
 
 group = "org.phellang"
-version = "0.4.2"
+version = "0.4.3"
 
 plugins {
     id("java")

--- a/src/main/kotlin/org/phellang/annotator/analyzers/PhelSymbolPositionAnalyzer.kt
+++ b/src/main/kotlin/org/phellang/annotator/analyzers/PhelSymbolPositionAnalyzer.kt
@@ -39,4 +39,27 @@ object PhelSymbolPositionAnalyzer {
     fun hasNamespacePrefix(text: String): Boolean {
         return text.contains("\\") && !text.startsWith("\\") && !text.endsWith("\\")
     }
+
+    /**
+     * Returns true when [symbol] is the immediate argument of a PHP constructor form:
+     * either `(new ClassName ...)` or `(php/new ClassName ...)`. Used to colour the
+     * class name itself as PHP interop even when it isn't a `:use`-d short class.
+     */
+    fun isConstructorClassArgument(symbol: PhelSymbol): Boolean {
+        var current: PsiElement? = symbol.parent
+        while (current != null && current !is PhelList) {
+            current = current.parent
+        }
+        val list = current as? PhelList ?: return false
+        val forms = list.forms
+        if (forms.size < 2) return false
+
+        val head = forms[0]
+        val headSymbol = head as? PhelSymbol ?: findFirstSymbol(head) ?: return false
+        val headText = headSymbol.text ?: return false
+        if (headText != "new" && headText != "php/new") return false
+
+        val argSymbol = forms[1] as? PhelSymbol ?: findFirstSymbol(forms[1]) ?: return false
+        return argSymbol === symbol
+    }
 }

--- a/src/main/kotlin/org/phellang/annotator/highlighters/PhelSymbolHighlighter.kt
+++ b/src/main/kotlin/org/phellang/annotator/highlighters/PhelSymbolHighlighter.kt
@@ -16,6 +16,7 @@ import org.phellang.completion.data.PhelFunctionRegistry
 import org.phellang.annotator.analyzers.PhelSymbolPositionAnalyzer
 import org.phellang.annotator.infrastructure.PhelAnnotationUtils
 import org.phellang.core.psi.PhelSymbolAnalyzer
+import org.phellang.language.psi.PhelInteropShorthands
 import org.phellang.language.psi.PhelNamespaceUtils
 import org.phellang.language.psi.PhelSymbol
 import org.phellang.language.psi.files.PhelFile
@@ -67,6 +68,29 @@ object PhelSymbolHighlighter {
             return
         }
 
+        // PHP interop shorthands: `Class.`, `.method`, `.-field`, `Class/method`,
+        // `Class/CONST`, bare `new`, and `\Foo` / `\Foo\Bar` class references.
+        val containingFile = symbol.containingFile as? PhelFile
+        val usedClasses = if (containingFile != null) {
+            PhelNamespaceUtils.extractUsedClasses(containingFile)
+        } else {
+            emptySet()
+        }
+        if (PhelInteropShorthands.isInteropShorthand(text, usedClasses)) {
+            PhelAnnotationUtils.createAnnotation(holder, symbol, PHP_INTEROP)
+            return
+        }
+
+        // ClassName argument of `(new ClassName ...)` / `(php/new ClassName ...)`.
+        // We only colour it when the text actually looks like a PHP class — otherwise
+        // we'd paint user-defined macros that happen to be called `new`.
+        if (PhelInteropShorthands.isInteropClassName(text)
+            && PhelSymbolPositionAnalyzer.isConstructorClassArgument(symbol)
+        ) {
+            PhelAnnotationUtils.createAnnotation(holder, symbol, PHP_INTEROP)
+            return
+        }
+
         // Namespace-qualified function calls - use "/" as separator
         if (text.contains("/") && !text.startsWith("/") && !text.endsWith("/")) {
             // First, validate the namespace itself
@@ -105,7 +129,6 @@ object PhelSymbolHighlighter {
         // Function call position
         if (PhelSymbolPositionAnalyzer.isInFunctionCallPosition(symbol)) {
             // Check if this is an imported function via :refer - use FUNCTION_CALL color
-            val containingFile = symbol.containingFile as? PhelFile
             if (containingFile != null && PhelNamespaceUtils.isReferredSymbol(containingFile, text)) {
                 PhelAnnotationUtils.createAnnotation(holder, symbol, FUNCTION_CALL)
                 return

--- a/src/main/kotlin/org/phellang/annotator/validators/PhelFunctionReferenceValidator.kt
+++ b/src/main/kotlin/org/phellang/annotator/validators/PhelFunctionReferenceValidator.kt
@@ -3,6 +3,7 @@ package org.phellang.annotator.validators
 import org.phellang.completion.documentation.PhelApiDocumentation
 import org.phellang.completion.indexing.PhelProjectSymbolIndex
 import org.phellang.language.psi.utils.PhelPsiUtils
+import org.phellang.language.psi.PhelInteropShorthands
 import org.phellang.language.psi.PhelNamespaceUtils
 import org.phellang.language.psi.PhelProjectNamespaceFinder
 import org.phellang.language.psi.PhelSymbol
@@ -33,6 +34,14 @@ object PhelFunctionReferenceValidator {
         }
 
         val containingFile = symbol.containingFile as? PhelFile ?: return null
+
+        // Skip PHP-class interop shorthands (e.g. `DateTime/createFromFormat`,
+        // `\Foo\Bar/CONST`). The qualifier is a PHP class, not a Phel namespace,
+        // so the regular function lookup can't validate it.
+        val usedClasses = PhelNamespaceUtils.extractUsedClasses(containingFile)
+        if (PhelInteropShorthands.isInteropShorthand(text, usedClasses)) {
+            return null
+        }
 
         // Get alias map to resolve the actual namespace
         val aliasMap = PhelNamespaceUtils.extractAliasMap(containingFile)

--- a/src/main/kotlin/org/phellang/annotator/validators/PhelNamespaceValidator.kt
+++ b/src/main/kotlin/org/phellang/annotator/validators/PhelNamespaceValidator.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.util.PsiTreeUtil
 import org.phellang.language.psi.utils.PhelPsiUtils
 import org.phellang.language.psi.PhelForm
+import org.phellang.language.psi.PhelInteropShorthands
 import org.phellang.language.psi.PhelNamespaceUtils
 import org.phellang.language.psi.PhelProjectNamespaceFinder
 import org.phellang.language.psi.PhelSymbol
@@ -34,6 +35,14 @@ object PhelNamespaceValidator {
         }
 
         val containingFile = symbol.containingFile as? PhelFile ?: return null
+
+        // Skip PHP-class interop shorthands like `DateTime/createFromFormat` or
+        // `\Foo\Bar/CONST`. These look namespaced but the qualifier is a PHP class,
+        // not a Phel namespace, so the regular import lookup would always fail.
+        val usedClasses = PhelNamespaceUtils.extractUsedClasses(containingFile)
+        if (PhelInteropShorthands.isInteropShorthand(text, usedClasses)) {
+            return null
+        }
 
         // Check if the qualifier is imported or aliased AND the namespace exists
         val importStatus = checkImportStatus(containingFile, qualifier)

--- a/src/main/kotlin/org/phellang/completion/data/registerPhpInteropFunctions.kt
+++ b/src/main/kotlin/org/phellang/completion/data/registerPhpInteropFunctions.kt
@@ -12,15 +12,7 @@ internal fun registerPhpInteropFunctions(): List<PhelFunction> = listOf(
             priority = PhelCompletionPriority.SPECIAL_FORMS,
         ),
         documentation = DocumentationInfo(
-            summary = """
-Access to an object property or result of chained calls.
-<br><br>
-Shorthands:
-<ul>
-<li><code>(.method obj args)</code> &rarr; <code>(php/-&gt; obj (method args))</code></li>
-<li><code>(.-field obj)</code> &rarr; <code>(php/-&gt; obj field)</code></li>
-</ul>
-""",
+            summary = "Access to an object property or result of chained calls.",
             example = "(php/-&gt; date (format \"Y-m-d\"))",
             links = DocumentationLinks(
                 github = "",
@@ -39,12 +31,6 @@ Shorthands:
         documentation = DocumentationInfo(
             summary = """
 Calls a static method or property from a PHP class. Both method-name and property must be symbols and cannot be an evaluated value.
-<br><br>
-Shorthands:
-<ul>
-<li><code>(ClassName/method args)</code> &rarr; <code>(php/:: ClassName (method args))</code></li>
-<li><code>ClassName/MEMBER</code> &rarr; <code>(php/:: ClassName MEMBER)</code></li>
-</ul>
 """,
             example = "(php/:: DateTime (createFromFormat \"Y-m-d\" \"2024-01-01\"))",
             links = DocumentationLinks(
@@ -214,12 +200,6 @@ Equivalent to PHP's <code>unset(arr[k1][k2][k...])</code>.
         documentation = DocumentationInfo(
             summary = """
 Evaluates expr and creates a new PHP class using the arguments. The instance of the class is returned.
-<br><br>
-Shorthands:
-<ul>
-<li><code>(ClassName. args)</code> &rarr; <code>(php/new ClassName args)</code></li>
-<li><code>(new ClassName args)</code> &rarr; <code>(php/new ClassName args)</code></li>
-</ul>
 """,
             example = "(php/new DateTime \"2024-01-01\")",
             links = DocumentationLinks(

--- a/src/main/kotlin/org/phellang/completion/data/registerPhpInteropFunctions.kt
+++ b/src/main/kotlin/org/phellang/completion/data/registerPhpInteropFunctions.kt
@@ -12,7 +12,15 @@ internal fun registerPhpInteropFunctions(): List<PhelFunction> = listOf(
             priority = PhelCompletionPriority.SPECIAL_FORMS,
         ),
         documentation = DocumentationInfo(
-            summary = "Access to an object property or result of chained calls.",
+            summary = """
+Access to an object property or result of chained calls.
+<br><br>
+Shorthands:
+<ul>
+<li><code>(.method obj args)</code> &rarr; <code>(php/-&gt; obj (method args))</code></li>
+<li><code>(.-field obj)</code> &rarr; <code>(php/-&gt; obj field)</code></li>
+</ul>
+""",
             example = "(php/-&gt; date (format \"Y-m-d\"))",
             links = DocumentationLinks(
                 github = "",
@@ -31,6 +39,12 @@ internal fun registerPhpInteropFunctions(): List<PhelFunction> = listOf(
         documentation = DocumentationInfo(
             summary = """
 Calls a static method or property from a PHP class. Both method-name and property must be symbols and cannot be an evaluated value.
+<br><br>
+Shorthands:
+<ul>
+<li><code>(ClassName/method args)</code> &rarr; <code>(php/:: ClassName (method args))</code></li>
+<li><code>ClassName/MEMBER</code> &rarr; <code>(php/:: ClassName MEMBER)</code></li>
+</ul>
 """,
             example = "(php/:: DateTime (createFromFormat \"Y-m-d\" \"2024-01-01\"))",
             links = DocumentationLinks(
@@ -200,6 +214,12 @@ Equivalent to PHP's <code>unset(arr[k1][k2][k...])</code>.
         documentation = DocumentationInfo(
             summary = """
 Evaluates expr and creates a new PHP class using the arguments. The instance of the class is returned.
+<br><br>
+Shorthands:
+<ul>
+<li><code>(ClassName. args)</code> &rarr; <code>(php/new ClassName args)</code></li>
+<li><code>(new ClassName args)</code> &rarr; <code>(php/new ClassName args)</code></li>
+</ul>
 """,
             example = "(php/new DateTime \"2024-01-01\")",
             links = DocumentationLinks(

--- a/src/main/kotlin/org/phellang/completion/engine/PhelMainCompletionProvider.kt
+++ b/src/main/kotlin/org/phellang/completion/engine/PhelMainCompletionProvider.kt
@@ -9,6 +9,7 @@ import org.phellang.completion.infrastructure.PhelCompletionErrorHandler
 import org.phellang.completion.infrastructure.PhelProjectCompletionHelper
 import org.phellang.completion.infrastructure.PhelReferCompletionHelper
 import org.phellang.completion.infrastructure.PhelRegistryCompletionHelper
+import org.phellang.completion.infrastructure.PhelUsedClassCompletionHelper
 import org.phellang.core.utils.PhelErrorHandler
 import org.phellang.language.infrastructure.PhelIcons
 import org.phellang.language.psi.PhelNamespaceUtils
@@ -134,6 +135,7 @@ class PhelMainCompletionProvider : CompletionProvider<CompletionParameters?>() {
             // Project symbols (functions from other project files)
             if (psiFile != null) {
                 PhelProjectCompletionHelper.addProjectCompletions(result, psiFile, aliasMap)
+                PhelUsedClassCompletionHelper.addUsedClassCompletions(result, psiFile)
             }
         }
     }

--- a/src/main/kotlin/org/phellang/completion/infrastructure/PhelUsedClassCompletionHelper.kt
+++ b/src/main/kotlin/org/phellang/completion/infrastructure/PhelUsedClassCompletionHelper.kt
@@ -3,18 +3,22 @@ package org.phellang.completion.infrastructure
 import com.intellij.codeInsight.completion.CompletionResultSet
 import com.intellij.codeInsight.completion.PrioritizedLookupElement
 import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.psi.util.PsiTreeUtil
 import org.phellang.language.infrastructure.PhelIcons
 import org.phellang.language.psi.PhelNamespaceUtils
+import org.phellang.language.psi.PhelSymbol
 import org.phellang.language.psi.files.PhelFile
+import org.phellang.language.psi.references.PhpClassResolver
 
 /**
  * Completion for PHP classes brought into scope via `(:use ...)` in the file's
- * `ns` declaration. For each used class `Foo` we offer three lookups that mirror
- * the three interop shorthands users can write:
+ * `ns` declaration. For each used class `Foo` we offer:
  *
  *  * `Foo`   — bare reference (catch targets, `(new Foo ...)`)
  *  * `Foo.`  — constructor shorthand, expands to `(php/new Foo ...)`
  *  * `Foo/`  — static call/member prefix; the user types the member next
+ *  * `Foo/name` for each public method/constant/field on `Foo` (when the PHP
+ *    plugin is available — silently no-ops otherwise).
  */
 object PhelUsedClassCompletionHelper {
 
@@ -23,11 +27,58 @@ object PhelUsedClassCompletionHelper {
         val classes = PhelNamespaceUtils.extractUsedClasses(file)
         if (classes.isEmpty()) return
 
+        val fqnByShort = buildFqnIndex(file)
+
         for (className in classes) {
             result.addElement(usedClassLookup(className))
             result.addElement(constructorLookup(className))
             result.addElement(staticPrefixLookup(className))
+
+            val fqn = fqnByShort[className] ?: "\\$className"
+            for (member in PhpClassResolver.listMembers(file.project, fqn)) {
+                result.addElement(memberLookup(className, member))
+            }
         }
+    }
+
+    private fun buildFqnIndex(file: PhelFile): Map<String, String> {
+        val nsDeclaration = PhelNamespaceUtils.findNamespaceDeclaration(file) ?: return emptyMap()
+        val index = mutableMapOf<String, String>()
+        for (useForm in PhelNamespaceUtils.findUseForms(nsDeclaration)) {
+            val forms = useForm.forms
+            for (i in 1 until forms.size) {
+                val form = forms[i]
+                val sym = form as? PhelSymbol ?: PsiTreeUtil.findChildOfType(form, PhelSymbol::class.java)
+                val raw = sym?.text ?: continue
+                val shortName = raw.trimStart('\\').substringAfterLast('\\')
+                val fqn = if (raw.startsWith("\\")) raw else "\\$raw"
+                index[shortName] = fqn
+            }
+        }
+        return index
+    }
+
+    private fun memberLookup(
+        className: String,
+        member: PhpClassResolver.PhpMemberInfo,
+    ) = PrioritizedLookupElement.withPriority(
+        LookupElementBuilder.create("$className/${member.name}")
+            .withIcon(PhelIcons.FILE)
+            .withTypeText(memberTypeText(member), true)
+            .withTailText(memberTailText(member), true),
+        // Concrete members beat the bare `Class/` prefix so they sort above it.
+        PhelCompletionPriority.PHP_INTEROP.value + 0.1,
+    )
+
+    private fun memberTypeText(member: PhpClassResolver.PhpMemberInfo): String = when (member.kind) {
+        PhpClassResolver.MemberKind.METHOD -> if (member.isStatic) "static method" else "method"
+        PhpClassResolver.MemberKind.CONSTANT -> "constant"
+        PhpClassResolver.MemberKind.FIELD -> if (member.isStatic) "static field" else "field"
+    }
+
+    private fun memberTailText(member: PhpClassResolver.PhpMemberInfo): String = when (member.kind) {
+        PhpClassResolver.MemberKind.METHOD -> " — ${member.signature}"
+        else -> ""
     }
 
     private fun usedClassLookup(className: String) = PrioritizedLookupElement.withPriority(

--- a/src/main/kotlin/org/phellang/completion/infrastructure/PhelUsedClassCompletionHelper.kt
+++ b/src/main/kotlin/org/phellang/completion/infrastructure/PhelUsedClassCompletionHelper.kt
@@ -1,0 +1,56 @@
+package org.phellang.completion.infrastructure
+
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.codeInsight.completion.PrioritizedLookupElement
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import org.phellang.language.infrastructure.PhelIcons
+import org.phellang.language.psi.PhelNamespaceUtils
+import org.phellang.language.psi.files.PhelFile
+
+/**
+ * Completion for PHP classes brought into scope via `(:use ...)` in the file's
+ * `ns` declaration. For each used class `Foo` we offer three lookups that mirror
+ * the three interop shorthands users can write:
+ *
+ *  * `Foo`   — bare reference (catch targets, `(new Foo ...)`)
+ *  * `Foo.`  — constructor shorthand, expands to `(php/new Foo ...)`
+ *  * `Foo/`  — static call/member prefix; the user types the member next
+ */
+object PhelUsedClassCompletionHelper {
+
+    @JvmStatic
+    fun addUsedClassCompletions(result: CompletionResultSet, file: PhelFile) {
+        val classes = PhelNamespaceUtils.extractUsedClasses(file)
+        if (classes.isEmpty()) return
+
+        for (className in classes) {
+            result.addElement(usedClassLookup(className))
+            result.addElement(constructorLookup(className))
+            result.addElement(staticPrefixLookup(className))
+        }
+    }
+
+    private fun usedClassLookup(className: String) = PrioritizedLookupElement.withPriority(
+        LookupElementBuilder.create(className)
+            .withIcon(PhelIcons.FILE)
+            .withTypeText("PHP class (use)", true)
+            .withTailText(" — bare reference", true),
+        PhelCompletionPriority.PHP_INTEROP.value
+    )
+
+    private fun constructorLookup(className: String) = PrioritizedLookupElement.withPriority(
+        LookupElementBuilder.create("$className.")
+            .withIcon(PhelIcons.FILE)
+            .withTypeText("(php/new $className ...)", true)
+            .withTailText(" — constructor", true),
+        PhelCompletionPriority.PHP_INTEROP.value
+    )
+
+    private fun staticPrefixLookup(className: String) = PrioritizedLookupElement.withPriority(
+        LookupElementBuilder.create("$className/")
+            .withIcon(PhelIcons.FILE)
+            .withTypeText("(php/:: $className ...)", true)
+            .withTailText(" — static call/member", true),
+        PhelCompletionPriority.PHP_INTEROP.value
+    )
+}

--- a/src/main/kotlin/org/phellang/inspection/deprecated/PhelBackslashNamespaceInspection.kt
+++ b/src/main/kotlin/org/phellang/inspection/deprecated/PhelBackslashNamespaceInspection.kt
@@ -17,10 +17,14 @@ import org.phellang.language.psi.PhelSymbol
 import org.phellang.language.psi.PhelVisitor
 
 /**
- * Flags backslash-separated namespaces inside `(ns ...)`, `:require`, and `:use`
- * clauses. Phel 0.35 made dot-separation the canonical form and accepts backslashes
- * only for back-compat (with `PHEL_WARN_DEPRECATIONS=1`). This mirrors that warning
- * inside the IDE so projects can migrate.
+ * Flags backslash-separated namespaces inside `(ns ...)` and `:require` clauses.
+ * Phel 0.35 made dot-separation the canonical form for Phel namespaces and accepts
+ * backslashes only for back-compat (with `PHEL_WARN_DEPRECATIONS=1`). This mirrors
+ * that warning inside the IDE so projects can migrate.
+ *
+ * `:use` is intentionally excluded: it brings PHP classes into scope and PHP FQNs
+ * are always backslash-separated, so `(:use \DateTimeImmutable)` is the correct
+ * Phel form — not a deprecation.
  */
 class PhelBackslashNamespaceInspection : LocalInspectionTool() {
 
@@ -46,10 +50,12 @@ class PhelBackslashNamespaceInspection : LocalInspectionTool() {
         val forms = enclosingList.forms
         if (forms.isEmpty()) return false
 
-        // (:require ns ...) / (:use ns ...) — first form is the keyword.
+        // (:require ns ...) — first form is the keyword.
+        // `:use` is deliberately excluded: it imports PHP classes, whose FQNs must
+        // use backslashes (e.g. `(:use \DateTimeImmutable)`).
         val firstKeyword = forms[0] as? PhelKeyword
             ?: PsiTreeUtil.findChildOfType(forms[0], PhelKeyword::class.java)
-        if (firstKeyword != null && (firstKeyword.text == ":require" || firstKeyword.text == ":use")) {
+        if (firstKeyword?.text == ":require") {
             return true
         }
 

--- a/src/main/kotlin/org/phellang/language/psi/PhelInteropShorthands.kt
+++ b/src/main/kotlin/org/phellang/language/psi/PhelInteropShorthands.kt
@@ -1,0 +1,81 @@
+package org.phellang.language.psi
+
+import org.phellang.language.psi.files.PhelFile
+
+/**
+ * Recogniser for Phel's PHP interop shorthand surface forms. These are the terse
+ * alternatives to `(php/new ...)`, `(php/-> ...)`, `(php/:: ...)` documented at
+ * https://phel-lang.org/documentation/php-interop/.
+ *
+ * | Shorthand                 | Expands to                         |
+ * |---------------------------|------------------------------------|
+ * | `(ClassName. args)`       | `(php/new ClassName args)`         |
+ * | `(new ClassName args)`    | `(php/new ClassName args)`         |
+ * | `(.method obj args)`      | `(php/-> obj (method args))`       |
+ * | `(.-field obj)`           | `(php/-> obj field)`               |
+ * | `(ClassName/method args)` | `(php/:: ClassName (method args))` |
+ * | `ClassName/MEMBER`        | `(php/:: ClassName MEMBER)`        |
+ *
+ * The detector here works purely on a symbol's source text. We treat any qualifier
+ * that (a) is `\`-prefixed, (b) starts with an ASCII uppercase letter, or (c) was
+ * brought into scope via the file's `(:use ...)` clause as a PHP class — Phel
+ * namespaces are conventionally lowercase + dot/backslash separated, so this
+ * heuristic doesn't collide with real namespaces in practice.
+ */
+object PhelInteropShorthands {
+
+    /** `new` is the long-form constructor keyword (sister to `Class.`). */
+    private const val NEW_KEYWORD = "new"
+
+    fun isInteropClassName(text: String): Boolean {
+        if (text.isEmpty()) return false
+        if (text.startsWith("\\")) return true
+        return text[0] in 'A'..'Z'
+    }
+
+    /**
+     * Returns true when [text] is one of the lexical shorthands listed above.
+     * [usedClasses] should be the file's `(:use ...)` short-name set (see
+     * [PhelNamespaceUtils.extractUsedClasses]); pass an empty set to rely on the
+     * uppercase-first / backslash-prefix heuristic alone.
+     */
+    fun isInteropShorthand(text: String, usedClasses: Set<String> = emptySet()): Boolean {
+        if (text.isEmpty()) return false
+
+        // (.-field obj)
+        if (text.length > 2 && text.startsWith(".-")) return true
+
+        // (.method obj args) — `.` and `..` are not shorthands
+        if (text.length > 1 && text[0] == '.' && text[1] != '.' && text[1] != '-') return true
+
+        // (ClassName. args) — trailing dot constructor
+        if (text.length > 1 && text.endsWith(".")) {
+            val prefix = text.dropLast(1)
+            if (isInteropClassName(prefix) || prefix in usedClasses) return true
+        }
+
+        // (new ClassName args)
+        if (text == NEW_KEYWORD) return true
+
+        // ClassName/method or ClassName/CONST
+        if (text.contains("/") && !text.startsWith("/") && !text.endsWith("/")) {
+            val qualifier = text.substringBeforeLast('/')
+            if (isInteropClassName(qualifier)) return true
+            val shortQualifier = qualifier.trimStart('\\').substringAfterLast('\\')
+            if (shortQualifier in usedClasses) return true
+        }
+
+        // \Foo or \Foo\Bar with no `/` — bare PHP class reference (e.g., catch target)
+        if (text.startsWith("\\") && !text.contains("/")) return true
+
+        return false
+    }
+
+    /** Convenience overload that pulls the `(:use ...)` set from the symbol's file. */
+    fun isInteropShorthand(symbol: PhelSymbol): Boolean {
+        val text = symbol.text ?: return false
+        val file = symbol.containingFile as? PhelFile
+        val usedClasses = if (file != null) PhelNamespaceUtils.extractUsedClasses(file) else emptySet()
+        return isInteropShorthand(text, usedClasses)
+    }
+}

--- a/src/main/kotlin/org/phellang/language/psi/PhelNamespaceUtils.kt
+++ b/src/main/kotlin/org/phellang/language/psi/PhelNamespaceUtils.kt
@@ -30,6 +30,20 @@ object PhelNamespaceUtils {
     }
 
     fun findRequireForms(nsDeclaration: PhelList): List<PhelList> {
+        return findNsClauseForms(nsDeclaration, ":require")
+    }
+
+    /**
+     * Finds `(:use ...)` clauses inside an `(ns ...)` declaration. Phel's `:use`
+     * brings PHP classes (not Phel namespaces) into scope so they can be referenced
+     * without the leading `\`, e.g. `(:use \DateTime \Exception)` enables
+     * `DateTime/createFromFormat`, `(DateTime. ...)`, etc.
+     */
+    fun findUseForms(nsDeclaration: PhelList): List<PhelList> {
+        return findNsClauseForms(nsDeclaration, ":use")
+    }
+
+    private fun findNsClauseForms(nsDeclaration: PhelList, clauseKeyword: String): List<PhelList> {
         return PsiTreeUtil.findChildrenOfType(nsDeclaration, PhelList::class.java).filter { list ->
             val forms = list.forms
             if (forms.isEmpty()) return@filter false
@@ -37,8 +51,41 @@ object PhelNamespaceUtils {
             val firstForm = forms[0]
             val firstKeyword = firstForm as? PhelKeyword
                 ?: PsiTreeUtil.findChildOfType(firstForm, PhelKeyword::class.java)
-            firstKeyword?.text == ":require"
+            firstKeyword?.text == clauseKeyword
         }
+    }
+
+    /**
+     * Extracts PHP class short names declared via `(:use ...)` in the file's `ns` form.
+     *
+     * Both `\Foo\Bar` and `Foo\Bar` produce the short name `Bar`. The short name is
+     * what users actually type in interop shorthands such as `(Bar. arg)`,
+     * `(.method bar)`, or `Bar/static-fn`.
+     */
+    fun extractUsedClasses(file: PhelFile): Set<String> {
+        val nsDeclaration = findNamespaceDeclaration(file) ?: return emptySet()
+        val useForms = findUseForms(nsDeclaration)
+        if (useForms.isEmpty()) return emptySet()
+
+        val classes = mutableSetOf<String>()
+        for (useForm in useForms) {
+            val forms = useForm.forms
+            for (i in 1 until forms.size) {
+                val form = forms[i]
+                val symbol = form as? PhelSymbol ?: PsiTreeUtil.findChildOfType(form, PhelSymbol::class.java)
+                val text = symbol?.text ?: continue
+                val shortName = extractShortClassName(text) ?: continue
+                classes.add(shortName)
+            }
+        }
+        return classes
+    }
+
+    private fun extractShortClassName(text: String): String? {
+        val trimmed = text.trimStart('\\')
+        if (trimmed.isEmpty()) return null
+        val short = trimmed.substringAfterLast('\\')
+        return short.ifEmpty { null }
     }
 
     fun extractAliasMap(file: PhelFile): Map<String, String> {

--- a/src/main/kotlin/org/phellang/language/psi/references/PhelReference.kt
+++ b/src/main/kotlin/org/phellang/language/psi/references/PhelReference.kt
@@ -132,6 +132,21 @@ class PhelReference @JvmOverloads constructor(
                 results.add(PsiElementResolveResult(def))
             }
         }
+
+        // 5. PHP interop fall-through. Only runs when nothing Phel-side resolved AND the
+        //    text looks like an interop shorthand — keeps the cost off the hot path for
+        //    ordinary Phel symbols and is a no-op when the PHP plugin isn't installed.
+        if (results.isEmpty()) {
+            addPhpClassResults(results)
+        }
+    }
+
+    private fun addPhpClassResults(results: MutableList<ResolveResult>) {
+        val element = myElement ?: return
+        val phpTargets = PhpClassResolver.resolveAsPhpClass(element)
+        for (target in phpTargets) {
+            results.add(PsiElementResolveResult(target))
+        }
     }
 
     /**
@@ -146,6 +161,14 @@ class PhelReference @JvmOverloads constructor(
         val results: MutableList<PsiElement> = ArrayList()
         val containingFile = myElement!!.containingFile as? PhelFile ?: return results
         val project = myElement!!.project
+
+        // PHP interop static call (`ClassName/method`, `\Foo\Bar/CONST`, …) —
+        // resolve to the PHP class, when the PHP plugin is available.
+        val phpTargets = PhpClassResolver.resolveAsPhpClass(myElement!!)
+        if (phpTargets.isNotEmpty()) {
+            results.addAll(phpTargets)
+            return results
+        }
 
         // First, try to resolve the qualifier via imports (handles aliases)
         val targetNamespace = resolveQualifierToNamespace(containingFile, qualifier)

--- a/src/main/kotlin/org/phellang/language/psi/references/PhelReference.kt
+++ b/src/main/kotlin/org/phellang/language/psi/references/PhelReference.kt
@@ -143,10 +143,15 @@ class PhelReference @JvmOverloads constructor(
 
     private fun addPhpClassResults(results: MutableList<ResolveResult>) {
         val element = myElement ?: return
-        val phpTargets = PhpClassResolver.resolveAsPhpClass(element)
-        for (target in phpTargets) {
-            results.add(PsiElementResolveResult(target))
+        // Prefer specific members (e.g. `Class.` -> __construct method) so go-to-def
+        // lands on the precise PHP node; fall back to the class otherwise.
+        val memberTargets = PhpClassResolver.resolveAsPhpMember(element)
+        if (memberTargets.isNotEmpty()) {
+            for (target in memberTargets) results.add(PsiElementResolveResult(target))
+            return
         }
+        val phpTargets = PhpClassResolver.resolveAsPhpClass(element)
+        for (target in phpTargets) results.add(PsiElementResolveResult(target))
     }
 
     /**
@@ -162,8 +167,15 @@ class PhelReference @JvmOverloads constructor(
         val containingFile = myElement!!.containingFile as? PhelFile ?: return results
         val project = myElement!!.project
 
-        // PHP interop static call (`ClassName/method`, `\Foo\Bar/CONST`, …) —
-        // resolve to the PHP class, when the PHP plugin is available.
+        // PHP interop static call (`ClassName/method`, `\Foo\Bar/CONST`, …).
+        // Try the specific member (method/constant) first so go-to-def lands on
+        // the precise PHP node; fall back to the class if the member lookup
+        // misses (or when the PHP plugin isn't available).
+        val memberTargets = PhpClassResolver.resolveAsPhpMember(myElement!!)
+        if (memberTargets.isNotEmpty()) {
+            results.addAll(memberTargets)
+            return results
+        }
         val phpTargets = PhpClassResolver.resolveAsPhpClass(myElement!!)
         if (phpTargets.isNotEmpty()) {
             results.addAll(phpTargets)

--- a/src/main/kotlin/org/phellang/language/psi/references/PhpClassResolver.kt
+++ b/src/main/kotlin/org/phellang/language/psi/references/PhpClassResolver.kt
@@ -3,6 +3,7 @@ package org.phellang.language.psi.references
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
 import org.phellang.language.psi.PhelInteropShorthands
 import org.phellang.language.psi.PhelNamespaceUtils
 import org.phellang.language.psi.PhelSymbol
@@ -11,7 +12,8 @@ import org.phellang.language.psi.files.PhelFile
 /**
  * Reflection-based bridge to the JetBrains PHP plugin (PhpStorm / Ultimate with
  * the PHP plugin installed). Resolves a Phel interop symbol to its underlying
- * PHP class so go-to-definition jumps straight into the class source.
+ * PHP class — or, where applicable, a specific class member — so go-to-definition
+ * jumps straight into the PHP source.
  *
  * The PHP plugin is **not** a compile-time dependency — we never want to break
  * Phel support in IDEA Community / WebStorm / Rider just because PHP isn't on
@@ -25,52 +27,99 @@ object PhpClassResolver {
     private val LOG = Logger.getInstance(PhpClassResolver::class.java)
 
     /**
-     * Memoised reflective handle to `PhpIndex`. `NotLoaded` means we tried and
-     * couldn't find the class (PHP plugin missing); `null` means we haven't
-     * tried yet.
+     * Member kinds we surface from a PHP class. We deliberately exclude private/
+     * protected members from completion and resolution since Phel can only call
+     * what's public from outside the class.
      */
+    enum class MemberKind { METHOD, CONSTANT, FIELD }
+
+    data class PhpMemberInfo(
+        val name: String,
+        val kind: MemberKind,
+        val isStatic: Boolean,
+        val signature: String,
+        val element: PsiElement,
+    )
+
     @Volatile
     private var phpIndexClass: Class<*>? = null
 
     @Volatile
     private var checkedForPhpPlugin: Boolean = false
 
+    // ──────────────────────────────────────────────────────────────────────────
+    // Class-level resolution (existing API; unchanged surface)
+    // ──────────────────────────────────────────────────────────────────────────
+
     fun resolveAsPhpClass(symbol: PhelSymbol): List<PsiElement> {
         if (!checkedForPhpPlugin) loadPhpIndexClass()
-        val phpIndex = phpIndexClass ?: return emptyList()
+        if (phpIndexClass == null) return emptyList()
+        val fqn = computeTargetFqn(symbol) ?: return emptyList()
+        return findClassesByFqn(symbol.project, fqn).mapNotNull { it as? PsiElement }
+    }
+
+    /**
+     * Resolves to a specific member (`Foo/method`, `Foo/CONST`, `\Foo\Bar/m`) or to
+     * the constructor when the symbol is the `(Class. ...)` head. Falls back to an
+     * empty list when the PHP plugin isn't available or the member can't be found —
+     * callers should then call [resolveAsPhpClass] for the class-level fallback.
+     */
+    fun resolveAsPhpMember(symbol: PhelSymbol): List<PsiElement> {
+        if (!checkedForPhpPlugin) loadPhpIndexClass()
+        if (phpIndexClass == null) return emptyList()
 
         val text = symbol.text ?: return emptyList()
-        val fqn = resolveTargetFqn(symbol, text) ?: return emptyList()
+        val classFqn = computeTargetFqn(symbol) ?: return emptyList()
+        val memberName = extractMemberName(text) ?: return emptyList()
+        val classes = findClassesByFqn(symbol.project, classFqn)
+        if (classes.isEmpty()) return emptyList()
 
-        return try {
-            val instanceMethod = phpIndex.getMethod("getInstance", Project::class.java)
-            val instance = instanceMethod.invoke(null, symbol.project)
-
-            val getByFqn = phpIndex.getMethod("getClassesByFQN", String::class.java)
-            @Suppress("UNCHECKED_CAST")
-            val classes = getByFqn.invoke(instance, fqn) as? Collection<Any> ?: return emptyList()
-            classes.mapNotNull { it as? PsiElement }
-        } catch (t: Throwable) {
-            LOG.debug("PHP class resolution failed for '$fqn'", t)
-            emptyList()
+        return classes.flatMap { phpClass ->
+            findMemberInClass(phpClass, memberName)
         }
     }
 
     /**
-     * Computes the PHP FQN we want to look up for [text] in [symbol]'s file.
+     * Enumerates the public, *statically reachable* members of [classFqn] for use
+     * in completion. Inherited members are included. Returns an empty list when
+     * the PHP plugin isn't available.
+     */
+    fun listMembers(project: Project, classFqn: String): List<PhpMemberInfo> {
+        if (!checkedForPhpPlugin) loadPhpIndexClass()
+        if (phpIndexClass == null) return emptyList()
+
+        val classes = findClassesByFqn(project, classFqn)
+        if (classes.isEmpty()) return emptyList()
+
+        val seen = mutableSetOf<String>()
+        val result = mutableListOf<PhpMemberInfo>()
+        for (phpClass in classes) {
+            for (info in collectMembers(phpClass)) {
+                val key = "${info.kind}:${info.name}"
+                if (seen.add(key)) result.add(info)
+            }
+        }
+        return result
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // FQN derivation (shared)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Computes the PHP FQN we want to look up for [symbol]'s text.
      *
      * * `\Foo\Bar`     -> `\Foo\Bar`
-     * * `Foo` (in :use)-> the `:use` clause's full FQN (e.g. `\Foo\Bar`)
+     * * `Foo` (in :use)-> the `:use` clause's full FQN
      * * `Foo.`         -> same as `Foo`
-     * * `Foo/method`   -> same as `Foo`
+     * * `Foo/method`   -> same as `Foo` (class part of static member access)
      * * any other      -> null (let Phel-only resolution stay authoritative)
      */
-    private fun resolveTargetFqn(symbol: PhelSymbol, text: String): String? {
+    private fun computeTargetFqn(symbol: PhelSymbol): String? {
+        val text = symbol.text ?: return null
         val file = symbol.containingFile as? PhelFile ?: return null
 
-        if (text.startsWith("\\") && !text.contains("/")) {
-            return text
-        }
+        if (text.startsWith("\\") && !text.contains("/")) return text
 
         if (!PhelInteropShorthands.isInteropShorthand(text, PhelNamespaceUtils.extractUsedClasses(file))) {
             return null
@@ -85,13 +134,22 @@ object PhpClassResolver {
 
         if (rawQualifier.startsWith("\\")) return rawQualifier
 
-        // Bare short name like `DateTime`. Try to find the matching `:use` FQN
-        // (e.g. `(:use \DateTime)` -> `\DateTime`, `(:use \Foo\Bar)` -> `\Foo\Bar`).
         val useFqn = findUseFqn(file, rawQualifier)
         if (useFqn != null) return useFqn
 
-        // Fallback: ask PhpIndex for the bare name at the global namespace.
         return "\\$rawQualifier"
+    }
+
+    /**
+     * For `Foo/method` returns `method`; for `Foo.` returns `__construct` (the
+     * canonical PHP constructor name). Returns null when the text doesn't address
+     * a specific member.
+     */
+    private fun extractMemberName(text: String): String? {
+        if (text.endsWith(".") && text.length > 1) return CONSTRUCTOR_NAME
+        if (!text.contains("/")) return null
+        val tail = text.substringAfterLast('/')
+        return tail.ifEmpty { null }
     }
 
     private fun findUseFqn(file: PhelFile, shortName: String): String? {
@@ -101,8 +159,7 @@ object PhpClassResolver {
             val forms = useForm.forms
             for (i in 1 until forms.size) {
                 val form = forms[i]
-                val sym = form as? PhelSymbol
-                    ?: com.intellij.psi.util.PsiTreeUtil.findChildOfType(form, PhelSymbol::class.java)
+                val sym = form as? PhelSymbol ?: PsiTreeUtil.findChildOfType(form, PhelSymbol::class.java)
                 val raw = sym?.text ?: continue
                 val candidateShort = raw.trimStart('\\').substringAfterLast('\\')
                 if (candidateShort == shortName) {
@@ -111,6 +168,134 @@ object PhpClassResolver {
             }
         }
         return null
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // PhpIndex reflection
+    // ──────────────────────────────────────────────────────────────────────────
+
+    private fun findClassesByFqn(project: Project, fqn: String): List<Any> {
+        val phpIndex = phpIndexClass ?: return emptyList()
+        return try {
+            val instance = phpIndex.getMethod("getInstance", Project::class.java).invoke(null, project)
+            val getByFqn = phpIndex.getMethod("getClassesByFQN", String::class.java)
+            @Suppress("UNCHECKED_CAST")
+            val classes = getByFqn.invoke(instance, fqn) as? Collection<Any> ?: return emptyList()
+            classes.toList()
+        } catch (t: Throwable) {
+            LOG.debug("PHP class lookup failed for '$fqn'", t)
+            emptyList()
+        }
+    }
+
+    private fun findMemberInClass(phpClass: Any, memberName: String): List<PsiElement> {
+        val cls = phpClass::class.java
+        val results = mutableListOf<PsiElement>()
+
+        // Methods (including the constructor when memberName == "__construct").
+        tryInvokeCollection(cls, phpClass, "getMethods")?.let { methods ->
+            for (method in methods) {
+                if (readStringProperty(method, "getName") == memberName) {
+                    (method as? PsiElement)?.let { results.add(it) }
+                }
+            }
+        }
+
+        // Fields (which in the PHP plugin model also covers constants).
+        tryInvokeCollection(cls, phpClass, "getFields")?.let { fields ->
+            for (field in fields) {
+                if (readStringProperty(field, "getName") == memberName) {
+                    (field as? PsiElement)?.let { results.add(it) }
+                }
+            }
+        }
+
+        return results
+    }
+
+    private fun collectMembers(phpClass: Any): List<PhpMemberInfo> {
+        val cls = phpClass::class.java
+        val out = mutableListOf<PhpMemberInfo>()
+
+        tryInvokeCollection(cls, phpClass, "getMethods")?.forEach { method ->
+            val name = readStringProperty(method, "getName") ?: return@forEach
+            if (name == CONSTRUCTOR_NAME) return@forEach // surfaced via `Class.` shorthand, not `Class/`
+            if (!isAccessible(method)) return@forEach
+            val element = method as? PsiElement ?: return@forEach
+            val isStatic = readBoolProperty(method, "isStatic") ?: false
+            val signature = methodSignature(method, name)
+            out.add(PhpMemberInfo(name, MemberKind.METHOD, isStatic, signature, element))
+        }
+
+        tryInvokeCollection(cls, phpClass, "getFields")?.forEach { field ->
+            val name = readStringProperty(field, "getName") ?: return@forEach
+            if (!isAccessible(field)) return@forEach
+            val element = field as? PsiElement ?: return@forEach
+            val isConstant = readBoolProperty(field, "isConstant") ?: false
+            val isStatic = readBoolProperty(field, "isStatic") ?: isConstant
+            val kind = if (isConstant) MemberKind.CONSTANT else MemberKind.FIELD
+            out.add(PhpMemberInfo(name, kind, isStatic, name, element))
+        }
+
+        return out
+    }
+
+    private fun methodSignature(method: Any?, name: String): String {
+        if (method == null) return "$name(...)"
+        return try {
+            val getParameters = method.javaClass.getMethod("getParameters")
+            val params = getParameters.invoke(method) as? Array<*> ?: return "$name(...)"
+            val rendered = params.joinToString(", ") { p ->
+                readStringProperty(p, "getName")?.let { "$$it" } ?: "?"
+            }
+            "$name($rendered)"
+        } catch (_: Throwable) {
+            "$name(...)"
+        }
+    }
+
+    private fun isAccessible(member: Any?): Boolean {
+        if (member == null) return false
+        // Access object lives on Method/Field via `getModifier().getAccess()`.
+        // Anything that isn't explicitly private/protected is considered callable
+        // from Phel.
+        return try {
+            val getModifier = member.javaClass.getMethod("getModifier")
+            val modifier = getModifier.invoke(member) ?: return true
+            val getAccess = modifier.javaClass.getMethod("getAccess")
+            val access = getAccess.invoke(modifier) ?: return true
+            val name = (access.javaClass.getMethod("name").invoke(access) as? String)?.uppercase()
+            name == null || name == "PUBLIC"
+        } catch (_: Throwable) {
+            true
+        }
+    }
+
+    private fun tryInvokeCollection(cls: Class<*>, target: Any, name: String): Collection<*>? {
+        return try {
+            val m = cls.methods.firstOrNull { it.name == name && it.parameterCount == 0 } ?: return null
+            m.invoke(target) as? Collection<*>
+        } catch (_: Throwable) {
+            null
+        }
+    }
+
+    private fun readStringProperty(target: Any?, methodName: String): String? {
+        if (target == null) return null
+        return try {
+            target.javaClass.getMethod(methodName).invoke(target) as? String
+        } catch (_: Throwable) {
+            null
+        }
+    }
+
+    private fun readBoolProperty(target: Any?, methodName: String): Boolean? {
+        if (target == null) return null
+        return try {
+            target.javaClass.getMethod(methodName).invoke(target) as? Boolean
+        } catch (_: Throwable) {
+            null
+        }
     }
 
     private fun loadPhpIndexClass() {
@@ -127,4 +312,6 @@ object PhpClassResolver {
             }
         }
     }
+
+    private const val CONSTRUCTOR_NAME = "__construct"
 }

--- a/src/main/kotlin/org/phellang/language/psi/references/PhpClassResolver.kt
+++ b/src/main/kotlin/org/phellang/language/psi/references/PhpClassResolver.kt
@@ -1,0 +1,130 @@
+package org.phellang.language.psi.references
+
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import org.phellang.language.psi.PhelInteropShorthands
+import org.phellang.language.psi.PhelNamespaceUtils
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.files.PhelFile
+
+/**
+ * Reflection-based bridge to the JetBrains PHP plugin (PhpStorm / Ultimate with
+ * the PHP plugin installed). Resolves a Phel interop symbol to its underlying
+ * PHP class so go-to-definition jumps straight into the class source.
+ *
+ * The PHP plugin is **not** a compile-time dependency — we never want to break
+ * Phel support in IDEA Community / WebStorm / Rider just because PHP isn't on
+ * the classpath. Instead we load `com.jetbrains.php.PhpIndex` reflectively on
+ * first use; if absent (or anything else goes wrong) we return an empty list,
+ * which is the same as "no PHP target found" and lets the existing Phel-only
+ * resolution remain authoritative.
+ */
+object PhpClassResolver {
+
+    private val LOG = Logger.getInstance(PhpClassResolver::class.java)
+
+    /**
+     * Memoised reflective handle to `PhpIndex`. `NotLoaded` means we tried and
+     * couldn't find the class (PHP plugin missing); `null` means we haven't
+     * tried yet.
+     */
+    @Volatile
+    private var phpIndexClass: Class<*>? = null
+
+    @Volatile
+    private var checkedForPhpPlugin: Boolean = false
+
+    fun resolveAsPhpClass(symbol: PhelSymbol): List<PsiElement> {
+        if (!checkedForPhpPlugin) loadPhpIndexClass()
+        val phpIndex = phpIndexClass ?: return emptyList()
+
+        val text = symbol.text ?: return emptyList()
+        val fqn = resolveTargetFqn(symbol, text) ?: return emptyList()
+
+        return try {
+            val instanceMethod = phpIndex.getMethod("getInstance", Project::class.java)
+            val instance = instanceMethod.invoke(null, symbol.project)
+
+            val getByFqn = phpIndex.getMethod("getClassesByFQN", String::class.java)
+            @Suppress("UNCHECKED_CAST")
+            val classes = getByFqn.invoke(instance, fqn) as? Collection<Any> ?: return emptyList()
+            classes.mapNotNull { it as? PsiElement }
+        } catch (t: Throwable) {
+            LOG.debug("PHP class resolution failed for '$fqn'", t)
+            emptyList()
+        }
+    }
+
+    /**
+     * Computes the PHP FQN we want to look up for [text] in [symbol]'s file.
+     *
+     * * `\Foo\Bar`     -> `\Foo\Bar`
+     * * `Foo` (in :use)-> the `:use` clause's full FQN (e.g. `\Foo\Bar`)
+     * * `Foo.`         -> same as `Foo`
+     * * `Foo/method`   -> same as `Foo`
+     * * any other      -> null (let Phel-only resolution stay authoritative)
+     */
+    private fun resolveTargetFqn(symbol: PhelSymbol, text: String): String? {
+        val file = symbol.containingFile as? PhelFile ?: return null
+
+        if (text.startsWith("\\") && !text.contains("/")) {
+            return text
+        }
+
+        if (!PhelInteropShorthands.isInteropShorthand(text, PhelNamespaceUtils.extractUsedClasses(file))) {
+            return null
+        }
+
+        val rawQualifier = when {
+            text.endsWith(".") -> text.dropLast(1)
+            text.contains("/") -> text.substringBeforeLast('/')
+            else -> text
+        }
+        if (rawQualifier.isEmpty()) return null
+
+        if (rawQualifier.startsWith("\\")) return rawQualifier
+
+        // Bare short name like `DateTime`. Try to find the matching `:use` FQN
+        // (e.g. `(:use \DateTime)` -> `\DateTime`, `(:use \Foo\Bar)` -> `\Foo\Bar`).
+        val useFqn = findUseFqn(file, rawQualifier)
+        if (useFqn != null) return useFqn
+
+        // Fallback: ask PhpIndex for the bare name at the global namespace.
+        return "\\$rawQualifier"
+    }
+
+    private fun findUseFqn(file: PhelFile, shortName: String): String? {
+        val nsDeclaration = PhelNamespaceUtils.findNamespaceDeclaration(file) ?: return null
+        val useForms = PhelNamespaceUtils.findUseForms(nsDeclaration)
+        for (useForm in useForms) {
+            val forms = useForm.forms
+            for (i in 1 until forms.size) {
+                val form = forms[i]
+                val sym = form as? PhelSymbol
+                    ?: com.intellij.psi.util.PsiTreeUtil.findChildOfType(form, PhelSymbol::class.java)
+                val raw = sym?.text ?: continue
+                val candidateShort = raw.trimStart('\\').substringAfterLast('\\')
+                if (candidateShort == shortName) {
+                    return if (raw.startsWith("\\")) raw else "\\$raw"
+                }
+            }
+        }
+        return null
+    }
+
+    private fun loadPhpIndexClass() {
+        synchronized(this) {
+            if (checkedForPhpPlugin) return
+            checkedForPhpPlugin = true
+            phpIndexClass = try {
+                Class.forName("com.jetbrains.php.PhpIndex", false, javaClass.classLoader)
+            } catch (_: ClassNotFoundException) {
+                null
+            } catch (t: Throwable) {
+                LOG.debug("Unexpected error loading PhpIndex", t)
+                null
+            }
+        }
+    }
+}

--- a/src/test/kotlin/org/phellang/unit/language/psi/PhelInteropShorthandsTest.kt
+++ b/src/test/kotlin/org/phellang/unit/language/psi/PhelInteropShorthandsTest.kt
@@ -1,0 +1,134 @@
+package org.phellang.unit.language.psi
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.phellang.language.psi.PhelInteropShorthands
+
+class PhelInteropShorthandsTest {
+
+    @Nested
+    inner class InteropClassName {
+
+        @Test
+        fun `backslash-prefixed names are classified as PHP classes`() {
+            assertTrue(PhelInteropShorthands.isInteropClassName("\\DateTime"))
+            assertTrue(PhelInteropShorthands.isInteropClassName("\\Foo\\Bar"))
+        }
+
+        @Test
+        fun `uppercase-starting names are classified as PHP classes`() {
+            assertTrue(PhelInteropShorthands.isInteropClassName("DateTime"))
+            assertTrue(PhelInteropShorthands.isInteropClassName("Exception"))
+        }
+
+        @Test
+        fun `lowercase names are not classified as PHP classes`() {
+            assertFalse(PhelInteropShorthands.isInteropClassName("phel"))
+            assertFalse(PhelInteropShorthands.isInteropClassName("phel.string"))
+            assertFalse(PhelInteropShorthands.isInteropClassName("my-app"))
+            assertFalse(PhelInteropShorthands.isInteropClassName(""))
+        }
+    }
+
+    @Nested
+    inner class ConstructorShorthand {
+
+        @Test
+        fun `ClassName-dot is recognised`() {
+            assertTrue(PhelInteropShorthands.isInteropShorthand("DateTimeImmutable."))
+            assertTrue(PhelInteropShorthands.isInteropShorthand("Exception."))
+        }
+
+        @Test
+        fun `lowercase-dot is not recognised unless in used-classes`() {
+            assertFalse(PhelInteropShorthands.isInteropShorthand("foo."))
+            assertTrue(PhelInteropShorthands.isInteropShorthand("foo.", setOf("foo")))
+        }
+
+        @Test
+        fun `bare dot and ellipsis are not constructors`() {
+            assertFalse(PhelInteropShorthands.isInteropShorthand("."))
+            assertFalse(PhelInteropShorthands.isInteropShorthand(".."))
+        }
+    }
+
+    @Nested
+    inner class MethodAndFieldShorthand {
+
+        @Test
+        fun `dot-method is recognised`() {
+            assertTrue(PhelInteropShorthands.isInteropShorthand(".format"))
+            assertTrue(PhelInteropShorthands.isInteropShorthand(".getMessage"))
+        }
+
+        @Test
+        fun `dot-dash field is recognised`() {
+            assertTrue(PhelInteropShorthands.isInteropShorthand(".-s"))
+            assertTrue(PhelInteropShorthands.isInteropShorthand(".-property"))
+        }
+
+        @Test
+        fun `bare dot-dash is not a field access`() {
+            assertFalse(PhelInteropShorthands.isInteropShorthand(".-"))
+        }
+    }
+
+    @Nested
+    inner class StaticCallShorthand {
+
+        @Test
+        fun `uppercase-qualified static call is recognised`() {
+            assertTrue(PhelInteropShorthands.isInteropShorthand("DateTime/createFromFormat"))
+            assertTrue(PhelInteropShorthands.isInteropShorthand("DateTimeImmutable/ATOM"))
+        }
+
+        @Test
+        fun `backslash-qualified static call is recognised`() {
+            assertTrue(PhelInteropShorthands.isInteropShorthand("\\Foo\\Bar/baz"))
+        }
+
+        @Test
+        fun `lowercase qualifier matches when in used-classes`() {
+            assertTrue(PhelInteropShorthands.isInteropShorthand("date/today", setOf("date")))
+        }
+
+        @Test
+        fun `lowercase qualifier outside used-classes is not interop`() {
+            assertFalse(PhelInteropShorthands.isInteropShorthand("phel.string/trim"))
+            assertFalse(PhelInteropShorthands.isInteropShorthand("str/join"))
+        }
+    }
+
+    @Nested
+    inner class BareReferences {
+
+        @Test
+        fun `bare new keyword is interop`() {
+            assertTrue(PhelInteropShorthands.isInteropShorthand("new"))
+        }
+
+        @Test
+        fun `backslash-prefixed class reference is interop`() {
+            assertTrue(PhelInteropShorthands.isInteropShorthand("\\DateTime"))
+            assertTrue(PhelInteropShorthands.isInteropShorthand("\\DivisionByZeroError"))
+        }
+
+        @Test
+        fun `regular Phel symbols are not interop`() {
+            assertFalse(PhelInteropShorthands.isInteropShorthand("map"))
+            assertFalse(PhelInteropShorthands.isInteropShorthand("my-function"))
+            assertFalse(PhelInteropShorthands.isInteropShorthand("test?"))
+            assertFalse(PhelInteropShorthands.isInteropShorthand("&"))
+        }
+
+        @Test
+        fun `php-qualified names are not classified here`() {
+            // `php/new`, `php/->`, etc. are handled separately in the highlighter.
+            // The shorthand detector deliberately ignores them — they're not shorthand forms.
+            assertFalse(PhelInteropShorthands.isInteropShorthand("php/new"))
+            assertFalse(PhelInteropShorthands.isInteropShorthand("php/->"))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Teach the plugin about Phel's PHP interop shorthand surface forms and the `(:use ...)` clause, so symbols like `DateTime.`, `.method`, `.-field`, `Foo/bar`, `\Foo\Bar`, and bare `:use`-imported class names are no longer treated as unresolved Phel references.

See: https://phel-lang.org/documentation/php-interop/

## What's new

- **`PhelInteropShorthands`** — single source of truth that classifies a symbol's text as one of:
  - `(ClassName. args)` — constructor shorthand
  - `(new ClassName args)` — long-form constructor
  - `(.method obj args)` / `(.-field obj)` — instance call / field access
  - `(ClassName/method args)` / `ClassName/MEMBER` — static call/const
  - `\Foo\Bar` — bare FQN (e.g., catch targets)
  Heuristic: backslash-prefixed, ASCII-uppercase first letter, or a short name brought into scope via `(:use ...)`.

- **`(:use ...)` awareness in `PhelNamespaceUtils`** — extracts the set of short class names imported in the file's `ns` declaration and exposes it to annotators, validators, and completion.

- **PhpStorm interop (`PhpClassResolver`)** — when the JetBrains PHP plugin is on the classpath, `PhelReference` resolves interop symbols to the underlying PHP class via reflection on `com.jetbrains.php.PhpIndex`, so go-to-definition jumps into the PHP source. Falls back gracefully (no errors, no behavior change) on IDEA Community / WebStorm / Rider.

- **Highlighting + validators** —
  - `PhelSymbolPositionAnalyzer` / `PhelSymbolHighlighter`: interop forms get the appropriate color instead of being styled as unknown symbols.
  - `PhelFunctionReferenceValidator`, `PhelNamespaceValidator`, `PhelBackslashNamespaceInspection`: skip warnings for shapes that are valid PHP interop, not malformed Phel.

- **Completion** — `PhelUsedClassCompletionHelper` adds three lookups per `:use`-imported class:
  - `Foo` — bare reference
  - `Foo.` — constructor (`(php/new Foo ...)`)
  - `Foo/` — static call/member prefix
  Wired into `PhelMainCompletionProvider`. `registerPhpInteropFunctions` also extended.
