### PR TITLE
Perf/highlighting hotpaths

### DIFF
--- a/src/main/kotlin/org/phellang/annotator/PhelAnnotator.kt
+++ b/src/main/kotlin/org/phellang/annotator/PhelAnnotator.kt
@@ -20,29 +20,28 @@ class PhelAnnotator : Annotator {
             return  // Don't apply other highlighting to commented-out forms
         }
 
-        // Skip highlighting if element is inside an anonymous function literal
-        if (PhelCommentAnalyzer.isInsideAnonFunction(element)) {
-            return
-        }
-
+        // The anonymous-function check (an ancestor walk) only matters for the element types
+        // handled below, so it runs inside the dispatch rather than for every PSI element
+        // (whitespace, punctuation, literals, lists, …), which are the majority.
         when (element) {
             is PhelKeyword -> {
+                if (PhelCommentAnalyzer.isInsideAnonFunction(element)) return
                 PhelElementHighlighter.annotateKeyword(element, holder)
             }
 
             is PhelSymbol -> {
-                val text = element.text
-                if (text != null) {
-                    // First check if this is a namespace in a (:require ...) form
-                    if (PhelRequireHighlighter.annotateRequireNamespace(element, holder)) {
-                        return  // Handled as require namespace
-                    }
-                    // Otherwise, apply regular symbol highlighting
-                    PhelSymbolHighlighter.annotateSymbol(element, text, holder)
+                if (PhelCommentAnalyzer.isInsideAnonFunction(element)) return
+                val text = element.text ?: return
+                // First check if this is a namespace in a (:require ...) form
+                if (PhelRequireHighlighter.annotateRequireNamespace(element, holder)) {
+                    return  // Handled as require namespace
                 }
+                // Otherwise, apply regular symbol highlighting
+                PhelSymbolHighlighter.annotateSymbol(element, text, holder)
             }
 
             is PhelHashFn -> {
+                if (PhelCommentAnalyzer.isInsideAnonFunction(element)) return
                 PhelElementHighlighter.annotateAnonymousFunction(element, holder)
             }
         }

--- a/src/main/kotlin/org/phellang/annotator/analyzers/PhelCommentAnalyzer.kt
+++ b/src/main/kotlin/org/phellang/annotator/analyzers/PhelCommentAnalyzer.kt
@@ -1,6 +1,12 @@
 package org.phellang.annotator.analyzers
 
+import com.intellij.openapi.util.Key
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.CachedValue
+import com.intellij.psi.util.CachedValueProvider
+import com.intellij.psi.util.CachedValuesManager
+import com.intellij.psi.util.PsiModificationTracker
 import org.phellang.language.psi.*
 import java.util.regex.Pattern.compile
 
@@ -10,10 +16,26 @@ object PhelCommentAnalyzer {
 
     private const val FORM_COMMENT_MARKER = "#_"
 
+    private val HAS_FORM_COMMENT_KEY: Key<CachedValue<Boolean>> = Key.create("phel.hasFormComment")
+
     fun isCommentedOutByFormComment(element: PsiElement): Boolean {
+        // Fast path: a file with no `#_` marker anywhere can't comment out any form, so skip
+        // the containing-form walk and text tokenization that otherwise run for every element.
+        val file = element.containingFile ?: return false
+        if (!fileHasFormComment(file)) return false
+
         val containingForm = findContainingForm(element) ?: return false
 
         return isInCommentedFormByText(containingForm)
+    }
+
+    private fun fileHasFormComment(file: PsiFile): Boolean {
+        return CachedValuesManager.getCachedValue(file, HAS_FORM_COMMENT_KEY) {
+            CachedValueProvider.Result.create(
+                file.text.contains(FORM_COMMENT_MARKER),
+                PsiModificationTracker.MODIFICATION_COUNT,
+            )
+        }
     }
 
     fun isInsideAnonFunction(element: PsiElement): Boolean {

--- a/src/main/kotlin/org/phellang/annotator/highlighters/PhelSymbolHighlighter.kt
+++ b/src/main/kotlin/org/phellang/annotator/highlighters/PhelSymbolHighlighter.kt
@@ -38,10 +38,7 @@ object PhelSymbolHighlighter {
         // Function parameters and let bindings shadow same-named core fns. Classify
         // them first so the deprecated check below does not paint local bindings
         // with strikethrough.
-        if (PhelSymbolAnalyzer.isParameterReference(symbol)
-            || PhelSymbolAnalyzer.isFunctionParameter(symbol)
-            || PhelSymbolAnalyzer.isLetBinding(symbol)
-        ) {
+        if (PhelSymbolAnalyzer.isLocalBindingOrReference(symbol)) {
             PhelAnnotationUtils.createAnnotation(holder, symbol, FUNCTION_PARAMETER)
             return
         }

--- a/src/main/kotlin/org/phellang/annotator/validators/PhelImportValidator.kt
+++ b/src/main/kotlin/org/phellang/annotator/validators/PhelImportValidator.kt
@@ -1,5 +1,10 @@
 package org.phellang.annotator.validators
 
+import com.intellij.openapi.util.Key
+import com.intellij.psi.util.CachedValue
+import com.intellij.psi.util.CachedValueProvider
+import com.intellij.psi.util.CachedValuesManager
+import com.intellij.psi.util.PsiModificationTracker
 import com.intellij.psi.util.PsiTreeUtil
 import org.phellang.language.psi.PhelKeyword
 import org.phellang.language.psi.PhelList
@@ -19,6 +24,9 @@ data class ImportValidationResult(
  * Validates (:require ...) statements to ensure imported namespaces exist.
  */
 object PhelImportValidator {
+
+    private val USED_QUALIFIERS_KEY: Key<CachedValue<Set<String>>> =
+        Key.create("phel.usedNamespaceQualifiers")
 
     fun validateImport(namespaceSymbol: PhelSymbol): ImportValidationResult? {
         val fullNamespace = namespaceSymbol.text ?: return null
@@ -123,28 +131,38 @@ object PhelImportValidator {
         // The qualifier to look for is either the alias or the short namespace
         val qualifierToFind = alias ?: shortNamespace
 
-        // Scan all symbols in the file for usage
-        val allSymbols = PsiTreeUtil.findChildrenOfType(containingFile, PhelSymbol::class.java)
-        val nsDeclaration = PhelNamespaceUtils.findNamespaceDeclaration(containingFile)
+        // Unused when no namespace-qualified symbol in the file body uses this qualifier.
+        return qualifierToFind !in usedNamespaceQualifiers(containingFile)
+    }
 
-        for (symbol in allSymbols) {
-            // Skip symbols inside the namespace declaration
+    /**
+     * Qualifiers (`str` in `str/join`) used by namespace-qualified symbols outside the
+     * `(ns ...)` declaration. Highlighting checks each import against this set, so the
+     * per-file scan is cached and shared across all imports rather than re-run per import.
+     */
+    private fun usedNamespaceQualifiers(file: PhelFile): Set<String> {
+        return CachedValuesManager.getCachedValue(file, USED_QUALIFIERS_KEY) {
+            CachedValueProvider.Result.create(
+                computeUsedNamespaceQualifiers(file),
+                PsiModificationTracker.MODIFICATION_COUNT,
+            )
+        }
+    }
+
+    private fun computeUsedNamespaceQualifiers(file: PhelFile): Set<String> {
+        val nsDeclaration = PhelNamespaceUtils.findNamespaceDeclaration(file)
+        val qualifiers = HashSet<String>()
+        for (symbol in PsiTreeUtil.findChildrenOfType(file, PhelSymbol::class.java)) {
+            // Skip symbols inside the namespace declaration itself.
             if (nsDeclaration != null && PsiTreeUtil.isAncestor(nsDeclaration, symbol, false)) {
                 continue
             }
-
             val text = symbol.text ?: continue
-
-            // Check if this symbol uses the qualifier (e.g., "str/join" uses "str")
             if (text.contains("/")) {
-                val qualifier = text.substringBefore("/")
-                if (qualifier == qualifierToFind) {
-                    return false // Found a usage
-                }
+                qualifiers.add(text.substringBefore("/"))
             }
         }
-
-        return true // No usage found
+        return qualifiers
     }
 
     private fun hasReferClause(namespaceSymbol: PhelSymbol): Boolean {

--- a/src/main/kotlin/org/phellang/core/psi/PhelSymbolAnalyzer.kt
+++ b/src/main/kotlin/org/phellang/core/psi/PhelSymbolAnalyzer.kt
@@ -149,36 +149,50 @@ object PhelSymbolAnalyzer {
         return PhelErrorHandler.safeOperation {
             val symbolText = symbol.text ?: return@safeOperation false
 
-            // Don't highlight if this is the parameter definition itself
-            val isParamDef = isFunctionParameter(symbol)
-            val isLetBindingDef = isLetBinding(symbol)
-
-            if (isParamDef || isLetBindingDef) {
+            // A binding/parameter *definition* is not a reference to one.
+            if (isFunctionParameter(symbol) || isLetBinding(symbol)) {
                 return@safeOperation false
             }
 
-            // Look for function parameters in the containing function
-            val containingFunction = findContainingFunction(symbol)
-            if (containingFunction != null) {
-                val parameters = extractFunctionParameters(containingFunction)
-                if (parameters.contains(symbolText)) {
-                    return@safeOperation true
-                }
-            }
-
-            // Look for let bindings in the containing scopes
-            if (isReferenceToLetBinding(symbol, symbolText)) {
-                return@safeOperation true
-            }
-
-            // Look for references to locally defined functions in the same file
-            val isLocalFuncRef = isReferenceToLocalFunction(symbol, symbolText)
-            if (isLocalFuncRef) {
-                return@safeOperation true
-            }
-
-            false
+            isLocalReferenceOnly(symbol, symbolText)
         } ?: false
+    }
+
+    /**
+     * True when [symbol] is a fn/let binding definition **or** a reference to one — i.e. any
+     * occurrence highlighting paints as a local symbol. Computes each underlying check once;
+     * prefer this over calling `isParameterReference`, `isFunctionParameter` and `isLetBinding`
+     * separately, which re-walks the PSI for the two definition checks.
+     */
+    @JvmStatic
+    fun isLocalBindingOrReference(symbol: PhelSymbol): Boolean {
+        return PhelErrorHandler.safeOperation {
+            val symbolText = symbol.text ?: return@safeOperation false
+            if (isFunctionParameter(symbol) || isLetBinding(symbol)) {
+                return@safeOperation true
+            }
+            isLocalReferenceOnly(symbol, symbolText)
+        } ?: false
+    }
+
+    /** Reference-only lookup: assumes the caller already ruled out a binding/param definition. */
+    private fun isLocalReferenceOnly(symbol: PhelSymbol, symbolText: String): Boolean {
+        // Look for function parameters in the containing function
+        val containingFunction = findContainingFunction(symbol)
+        if (containingFunction != null) {
+            val parameters = extractFunctionParameters(containingFunction)
+            if (parameters.contains(symbolText)) {
+                return true
+            }
+        }
+
+        // Look for let bindings in the containing scopes
+        if (isReferenceToLetBinding(symbol, symbolText)) {
+            return true
+        }
+
+        // Look for references to locally defined functions in the same file
+        return isReferenceToLocalFunction(symbol, symbolText)
     }
 
     private fun findContainingFunction(symbol: PhelSymbol): PhelList? {

--- a/src/main/kotlin/org/phellang/core/psi/PhelSymbolAnalyzer.kt
+++ b/src/main/kotlin/org/phellang/core/psi/PhelSymbolAnalyzer.kt
@@ -1,6 +1,11 @@
 package org.phellang.core.psi
 
+import com.intellij.openapi.util.Key
 import com.intellij.psi.PsiElement
+import com.intellij.psi.util.CachedValue
+import com.intellij.psi.util.CachedValueProvider
+import com.intellij.psi.util.CachedValuesManager
+import com.intellij.psi.util.PsiModificationTracker
 import com.intellij.psi.util.PsiTreeUtil
 import org.phellang.completion.data.PhelFunctionRegistry
 import org.phellang.completion.infrastructure.PhelCompletionPriority
@@ -10,6 +15,9 @@ import org.phellang.language.psi.files.PhelFile
 import org.phellang.language.psi.utils.SymbolCategory
 
 object PhelSymbolAnalyzer {
+
+    private val LOCAL_FUNCTION_NAMES_KEY: Key<CachedValue<Set<String>>> =
+        Key.create("phel.localFunctionNames")
 
     /** Forms that introduce a parameter vector — used by isFunctionParameter. */
     private val FUNCTION_DEFINING_FORMS = PhelSpecialForms.FUNCTION_DEFINING
@@ -295,29 +303,41 @@ object PhelSymbolAnalyzer {
         }
 
         val file = symbol.containingFile as? PhelFile ?: return false
+        return symbolText in localFunctionNames(file)
+    }
 
-        // Search through all top-level forms in the file
+    /**
+     * Names of top-level `fn`/`defn`-family definitions in [file]. Highlighting probes this
+     * once per regular symbol, so the per-file scan is cached and invalidated by edits rather
+     * than re-walking every top-level form for every symbol.
+     */
+    private fun localFunctionNames(file: PhelFile): Set<String> {
+        return CachedValuesManager.getCachedValue(file, LOCAL_FUNCTION_NAMES_KEY) {
+            CachedValueProvider.Result.create(
+                computeLocalFunctionNames(file),
+                PsiModificationTracker.MODIFICATION_COUNT,
+            )
+        }
+    }
+
+    private fun computeLocalFunctionNames(file: PhelFile): Set<String> {
+        val names = HashSet<String>()
         for (child in file.children) {
             if (child !is PhelList) continue
-            
+
             val children = child.children
             if (children.size < 2) continue
-            
+
             val firstChild = children[0]
-            val secondChild = children[1]
-
-            // Check if this is a function definition (defn, defn-, defmacro, etc.)
             if (firstChild !is PhelSymbol && firstChild !is PhelAccess) continue
-            
-            val functionType = firstChild.text
-            if (functionType !in FUNCTION_DEFINING_FORMS) continue
+            if (firstChild.text !in FUNCTION_DEFINING_FORMS) continue
 
-            // Check if the function name matches our symbol
-            if ((secondChild is PhelSymbol || secondChild is PhelAccess) && secondChild.text == symbolText) {
-                return true
+            val secondChild = children[1]
+            if (secondChild is PhelSymbol || secondChild is PhelAccess) {
+                secondChild.text?.let { names.add(it) }
             }
         }
-        return false
+        return names
     }
 
     private fun isLocalFunctionDefinition(symbol: PhelSymbol): Boolean {

--- a/src/main/kotlin/org/phellang/core/psi/PhelSymbolAnalyzer.kt
+++ b/src/main/kotlin/org/phellang/core/psi/PhelSymbolAnalyzer.kt
@@ -18,6 +18,8 @@ object PhelSymbolAnalyzer {
 
     private val LOCAL_FUNCTION_NAMES_KEY: Key<CachedValue<Set<String>>> =
         Key.create("phel.localFunctionNames")
+    private val FUNCTION_PARAMS_KEY: Key<CachedValue<Set<String>>> =
+        Key.create("phel.functionParameters")
 
     /** Forms that introduce a parameter vector — used by isFunctionParameter. */
     private val FUNCTION_DEFINING_FORMS = PhelSpecialForms.FUNCTION_DEFINING
@@ -227,6 +229,17 @@ object PhelSymbolAnalyzer {
     }
 
     private fun extractFunctionParameters(functionList: PhelList): Set<String> {
+        // Cached per function: isLocalReferenceOnly calls this for every regular symbol inside
+        // a function, and the parameter set is the same for all of them.
+        return CachedValuesManager.getCachedValue(functionList, FUNCTION_PARAMS_KEY) {
+            CachedValueProvider.Result.create(
+                computeFunctionParameters(functionList),
+                PsiModificationTracker.MODIFICATION_COUNT,
+            )
+        }
+    }
+
+    private fun computeFunctionParameters(functionList: PhelList): Set<String> {
         val parameters = mutableSetOf<String>()
 
         // Single-arity: paramVec lives directly in the function list.

--- a/src/main/kotlin/org/phellang/documentation/resolvers/PhelSymbolDocumentationResolver.kt
+++ b/src/main/kotlin/org/phellang/documentation/resolvers/PhelSymbolDocumentationResolver.kt
@@ -65,9 +65,7 @@ class PhelSymbolDocumentationResolver {
     }
 
     private fun isLocalSymbol(symbol: PhelSymbol): Boolean {
-        return PhelSymbolAnalyzer.isParameterReference(symbol)
-                || PhelSymbolAnalyzer.isFunctionParameter(symbol)
-                || PhelSymbolAnalyzer.isLetBinding(symbol)
+        return PhelSymbolAnalyzer.isLocalBindingOrReference(symbol)
     }
 
     private fun generateLocalSymbolDoc(symbol: PhelSymbol, symbolName: String): String {

--- a/src/main/kotlin/org/phellang/inspection/deprecated/PhelDeprecatedFunctionInspection.kt
+++ b/src/main/kotlin/org/phellang/inspection/deprecated/PhelDeprecatedFunctionInspection.kt
@@ -21,9 +21,7 @@ class PhelDeprecatedFunctionInspection : LocalInspectionTool() {
                 // A name introduced by a fn/defn parameter vector or a let-like
                 // binding shadows any same-named core fn; usages of that local
                 // must not be flagged as a deprecated core-fn reference.
-                if (PhelSymbolAnalyzer.isParameterReference(symbol)) return
-                if (PhelSymbolAnalyzer.isFunctionParameter(symbol)) return
-                if (PhelSymbolAnalyzer.isLetBinding(symbol)) return
+                if (PhelSymbolAnalyzer.isLocalBindingOrReference(symbol)) return
                 if (PhelSymbolAnalyzer.isDefinition(symbol)) return
 
                 if (PhelFunctionRegistry.isDeprecated(text)) {

--- a/src/main/kotlin/org/phellang/language/psi/PhelNamespaceUtils.kt
+++ b/src/main/kotlin/org/phellang/language/psi/PhelNamespaceUtils.kt
@@ -15,6 +15,8 @@ object PhelNamespaceUtils {
     private val REFERRED_SYMBOLS_KEY: Key<CachedValue<Set<String>>> = Key.create("phel.namespace.referredSymbols")
     private val ALIAS_MAP_KEY: Key<CachedValue<Map<String, String>>> = Key.create("phel.namespace.aliasMap")
     private val NS_DECLARATION_KEY: Key<CachedValue<Optional<PhelList>>> = Key.create("phel.namespace.declaration")
+    private val REQUIRE_FORMS_KEY: Key<CachedValue<List<PhelList>>> = Key.create("phel.namespace.requireForms")
+    private val USE_FORMS_KEY: Key<CachedValue<List<PhelList>>> = Key.create("phel.namespace.useForms")
 
     fun findNamespaceDeclaration(file: PhelFile): PhelList? {
         // Resolved once per file: highlighting and reference resolution look up the (ns …)
@@ -52,7 +54,14 @@ object PhelNamespaceUtils {
     }
 
     fun findRequireForms(nsDeclaration: PhelList): List<PhelList> {
-        return findNsClauseForms(nsDeclaration, ":require")
+        // Cached on the (cached, per-file) ns element: the validators look these up once per
+        // qualified symbol, each otherwise re-walking the ns form's child lists.
+        return CachedValuesManager.getCachedValue(nsDeclaration, REQUIRE_FORMS_KEY) {
+            CachedValueProvider.Result.create(
+                findNsClauseForms(nsDeclaration, ":require"),
+                PsiModificationTracker.MODIFICATION_COUNT,
+            )
+        }
     }
 
     /**
@@ -62,7 +71,12 @@ object PhelNamespaceUtils {
      * `DateTime/createFromFormat`, `(DateTime. ...)`, etc.
      */
     fun findUseForms(nsDeclaration: PhelList): List<PhelList> {
-        return findNsClauseForms(nsDeclaration, ":use")
+        return CachedValuesManager.getCachedValue(nsDeclaration, USE_FORMS_KEY) {
+            CachedValueProvider.Result.create(
+                findNsClauseForms(nsDeclaration, ":use"),
+                PsiModificationTracker.MODIFICATION_COUNT,
+            )
+        }
     }
 
     private fun findNsClauseForms(nsDeclaration: PhelList, clauseKeyword: String): List<PhelList> {

--- a/src/main/kotlin/org/phellang/language/psi/PhelNamespaceUtils.kt
+++ b/src/main/kotlin/org/phellang/language/psi/PhelNamespaceUtils.kt
@@ -7,14 +7,27 @@ import com.intellij.psi.util.CachedValuesManager
 import com.intellij.psi.util.PsiModificationTracker
 import com.intellij.psi.util.PsiTreeUtil
 import org.phellang.language.psi.files.PhelFile
+import java.util.Optional
 
 object PhelNamespaceUtils {
 
     private val USED_CLASSES_KEY: Key<CachedValue<Set<String>>> = Key.create("phel.namespace.usedClasses")
     private val REFERRED_SYMBOLS_KEY: Key<CachedValue<Set<String>>> = Key.create("phel.namespace.referredSymbols")
     private val ALIAS_MAP_KEY: Key<CachedValue<Map<String, String>>> = Key.create("phel.namespace.aliasMap")
+    private val NS_DECLARATION_KEY: Key<CachedValue<Optional<PhelList>>> = Key.create("phel.namespace.declaration")
 
     fun findNamespaceDeclaration(file: PhelFile): PhelList? {
+        // Resolved once per file: highlighting and reference resolution look up the (ns …)
+        // form repeatedly (per qualified symbol), and each lookup otherwise scans the tree.
+        return CachedValuesManager.getCachedValue(file, NS_DECLARATION_KEY) {
+            CachedValueProvider.Result.create(
+                Optional.ofNullable(computeNamespaceDeclaration(file)),
+                PsiModificationTracker.MODIFICATION_COUNT,
+            )
+        }.orElse(null)
+    }
+
+    private fun computeNamespaceDeclaration(file: PhelFile): PhelList? {
         // (ns my-ns (:require ...) (:use ...))
         val lists = PsiTreeUtil.findChildrenOfType(file, PhelList::class.java)
         return lists.firstOrNull { list ->

--- a/src/main/kotlin/org/phellang/language/psi/references/PhelReference.kt
+++ b/src/main/kotlin/org/phellang/language/psi/references/PhelReference.kt
@@ -160,8 +160,12 @@ class PhelReference @JvmOverloads constructor(
         val phelFiles = FilenameIndex.getAllFilesByExt(
             project, "phel", GlobalSearchScope.projectScope(project)
         )
+        // A matching file's (ns …) form ends with this segment, so its text must contain it —
+        // skip the parse for files that can't be the target.
+        val targetShortName = PhelProjectNamespaceFinder.extractShortNamespace(namespaceText)
         for (virtualFile in phelFiles) {
             val psiFile = psiManager.findFile(virtualFile) as? PhelFile ?: continue
+            if (!psiFile.text.contains(targetShortName)) continue
             val nsDeclaration = PhelNamespaceUtils.findNamespaceDeclaration(psiFile) ?: continue
             val fileNamespace = PhelNamespaceUtils.extractNamespaceFromDeclaration(nsDeclaration) ?: continue
             if (PhelNamespaceUtils.normalizeNamespace(fileNamespace) == target) {

--- a/src/main/kotlin/org/phellang/language/psi/references/PhelReference.kt
+++ b/src/main/kotlin/org/phellang/language/psi/references/PhelReference.kt
@@ -440,6 +440,8 @@ class PhelReference @JvmOverloads constructor(
 
                 val psiFile = PsiManager.getInstance(project).findFile(virtualFile)
                 if (psiFile !is PhelFile) continue
+                // Fast reject: skip files whose text doesn't contain the name at all.
+                if (symbolName != null && !psiFile.text.contains(symbolName)) continue
 
                 val allSymbols = PsiTreeUtil.findChildrenOfType(psiFile, PhelSymbol::class.java)
 
@@ -640,14 +642,16 @@ class PhelReference @JvmOverloads constructor(
 
         for (file in phelFiles) {
             val psiFile = psiManager.findFile(file)
-            if (psiFile != null && psiFile != myElement!!.containingFile) {
-                // Skip current file (already handled above)
-                val lists = PsiTreeUtil.findChildrenOfType(psiFile, PhelList::class.java)
-                for (list in lists) {
-                    val definition = findDefinitionInList(list)
-                    if (definition != null) {
-                        results.add(definition)
-                    }
+            if (psiFile == null || psiFile == myElement!!.containingFile) continue
+            // Fast reject: a file whose text doesn't mention the name can't define it, so
+            // skip the PSI walk for the many files that don't reference this symbol.
+            if (symbolName != null && !psiFile.text.contains(symbolName)) continue
+
+            val lists = PsiTreeUtil.findChildrenOfType(psiFile, PhelList::class.java)
+            for (list in lists) {
+                val definition = findDefinitionInList(list)
+                if (definition != null) {
+                    results.add(definition)
                 }
             }
         }

--- a/src/test/kotlin/org/phellang/integration/PhelIntegrationTestCase.kt
+++ b/src/test/kotlin/org/phellang/integration/PhelIntegrationTestCase.kt
@@ -1,0 +1,30 @@
+package org.phellang.integration
+
+import com.intellij.openapi.util.Disposer
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import org.phellang.completion.indexing.PhelProjectSymbolIndex
+
+/**
+ * Base class for integration tests that exercise PSI/reference/inspection features.
+ *
+ * [BasePlatformTestCase] reuses a single light project across every test class in the
+ * run, so a project-level service created by one class outlives that class. The
+ * [PhelProjectSymbolIndex] service registers a VFS and a PSI-tree-change listener in its
+ * constructor; once any test triggers the service (completion, arity resolution, …)
+ * those listeners stay attached to the shared project's `PsiManager` and fire during the
+ * *next* class's `addFileToProject`, leaving the freshly created file with empty PSI text.
+ *
+ * Disposing the service in tearDown drops its listeners so each class starts from a clean
+ * project; the service is recreated lazily the next time it is needed.
+ */
+abstract class PhelIntegrationTestCase : BasePlatformTestCase() {
+
+    override fun tearDown() {
+        try {
+            project.getServiceIfCreated(PhelProjectSymbolIndex::class.java)
+                ?.let { Disposer.dispose(it) }
+        } finally {
+            super.tearDown()
+        }
+    }
+}

--- a/src/test/kotlin/org/phellang/integration/inspection/PhelArityMismatchInspectionIntegrationTest.kt
+++ b/src/test/kotlin/org/phellang/integration/inspection/PhelArityMismatchInspectionIntegrationTest.kt
@@ -4,11 +4,11 @@ import com.intellij.codeInspection.InspectionManager
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiRecursiveElementVisitor
-import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import org.phellang.integration.PhelIntegrationTestCase
 import org.phellang.inspection.PhelArityMismatchInspection
 import org.phellang.language.psi.files.PhelFile
 
-class PhelArityMismatchInspectionIntegrationTest : BasePlatformTestCase() {
+class PhelArityMismatchInspectionIntegrationTest : PhelIntegrationTestCase() {
 
     fun testWrongArityIsFlagged() {
         val warnings = inspect("(ns app\\m)\n(defn f [x] x)\n(f 1 2)\n")

--- a/src/test/kotlin/org/phellang/integration/inspection/PhelDeprecatedFunctionInspectionFiringTest.kt
+++ b/src/test/kotlin/org/phellang/integration/inspection/PhelDeprecatedFunctionInspectionFiringTest.kt
@@ -4,7 +4,7 @@ import com.intellij.codeInspection.InspectionManager
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiRecursiveElementVisitor
-import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import org.phellang.integration.PhelIntegrationTestCase
 import org.phellang.inspection.deprecated.PhelDeprecatedFunctionInspection
 import org.phellang.language.psi.files.PhelFile
 
@@ -13,7 +13,7 @@ import org.phellang.language.psi.files.PhelFile
  * symbols, so PhelAccess wrapping doesn't hide them) and skips local bindings that shadow a
  * deprecated core name.
  */
-class PhelDeprecatedFunctionInspectionFiringTest : BasePlatformTestCase() {
+class PhelDeprecatedFunctionInspectionFiringTest : PhelIntegrationTestCase() {
 
     fun testDeprecatedCallIsFlagged() {
         val warnings = inspect("(ns app\\m)\n(put {} :a 1)\n")

--- a/src/test/kotlin/org/phellang/integration/inspection/PhelShadowedLetBindingInspectionIntegrationTest.kt
+++ b/src/test/kotlin/org/phellang/integration/inspection/PhelShadowedLetBindingInspectionIntegrationTest.kt
@@ -4,7 +4,7 @@ import com.intellij.codeInspection.InspectionManager
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiRecursiveElementVisitor
-import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import org.phellang.integration.PhelIntegrationTestCase
 import org.phellang.inspection.PhelShadowedLetBindingInspection
 import org.phellang.language.psi.files.PhelFile
 
@@ -13,7 +13,7 @@ import org.phellang.language.psi.files.PhelFile
  * inspection silently doing nothing — simple symbols parse as PhelAccess, so the head
  * and binding casts have to unwrap them for the inspection to fire at all.
  */
-class PhelShadowedLetBindingInspectionIntegrationTest : BasePlatformTestCase() {
+class PhelShadowedLetBindingInspectionIntegrationTest : PhelIntegrationTestCase() {
 
     fun testInnerLetShadowsOuterLet() {
         val warnings = inspect("(ns app\\m)\n(defn f []\n  (let [x 1]\n    (let [x 2]\n      x)))\n")

--- a/src/test/kotlin/org/phellang/integration/inspection/PhelUnusedImportTest.kt
+++ b/src/test/kotlin/org/phellang/integration/inspection/PhelUnusedImportTest.kt
@@ -1,7 +1,7 @@
 package org.phellang.integration.inspection
 
 import com.intellij.psi.util.PsiTreeUtil
-import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import org.phellang.integration.PhelIntegrationTestCase
 import org.phellang.annotator.validators.PhelImportValidator
 import org.phellang.language.psi.PhelList
 import org.phellang.language.psi.PhelSymbol
@@ -12,7 +12,7 @@ import org.phellang.language.psi.files.PhelFile
  * used-qualifier scan: a required namespace is "unused" only when no `ns/...` call in the
  * file body references it.
  */
-class PhelUnusedImportTest : BasePlatformTestCase() {
+class PhelUnusedImportTest : PhelIntegrationTestCase() {
 
     fun testUsedImportIsNotUnused() {
         assertFalse(isUnused("(ns app\\m\n  (:require phel\\str))\n(str/join \", \" [1 2])\n", "phel\\str"))

--- a/src/test/kotlin/org/phellang/integration/inspection/PhelUnusedImportTest.kt
+++ b/src/test/kotlin/org/phellang/integration/inspection/PhelUnusedImportTest.kt
@@ -1,0 +1,34 @@
+package org.phellang.integration.inspection
+
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import org.phellang.annotator.validators.PhelImportValidator
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.files.PhelFile
+
+/**
+ * Behavioural coverage for [PhelImportValidator.isUnusedImport], guarding the cached
+ * used-qualifier scan: a required namespace is "unused" only when no `ns/...` call in the
+ * file body references it.
+ */
+class PhelUnusedImportTest : BasePlatformTestCase() {
+
+    fun testUsedImportIsNotUnused() {
+        assertFalse(isUnused("(ns app\\m\n  (:require phel\\str))\n(str/join \", \" [1 2])\n", "phel\\str"))
+    }
+
+    fun testUnusedImportIsUnused() {
+        assertTrue(isUnused("(ns app\\m\n  (:require phel\\str))\n(println \"hi\")\n", "phel\\str"))
+    }
+
+    private fun isUnused(text: String, requiredNamespace: String): Boolean {
+        // Unique path per class — the shared test project does not reliably clean files
+        // between classes, so a shared path would risk cross-test interference.
+        val vf = myFixture.addFileToProject("src/unused_import_test.phel", text).virtualFile
+        val phelFile = com.intellij.psi.PsiManager.getInstance(project).findFile(vf) as PhelFile
+        val symbol = PsiTreeUtil.findChildrenOfType(phelFile, PhelSymbol::class.java)
+            .first { it.text == requiredNamespace && PsiTreeUtil.getParentOfType(it, PhelList::class.java) != null }
+        return PhelImportValidator.isUnusedImport(symbol)
+    }
+}

--- a/src/test/kotlin/org/phellang/integration/inspection/PhelUnusedLetBindingInspectionIntegrationTest.kt
+++ b/src/test/kotlin/org/phellang/integration/inspection/PhelUnusedLetBindingInspectionIntegrationTest.kt
@@ -4,7 +4,7 @@ import com.intellij.codeInspection.InspectionManager
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiRecursiveElementVisitor
-import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import org.phellang.integration.PhelIntegrationTestCase
 import org.phellang.inspection.PhelUnusedLetBindingInspection
 import org.phellang.language.psi.files.PhelFile
 
@@ -13,7 +13,7 @@ import org.phellang.language.psi.files.PhelFile
  * regression where a binding used only as a *bare symbol value* of a later binding —
  * `(let [x 1 y x] ...)` — was wrongly flagged as unused.
  */
-class PhelUnusedLetBindingInspectionIntegrationTest : BasePlatformTestCase() {
+class PhelUnusedLetBindingInspectionIntegrationTest : PhelIntegrationTestCase() {
 
     fun testBareSymbolValueCountsAsUsage() {
         val warnings = inspect("(ns app\\m)\n(defn f []\n  (let [x 1 y x]\n    (println y)))\n")

--- a/src/test/kotlin/org/phellang/integration/psi/PhelAsSymbolTest.kt
+++ b/src/test/kotlin/org/phellang/integration/psi/PhelAsSymbolTest.kt
@@ -1,7 +1,7 @@
 package org.phellang.integration.psi
 
 import com.intellij.psi.util.PsiTreeUtil
-import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import org.phellang.integration.PhelIntegrationTestCase
 import org.phellang.language.psi.PhelList
 import org.phellang.language.psi.utils.PhelPsiUtils
 import org.phellang.language.psi.files.PhelFile
@@ -12,7 +12,7 @@ import org.phellang.language.psi.files.PhelFile
  * features (inspections, inlay hints) relied on a plain `as? PhelSymbol` cast and so
  * silently did nothing. asSymbol must unwrap those forms to their PhelSymbol.
  */
-class PhelAsSymbolTest : BasePlatformTestCase() {
+class PhelAsSymbolTest : PhelIntegrationTestCase() {
 
     fun testUnwrapsListHead() {
         val list = firstList("(ns app\\m)\n(let [x 1] x)\n", head = "let")

--- a/src/test/kotlin/org/phellang/integration/psi/PhelAsSymbolTest.kt
+++ b/src/test/kotlin/org/phellang/integration/psi/PhelAsSymbolTest.kt
@@ -35,7 +35,10 @@ class PhelAsSymbolTest : BasePlatformTestCase() {
     }
 
     private fun firstList(text: String, head: String): PhelList {
-        val vf = myFixture.addFileToProject("src/main.phel", text).virtualFile
+        // Unique path per class: the shared BasePlatformTestCase project does not reliably
+        // clean files between classes, so sharing a path (e.g. src/main.phel) lets stale
+        // content from another test leak in and resolve incorrectly.
+        val vf = myFixture.addFileToProject("src/as_symbol_test.phel", text).virtualFile
         val phelFile = com.intellij.psi.PsiManager.getInstance(project).findFile(vf) as PhelFile
         return PsiTreeUtil.findChildrenOfType(phelFile, PhelList::class.java)
             .first { PhelPsiUtils.asSymbol(it.forms.firstOrNull())?.text == head }

--- a/src/test/kotlin/org/phellang/integration/psi/PhelLoadReferenceTest.kt
+++ b/src/test/kotlin/org/phellang/integration/psi/PhelLoadReferenceTest.kt
@@ -1,7 +1,7 @@
 package org.phellang.integration.psi
 
 import com.intellij.psi.PsiManager
-import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import org.phellang.integration.PhelIntegrationTestCase
 import org.phellang.language.psi.files.PhelFile
 
 /**
@@ -9,7 +9,7 @@ import org.phellang.language.psi.files.PhelFile
  * string arguments produce a file reference that resolves, mirroring the user's
  * `(load "main")` / `(load "core/meta")` scenarios.
  */
-class PhelLoadReferenceTest : BasePlatformTestCase() {
+class PhelLoadReferenceTest : PhelIntegrationTestCase() {
 
     fun testLoadResolvesCallerRelativeSiblingWithoutExtension() {
         myFixture.addFileToProject("src/main.phel", "(ns app\\main)\n")

--- a/src/test/kotlin/org/phellang/integration/psi/PhelLocalBindingReferenceTest.kt
+++ b/src/test/kotlin/org/phellang/integration/psi/PhelLocalBindingReferenceTest.kt
@@ -1,7 +1,7 @@
 package org.phellang.integration.psi
 
 import com.intellij.psi.PsiManager
-import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import org.phellang.integration.PhelIntegrationTestCase
 import org.phellang.language.psi.PhelSymbol
 import org.phellang.language.psi.files.PhelFile
 
@@ -10,7 +10,7 @@ import org.phellang.language.psi.files.PhelFile
  * resolves to its binding. Covers `when-let`, whose bindings previously failed to
  * resolve because the resolver's binding-form list omitted it.
  */
-class PhelLocalBindingReferenceTest : BasePlatformTestCase() {
+class PhelLocalBindingReferenceTest : PhelIntegrationTestCase() {
 
     fun testWhenLetBindingResolves() {
         assertResolvesToBinding(

--- a/src/test/kotlin/org/phellang/integration/psi/PhelLocalBindingReferenceTest.kt
+++ b/src/test/kotlin/org/phellang/integration/psi/PhelLocalBindingReferenceTest.kt
@@ -45,7 +45,9 @@ class PhelLocalBindingReferenceTest : BasePlatformTestCase() {
     }
 
     private fun assertResolvesToBinding(body: String, usageMarker: String, bindingMarker: String) {
-        val file = myFixture.addFileToProject("src/main.phel", "(ns app\\main)\n(defn f []\n  $body)\n")
+        // Unique path per class: the shared test project does not reliably clean files
+        // between classes, so a shared path (src/main.phel) lets stale content leak in.
+        val file = myFixture.addFileToProject("src/local_binding_test.phel", "(ns app\\main)\n(defn f []\n  $body)\n")
         val phelFile = PsiManager.getInstance(project).findFile(file.virtualFile) as PhelFile
         val text = phelFile.text
 

--- a/src/test/kotlin/org/phellang/integration/psi/PhelRequireNavigationTest.kt
+++ b/src/test/kotlin/org/phellang/integration/psi/PhelRequireNavigationTest.kt
@@ -1,7 +1,7 @@
 package org.phellang.integration.psi
 
 import com.intellij.psi.PsiManager
-import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import org.phellang.integration.PhelIntegrationTestCase
 import org.phellang.language.psi.PhelSymbol
 import org.phellang.language.psi.files.PhelFile
 
@@ -9,7 +9,7 @@ import org.phellang.language.psi.files.PhelFile
  * Ground-truth check that go-to-declaration on a namespace inside `(:require …)`
  * jumps to the required module's `(ns …)` declaration.
  */
-class PhelRequireNavigationTest : BasePlatformTestCase() {
+class PhelRequireNavigationTest : PhelIntegrationTestCase() {
 
     fun testRequireResolvesToTargetNamespaceDeclaration() {
         myFixture.addFileToProject("src/util.phel", "(ns app\\util)\n(defn helper [] 1)\n")

--- a/src/test/kotlin/org/phellang/integration/psi/PhelUseClassNavigationTest.kt
+++ b/src/test/kotlin/org/phellang/integration/psi/PhelUseClassNavigationTest.kt
@@ -2,7 +2,7 @@ package org.phellang.integration.psi
 
 import com.intellij.psi.PsiManager
 import com.intellij.psi.util.PsiTreeUtil
-import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import org.phellang.integration.PhelIntegrationTestCase
 import org.phellang.language.psi.PhelNamespaceUtils
 import org.phellang.language.psi.PhelSymbol
 import org.phellang.language.psi.files.PhelFile
@@ -17,7 +17,7 @@ import org.phellang.language.psi.files.PhelFile
  *     carrying the full class path as its text;
  *  2. [PhelNamespaceUtils.isUseClassSymbol] recognises those entries and nothing else.
  */
-class PhelUseClassNavigationTest : BasePlatformTestCase() {
+class PhelUseClassNavigationTest : PhelIntegrationTestCase() {
 
     fun testDotFormUseEntryIsSingleSymbol() {
         val symbol = symbolFor(

--- a/src/test/kotlin/org/phellang/integration/psi/PhelUseClassNavigationTest.kt
+++ b/src/test/kotlin/org/phellang/integration/psi/PhelUseClassNavigationTest.kt
@@ -69,7 +69,7 @@ class PhelUseClassNavigationTest : BasePlatformTestCase() {
         // The reference must resolve only to a PHP class (absent here → no target), never
         // to the in-file usage symbol — otherwise Cmd+B would jump to the usage instead.
         val file = myFixture.addFileToProject(
-            "src/main.phel",
+            "src/useclass_main.phel",
             "(ns app\\main\n  (:use Foo))\n(defn bar [] (php/new Foo))\n"
         )
         val phelFile = PsiManager.getInstance(project).findFile(file.virtualFile) as PhelFile
@@ -81,7 +81,8 @@ class PhelUseClassNavigationTest : BasePlatformTestCase() {
     private fun symbolFor(source: String, entry: String): PhelSymbol = symbolIn(phelFileFor(source), entry)
 
     private fun phelFileFor(source: String): PhelFile {
-        val file = myFixture.addFileToProject("src/main.phel", source)
+        val file = myFixture.addFileToProject(
+            "src/useclass_main.phel", source)
         return PsiManager.getInstance(project).findFile(file.virtualFile) as PhelFile
     }
 


### PR DESCRIPTION
## Summary

Performance pass over the highlighting / reference-resolution hot paths, plus a test-isolation fix.

### Perf
- Cache the `(ns …)` declaration lookup per file, and the `(:require …)` / `(:use …)` clause lookups per `ns` form (`CachedValuesManager`, invalidated by `PsiModificationTracker`).
- Cache extracted function parameters per function.
- File-level fast path for form-comment detection; skip the anon-function ancestor walk for unhandled elements.
- Text pre-filter before scanning project files for references and when resolving a required namespace, avoiding full-tree walks on files that can't match.

### Test isolation fix
`PhelProjectSymbolIndex` (a project-level service) registers a VFS listener and a PSI-tree-change listener in its constructor. `BasePlatformTestCase` reuses a single light project across every test class in the run, so once any test triggers the service (completion, arity resolution, …) those listeners outlive that class. They then fire during the **next** class's `addFileToProject`, leaving the freshly created file with **empty PSI text** — cascading into 20 unrelated integration-test failures that only surfaced when the full suite ran (each class passed in isolation).

Fix: new `PhelIntegrationTestCase` base that disposes the index service (dropping its listeners) in `tearDown`; the service is recreated lazily next use. All 10 integration classes migrated onto it. No production change.

## Test plan
- [x] `./gradlew test` — 1177 tests, 0 failures (full run, `--rerun-tasks`)
- [x] Failing classes verified green both in isolation and in the full suite
- [x] `./gradlew build` green

