### PR TITLE
fix: eliminate arity-mismatch false positives (variadic, multi-arity, short-fn)

### DIFF
--- a/src/main/kotlin/org/phellang/completion/data/PhelArity.kt
+++ b/src/main/kotlin/org/phellang/completion/data/PhelArity.kt
@@ -25,13 +25,26 @@ data class PhelArity(
             val paramTokens = tokens.drop(1) // first token is the function name
 
             val ampIndex = paramTokens.indexOf("&")
-            return if (ampIndex >= 0) {
-                val before = paramTokens.subList(0, ampIndex)
-                val rest = paramTokens.subList(ampIndex + 1, paramTokens.size)
-                val restName = rest.firstOrNull() ?: "rest"
-                PhelArity(params = before + restName, variadic = true)
-            } else {
-                PhelArity(params = paramTokens, variadic = false)
+            val lastToken = paramTokens.lastOrNull()
+            return when {
+                ampIndex >= 0 -> {
+                    val before = paramTokens.subList(0, ampIndex)
+                    val rest = paramTokens.subList(ampIndex + 1, paramTokens.size)
+                    val restName = rest.firstOrNull() ?: "rest"
+                    PhelArity(params = before + restName, variadic = true)
+                }
+
+                // Star-suffix convention (e.g. "(apply f expr*)") -- the registry's other
+                // way of spelling "zero or more trailing args" alongside `& rest`. Without
+                // this, variadic stdlib fns like `apply` parse as fixed-arity and a call
+                // with extra args is wrongly flagged.
+                lastToken != null && lastToken.length > 1 && lastToken.endsWith("*") -> {
+                    val before = paramTokens.dropLast(1)
+                    val restName = lastToken.dropLast(1)
+                    PhelArity(params = before + restName, variadic = true)
+                }
+
+                else -> PhelArity(params = paramTokens, variadic = false)
             }
         }
 

--- a/src/main/kotlin/org/phellang/completion/data/PhelArityResolver.kt
+++ b/src/main/kotlin/org/phellang/completion/data/PhelArityResolver.kt
@@ -10,17 +10,33 @@ import org.phellang.completion.indexing.PhelProjectSymbolIndex
  */
 object PhelArityResolver {
 
-    /** Arities for [name] (namespace qualifier ignored), or null when the name is unknown. */
+    /**
+     * Arities for [name], or null when the name is unknown.
+     *
+     * A namespace-qualified call (`ns/fn`) is resolved against that namespace first: a
+     * userland `myns/foo` must bind to the project's `myns/foo`, not to a same-named
+     * stdlib function. Only when no matching project symbol exists do we fall back to the
+     * registry, and finally to any same-named project symbol regardless of namespace.
+     */
     fun resolve(project: Project, name: String): List<PhelArity>? {
-        val shortName = name.substringAfterLast('/')
+        val slash = name.lastIndexOf('/')
+        val shortName = if (slash >= 0) name.substring(slash + 1) else name
+        val qualifier = if (slash > 0) name.substring(0, slash) else null
+
+        val index = PhelProjectSymbolIndex.getInstance(project)
+
+        if (qualifier != null) {
+            index.findSymbol(qualifier, shortName)
+                ?.takeIf { it.arities.isNotEmpty() }
+                ?.let { return it.arities }
+        }
 
         PhelFunctionRegistry.getFunction(shortName)?.let { fn ->
             val parsed = PhelArity.parseAll(fn.signature)
             if (parsed.isNotEmpty()) return parsed
         }
 
-        return PhelProjectSymbolIndex.getInstance(project)
-            .findByName(shortName)
+        return index.findByName(shortName)
             .firstOrNull { it.arities.isNotEmpty() }
             ?.arities
     }

--- a/src/main/kotlin/org/phellang/completion/data/core/registerCoreArraysFunctions.kt
+++ b/src/main/kotlin/org/phellang/completion/data/core/registerCoreArraysFunctions.kt
@@ -95,7 +95,7 @@ Sets the value at <code>index</code> in a PHP array to <code>val</code>. Returns
     PhelFunction(
         namespace = "core",
         name = "double-array",
-        signature = "(double-array size-or-seq)",
+        signature = "(double-array size-or-seq)\n(double-array size init-val-or-seq)",
         completion = CompletionInfo(
             tailText = "Creates a PHP array of doubles (same as float-array in PHP)",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -114,7 +114,7 @@ Creates a PHP array of doubles (same as float-array in PHP). Accepts the same ar
     PhelFunction(
         namespace = "core",
         name = "float-array",
-        signature = "(float-array size-or-seq)",
+        signature = "(float-array size-or-seq)\n(float-array size init-val-or-seq)",
         completion = CompletionInfo(
             tailText = "Creates a PHP array of floats",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -133,7 +133,7 @@ Creates a PHP array of floats. Accepts the same arities as <code>int-array</code
     PhelFunction(
         namespace = "core",
         name = "int-array",
-        signature = "(int-array size-or-seq)",
+        signature = "(int-array size-or-seq)\n(int-array size init-val-or-seq)",
         completion = CompletionInfo(
             tailText = "Creates a PHP array of integers, matching Clojure's clojure",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -159,7 +159,7 @@ PHP has no typed arrays, so the result is a plain PHP array.
     PhelFunction(
         namespace = "core",
         name = "into-array",
-        signature = "(into-array aseq)",
+        signature = "(into-array aseq)\n(into-array _type aseq)",
         completion = CompletionInfo(
             tailText = "Returns a PHP array containing the elements of aseq",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -184,7 +184,7 @@ Returns a PHP array containing the elements of <code>aseq</code>. Accepts any<br
     PhelFunction(
         namespace = "core",
         name = "long-array",
-        signature = "(long-array size-or-seq)",
+        signature = "(long-array size-or-seq)\n(long-array size init-val-or-seq)",
         completion = CompletionInfo(
             tailText = "Creates a PHP array of longs (same as int-array in PHP)",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -264,7 +264,7 @@ Arguments:<br />
     PhelFunction(
         namespace = "core",
         name = "short-array",
-        signature = "(short-array size-or-seq)",
+        signature = "(short-array size-or-seq)\n(short-array size init-val-or-seq)",
         completion = CompletionInfo(
             tailText = "Creates a PHP array of shorts (16-bit integers)",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,

--- a/src/main/kotlin/org/phellang/completion/data/core/registerCoreBooleansFunctions.kt
+++ b/src/main/kotlin/org/phellang/completion/data/core/registerCoreBooleansFunctions.kt
@@ -314,7 +314,7 @@ Checks if all values are identical. Same as <code>a === b</code> in PHP.
     PhelFunction(
         namespace = "core",
         name = "keyword",
-        signature = "(keyword x)",
+        signature = "(keyword x)\n(keyword ns nm)",
         completion = CompletionInfo(
             tailText = "Creates a new Keyword",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -466,7 +466,7 @@ Returns the first truthy value of applying predicate to elements, or nil if none
     PhelFunction(
         namespace = "core",
         name = "some?",
-        signature = "(some? x)",
+        signature = "(some? x)\n(some? pred coll)",
         completion = CompletionInfo(
             tailText = "With 1 arg, returns true if x is not nil (Clojure semantics)",
             priority = PhelCompletionPriority.PREDICATE_FUNCTIONS,

--- a/src/main/kotlin/org/phellang/completion/data/core/registerCoreExceptionsFunctions.kt
+++ b/src/main/kotlin/org/phellang/completion/data/core/registerCoreExceptionsFunctions.kt
@@ -46,7 +46,7 @@ internal fun registerCoreExceptionsFunctions(): List<PhelFunction> = listOf(
     PhelFunction(
         namespace = "core",
         name = "ex-info",
-        signature = "(ex-info msg data)",
+        signature = "(ex-info msg data)\n(ex-info msg data cause)",
         completion = CompletionInfo(
             tailText = "Creates an exception with a message and a data map",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,

--- a/src/main/kotlin/org/phellang/completion/data/core/registerCoreFnsSetsFunctions.kt
+++ b/src/main/kotlin/org/phellang/completion/data/core/registerCoreFnsSetsFunctions.kt
@@ -175,7 +175,7 @@ Returns a memoized version of the function <code>f</code>. The memoized function
     PhelFunction(
         namespace = "core",
         name = "memoize-lru",
-        signature = "(memoize-lru f)",
+        signature = "(memoize-lru f)\n(memoize-lru f max-size)",
         completion = CompletionInfo(
             tailText = "Returns a memoized version of the function f with an LRU (Least Recently Used) cache limited to m...",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -233,7 +233,7 @@ Takes a function <code>f</code> and fewer than the normal number of arguments to
     PhelFunction(
         namespace = "core",
         name = "some-fn",
-        signature = "(some-fn)",
+        signature = "(some-fn)\n(some-fn p & ps)",
         completion = CompletionInfo(
             tailText = "Takes a variadic set of predicates and returns a function f that, when called with any number of ...",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,

--- a/src/main/kotlin/org/phellang/completion/data/core/registerCoreIoFunctions.kt
+++ b/src/main/kotlin/org/phellang/completion/data/core/registerCoreIoFunctions.kt
@@ -133,7 +133,7 @@ Takes an expression and a set of test/form pairs. Threads <code>expr</code> (via
     PhelFunction(
         namespace = "core",
         name = "csv-seq",
-        signature = "(csv-seq filename)",
+        signature = "(csv-seq filename)\n(csv-seq filename options)",
         completion = CompletionInfo(
             tailText = "Returns a lazy sequence of rows from a CSV file",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,
@@ -368,7 +368,7 @@ Returns a PCRE pattern string from <code>s</code>. If <code>s</code> is already 
     PhelFunction(
         namespace = "core",
         name = "read-file-lazy",
-        signature = "(read-file-lazy filename)",
+        signature = "(read-file-lazy filename)\n(read-file-lazy filename chunk-size)",
         completion = CompletionInfo(
             tailText = "Returns a lazy sequence of byte chunks from a file",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,

--- a/src/main/kotlin/org/phellang/completion/data/core/registerCoreMathFunctions.kt
+++ b/src/main/kotlin/org/phellang/completion/data/core/registerCoreMathFunctions.kt
@@ -1151,7 +1151,7 @@ Returns the truncated integer quotient of <code>dividend</code> / <code>divisor<
     PhelFunction(
         namespace = "core",
         name = "rand",
-        signature = "(rand)",
+        signature = "(rand)\n(rand n)",
         completion = CompletionInfo(
             tailText = "Without arguments, returns a random number in [0, 1)",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,

--- a/src/main/kotlin/org/phellang/completion/data/core/registerCoreNsFunctions.kt
+++ b/src/main/kotlin/org/phellang/completion/data/core/registerCoreNsFunctions.kt
@@ -262,7 +262,7 @@ Removes the namespace and all of its definitions from the registry. Use with cau
     PhelFunction(
         namespace = "core",
         name = "var-get",
-        signature = "(var-get x)",
+        signature = "(var-get x)\n(var-get x not-found)",
         completion = CompletionInfo(
             tailText = "Resolves the value bound to a Var or to a fully-qualified symbol",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,

--- a/src/main/kotlin/org/phellang/completion/data/core/registerCoreProtocolsFunctions.kt
+++ b/src/main/kotlin/org/phellang/completion/data/core/registerCoreProtocolsFunctions.kt
@@ -12,7 +12,7 @@ internal fun registerCoreProtocolsFunctions(): List<PhelFunction> = listOf(
     PhelFunction(
         namespace = "core",
         name = "ancestors",
-        signature = "(ancestors tag)",
+        signature = "(ancestors tag)\n(ancestors h tag)",
         completion = CompletionInfo(
             tailText = "Returns the set of all transitive ancestors of tag, or nil",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -214,7 +214,7 @@ Deviation from Clojure: Phel's <code>deftype</code> shares the map-backed<br />
     PhelFunction(
         namespace = "core",
         name = "derive",
-        signature = "(derive child parent)",
+        signature = "(derive child parent)\n(derive h child parent)",
         completion = CompletionInfo(
             tailText = "Establishes a parent/child relationship between child and parent keywords",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -233,7 +233,7 @@ Establishes a parent/child relationship between child and parent keywords. With 
     PhelFunction(
         namespace = "core",
         name = "descendants",
-        signature = "(descendants tag)",
+        signature = "(descendants tag)\n(descendants h tag)",
         completion = CompletionInfo(
             tailText = "Returns the set of all descendants of tag, or nil",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -340,7 +340,7 @@ Returns true if the given type-key has implementations for all methods of the pr
     PhelFunction(
         namespace = "core",
         name = "find-hierarchy-method",
-        signature = "(find-hierarchy-method methods dispatch-val)",
+        signature = "(find-hierarchy-method methods dispatch-val)\n(find-hierarchy-method methods dispatch-val prefers-map)",
         completion = CompletionInfo(
             tailText = "Finds the best matching method for dispatch-val using the global hierarchy",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -417,7 +417,7 @@ Binds name to the value of test. If test is not nil, evaluates then with binding
     PhelFunction(
         namespace = "core",
         name = "isa?",
-        signature = "(isa? child parent)",
+        signature = "(isa? child parent)\n(isa? h child parent)",
         completion = CompletionInfo(
             tailText = "Returns true if child equals parent, or child is a descendant of parent",
             priority = PhelCompletionPriority.PREDICATE_FUNCTIONS,
@@ -510,7 +510,7 @@ Returns a map with <code>:parents</code>, <code>:descendants</code>, and <code>:
     PhelFunction(
         namespace = "core",
         name = "parents",
-        signature = "(parents tag)",
+        signature = "(parents tag)\n(parents h tag)",
         completion = CompletionInfo(
             tailText = "Returns the set of immediate parents of tag, or nil",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -730,7 +730,7 @@ Resolves the given symbol in the current environment and returns a resolved Symb
     PhelFunction(
         namespace = "core",
         name = "underive",
-        signature = "(underive child parent)",
+        signature = "(underive child parent)\n(underive h child parent)",
         completion = CompletionInfo(
             tailText = "Removes a parent/child relationship",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,

--- a/src/main/kotlin/org/phellang/completion/data/core/registerCoreRootFunctions.kt
+++ b/src/main/kotlin/org/phellang/completion/data/core/registerCoreRootFunctions.kt
@@ -158,7 +158,7 @@ Handle exceptions thrown in a <code>try</code> block by matching on the provided
     PhelFunction(
         namespace = "core",
         name = "conj",
-        signature = "(conj)",
+        signature = "(conj)\n(conj coll)\n(conj coll value)\n(conj coll value & more)",
         completion = CompletionInfo(
             tailText = "Returns a new collection with values added",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,
@@ -211,7 +211,7 @@ Returns a new collection with values added. Appends to vectors/sets, prepends to
     PhelFunction(
         namespace = "core",
         name = "defexception*",
-        signature = "(defexception name)",
+        signature = "(defexception name)\n(defexception name parent)",
         completion = CompletionInfo(
             tailText = "Defines a new exception, optionally extending a custom parent class",
             priority = PhelCompletionPriority.SPECIAL_FORMS,
@@ -362,7 +362,7 @@ Defines a function. A function consists of a list of parameters and a list of ex
     PhelFunction(
         namespace = "core",
         name = "foreach",
-        signature = "(foreach [value valueExpr] expr*)",
+        signature = "(foreach [value valueExpr] expr*)\n(foreach [key value valueExpr] expr*)",
         completion = CompletionInfo(
             tailText = "The foreach special form can be used to iterate over all kind of PHP datastructures",
             priority = PhelCompletionPriority.CONTROL_FLOW,

--- a/src/main/kotlin/org/phellang/completion/data/core/registerCoreSeqFnsFunctions.kt
+++ b/src/main/kotlin/org/phellang/completion/data/core/registerCoreSeqFnsFunctions.kt
@@ -200,7 +200,7 @@ Returns a lazy sequence with consecutive duplicate values removed in <code>coll<
     PhelFunction(
         namespace = "core",
         name = "disj",
-        signature = "(disj set)",
+        signature = "(disj set)\n(disj set k)\n(disj set k & ks)",
         completion = CompletionInfo(
             tailText = "Returns a new set that does not contain the given key(s)",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -308,7 +308,7 @@ Drops the first <code>n</code> elements of <code>coll</code>. Returns a lazy seq
     PhelFunction(
         namespace = "core",
         name = "drop-last",
-        signature = "(drop-last coll)",
+        signature = "(drop-last coll)\n(drop-last n coll)",
         completion = CompletionInfo(
             tailText = "Drops the last n elements of coll",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,
@@ -855,7 +855,7 @@ With a single collection behaves like <code>(apply concat (map f coll))</code>. 
     PhelFunction(
         namespace = "core",
         name = "merge",
-        signature = "(merge)",
+        signature = "(merge)\n(merge map)\n(merge map & more)",
         completion = CompletionInfo(
             tailText = "Merges multiple maps into one new map",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,
@@ -1266,7 +1266,7 @@ Extracts a slice of <code>coll</code> starting at <code>offset</code> with optio
     PhelFunction(
         namespace = "core",
         name = "sort",
-        signature = "(sort coll)",
+        signature = "(sort coll)\n(sort a b)",
         completion = CompletionInfo(
             tailText = "Returns a sorted vector",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,
@@ -1283,7 +1283,7 @@ Extracts a slice of <code>coll</code> starting at <code>offset</code> with optio
     PhelFunction(
         namespace = "core",
         name = "sort-by",
-        signature = "(sort-by keyfn coll)",
+        signature = "(sort-by keyfn coll)\n(sort-by keyfn comp-or-coll coll-or-comp)",
         completion = CompletionInfo(
             tailText = "Returns a sorted vector where the sort order is determined by comparing (keyfn item)",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,

--- a/src/main/kotlin/org/phellang/completion/data/core/registerCoreSequencesFunctions.kt
+++ b/src/main/kotlin/org/phellang/completion/data/core/registerCoreSequencesFunctions.kt
@@ -67,7 +67,7 @@ Returns <code>ds</code> without the given keys. With no keys returns <code>ds</c
     PhelFunction(
         namespace = "core",
         name = "nth",
-        signature = "(nth coll index)",
+        signature = "(nth coll index)\n(nth coll index not-found)",
         completion = CompletionInfo(
             tailText = "Returns the value at index in coll",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,

--- a/src/main/kotlin/org/phellang/completion/data/core/registerCoreTransientsFunctions.kt
+++ b/src/main/kotlin/org/phellang/completion/data/core/registerCoreTransientsFunctions.kt
@@ -36,7 +36,7 @@ Associates one or more key-value pairs with a transient collection,<br />
     PhelFunction(
         namespace = "core",
         name = "conj!",
-        signature = "(conj!)",
+        signature = "(conj!)\n(conj! tcoll)\n(conj! tcoll value)\n(conj! tcoll value & more)",
         completion = CompletionInfo(
             tailText = "Adds value to the transient collection tcoll, mutating it in place, and returns tcoll",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -55,7 +55,7 @@ Adds <code>value</code> to the transient collection <code>tcoll</code>, mutating
     PhelFunction(
         namespace = "core",
         name = "disj!",
-        signature = "(disj! tcoll)",
+        signature = "(disj! tcoll)\n(disj! tcoll value)\n(disj! tcoll value & more)",
         completion = CompletionInfo(
             tailText = "Removes one or more elements from a transient set, mutating it in place",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -74,7 +74,7 @@ Removes one or more elements from a transient set, mutating it in place. Raises 
     PhelFunction(
         namespace = "core",
         name = "dissoc!",
-        signature = "(dissoc! tcoll)",
+        signature = "(dissoc! tcoll)\n(dissoc! tcoll key)\n(dissoc! tcoll key & ks)",
         completion = CompletionInfo(
             tailText = "Dissociates one or more keys from a transient map, mutating it in place",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,

--- a/src/main/kotlin/org/phellang/completion/data/registerEdnFunctions.kt
+++ b/src/main/kotlin/org/phellang/completion/data/registerEdnFunctions.kt
@@ -6,7 +6,7 @@ internal fun registerEdnFunctions(): List<PhelFunction> = listOf(
     PhelFunction(
         namespace = "edn",
         name = "edn/read-string",
-        signature = "(read-string s)",
+        signature = "(read-string s)\n(read-string s opts)",
         completion = CompletionInfo(
             tailText = "Reads one EDN value from string s",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -30,7 +30,7 @@ Options:<br />
     PhelFunction(
         namespace = "edn",
         name = "edn/read-string-all",
-        signature = "(read-string-all s)",
+        signature = "(read-string-all s)\n(read-string-all s opts)",
         completion = CompletionInfo(
             tailText = "Reads every EDN value from string s and returns them as a vector",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,

--- a/src/main/kotlin/org/phellang/completion/data/registerPhpInteropFunctions.kt
+++ b/src/main/kotlin/org/phellang/completion/data/registerPhpInteropFunctions.kt
@@ -6,7 +6,7 @@ internal fun registerPhpInteropFunctions(): List<PhelFunction> = listOf(
     PhelFunction(
         namespace = "php",
         name = "php/->",
-        signature = "(php/-> object call*)",
+        signature = "(php/-> object call*)\n(php/:: class call*)",
         completion = CompletionInfo(
             tailText = "Access to an object property or result of chained calls",
             priority = PhelCompletionPriority.SPECIAL_FORMS,
@@ -23,7 +23,7 @@ internal fun registerPhpInteropFunctions(): List<PhelFunction> = listOf(
     PhelFunction(
         namespace = "php",
         name = "php/::",
-        signature = "(php/:: class (method-name expr*))",
+        signature = "(php/:: class (method-name expr*))\n(php/:: class call*)",
         completion = CompletionInfo(
             tailText = "Calls a static method or property from a PHP class",
             priority = PhelCompletionPriority.SPECIAL_FORMS,
@@ -211,7 +211,7 @@ Evaluates expr and creates a new PHP class using the arguments. The instance of 
     PhelFunction(
         namespace = "php",
         name = "php/oset",
-        signature = "(php/oset (php/-> object property) value)",
+        signature = "(php/oset (php/-> object property) value)\n(php/oset (php/:: class property) value)",
         completion = CompletionInfo(
             tailText = "Use php/oset to set a value to a class/object property",
             priority = PhelCompletionPriority.SPECIAL_FORMS,

--- a/src/main/kotlin/org/phellang/completion/data/registerTransitFunctions.kt
+++ b/src/main/kotlin/org/phellang/completion/data/registerTransitFunctions.kt
@@ -6,7 +6,7 @@ internal fun registerTransitFunctions(): List<PhelFunction> = listOf(
     PhelFunction(
         namespace = "transit",
         name = "transit/read-string",
-        signature = "(read-string s)",
+        signature = "(read-string s)\n(read-string s opts)",
         completion = CompletionInfo(
             tailText = "Reads one Transit+JSON-Verbose value from string s",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,

--- a/src/main/kotlin/org/phellang/completion/data/schema/registerSchemaFunctions.kt
+++ b/src/main/kotlin/org/phellang/completion/data/schema/registerSchemaFunctions.kt
@@ -90,7 +90,7 @@ Returns <code>nil</code> when <code>value</code> conforms to <code>schema</code>
     PhelFunction(
         namespace = "schema",
         name = "schema/generate",
-        signature = "(generate schema)",
+        signature = "(generate schema)\n(generate schema opts)",
         completion = CompletionInfo(
             tailText = "Generates a single value conforming to schema",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,

--- a/src/main/kotlin/org/phellang/completion/data/schema/registerSchemaGeneratorFunctions.kt
+++ b/src/main/kotlin/org/phellang/completion/data/schema/registerSchemaGeneratorFunctions.kt
@@ -12,7 +12,7 @@ internal fun registerSchemaGeneratorFunctions(): List<PhelFunction> = listOf(
     PhelFunction(
         namespace = "schema.generator",
         name = "schema.generator/generate",
-        signature = "(generate schema)",
+        signature = "(generate schema)\n(generate schema opts)",
         completion = CompletionInfo(
             tailText = "Generates one random value conforming to schema",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,

--- a/src/main/kotlin/org/phellang/completion/data/test/registerTestGenFunctions.kt
+++ b/src/main/kotlin/org/phellang/completion/data/test/registerTestGenFunctions.kt
@@ -244,7 +244,7 @@ Generator that picks one of the <code>[weight gen]</code> pairs with probability
     PhelFunction(
         namespace = "test.gen",
         name = "test.gen/generate",
-        signature = "(generate g)",
+        signature = "(generate g)\n(generate g {:size size, :seed seed})",
         completion = CompletionInfo(
             tailText = "Runs g once and returns a single value",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -394,7 +394,7 @@ Generator that selects uniformly from <code>gens</code> and runs the chosen one.
     PhelFunction(
         namespace = "test.gen",
         name = "test.gen/quick-check",
-        signature = "(quick-check num-tests args-gen property)",
+        signature = "(quick-check num-tests args-gen property)\n(quick-check num-tests args-gen property {:size size, :seed seed, :shrink? shrink?})",
         completion = CompletionInfo(
             tailText = "Runs property for num-tests trials, drawing each trial's arguments from args-gen (a generator ret...",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -461,7 +461,7 @@ Generator that always yields <code>x</code>.
     PhelFunction(
         namespace = "test.gen",
         name = "test.gen/sample",
-        signature = "(sample g)",
+        signature = "(sample g)\n(sample g num-samples)\n(sample g num-samples {:size size, :seed seed})",
         completion = CompletionInfo(
             tailText = "Runs g num-samples times (default 10) and returns a vector of values",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -594,7 +594,7 @@ Generator of ASCII alphanumeric strings, length in <code>[0, size]</code>.
     PhelFunction(
         namespace = "test.gen",
         name = "test.gen/such-that",
-        signature = "(such-that pred g)",
+        signature = "(such-that pred g)\n(such-that pred g max-tries)",
         completion = CompletionInfo(
             tailText = "Generator yielding only values from g that satisfy pred",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -652,7 +652,7 @@ Generator of a fixed-length vector produced by running each of the given generat
     PhelFunction(
         namespace = "test.gen",
         name = "test.gen/vector-of",
-        signature = "(vector-of g)",
+        signature = "(vector-of g)\n(vector-of g n)\n(vector-of g lo hi)",
         completion = CompletionInfo(
             tailText = "Generator of vectors",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,

--- a/src/main/kotlin/org/phellang/completion/indexing/PhelProjectSymbolScanner.kt
+++ b/src/main/kotlin/org/phellang/completion/indexing/PhelProjectSymbolScanner.kt
@@ -90,17 +90,19 @@ object PhelProjectSymbolScanner {
     private fun extractSignature(keyword: String, name: String, forms: List<PhelForm>): String {
         return when (keyword) {
             "defn", "defmacro" -> {
-                val aritySignatures = extractMultiAritySignatures(name, forms)
-                if (aritySignatures.isNotEmpty()) {
-                    aritySignatures.joinToString("\n")
+                // A defn is single-arity when it has a direct parameter vector
+                // (`(defn f [x] body)`) and multi-arity only when the body is made of
+                // `([params] body)` clauses with no top-level vector. Check the direct
+                // vector first: otherwise a single-arity body whose first form is a
+                // vector-headed list — e.g. `(defn idx [i] ([10 20 30] i))`, a vector
+                // used as a function — is misread as a 3-arity clause.
+                val paramVec = findDirectParameterVector(forms)
+                if (paramVec != null) {
+                    val params = extractParameterNames(paramVec)
+                    if (params.isEmpty()) "($name)" else "($name ${params.joinToString(" ")})"
                 } else {
-                    val paramVec = findDirectParameterVector(forms)
-                    if (paramVec != null) {
-                        val params = extractParameterNames(paramVec)
-                        if (params.isEmpty()) "($name)" else "($name ${params.joinToString(" ")})"
-                    } else {
-                        "($name)"
-                    }
+                    val aritySignatures = extractMultiAritySignatures(name, forms)
+                    if (aritySignatures.isNotEmpty()) aritySignatures.joinToString("\n") else "($name)"
                 }
             }
 

--- a/src/main/kotlin/org/phellang/inlay/PhelParameterHintsProvider.kt
+++ b/src/main/kotlin/org/phellang/inlay/PhelParameterHintsProvider.kt
@@ -28,7 +28,7 @@ class PhelParameterHintsProvider : InlayHintsProvider {
         override fun collectFromElement(element: PsiElement, sink: InlayTreeSink) {
             if (element !is PhelList) return
 
-            val forms = element.forms
+            val forms = PhelPsiUtils.activeForms(element)
             if (forms.size < 2) return
 
             val headSymbol = PhelPsiUtils.asSymbol(forms[0]) ?: return

--- a/src/main/kotlin/org/phellang/inspection/PhelArityMismatchInspection.kt
+++ b/src/main/kotlin/org/phellang/inspection/PhelArityMismatchInspection.kt
@@ -21,7 +21,7 @@ class PhelArityMismatchInspection : LocalInspectionTool() {
     override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
         return object : PhelVisitor() {
             override fun visitList(o: PhelList) {
-                val forms = o.forms
+                val forms = PhelPsiUtils.activeForms(o)
                 if (forms.isEmpty()) return
                 val head = PhelPsiUtils.asSymbol(forms[0]) ?: return
                 val name = head.text ?: return
@@ -33,6 +33,7 @@ class PhelArityMismatchInspection : LocalInspectionTool() {
                 if (isInQuoteContext(o)) return
                 if (isThreadedArgList(o)) return
                 if (resolvesToLocalBinding(head, name)) return
+                if (containsShortFnMarker(forms)) return
 
                 val arities = PhelArityResolver.resolve(head.project, name) ?: return
                 if (arities.isEmpty()) return
@@ -47,6 +48,20 @@ class PhelArityMismatchInspection : LocalInspectionTool() {
                 }
             }
         }
+    }
+
+    /**
+     * True when any argument is a bare `|` symbol — the marker for Phel's deprecated
+     * `|(...)` short-fn syntax. The lexer treats `|` as a plain symbol (it does not
+     * recognize the removed short-fn opener), so `|(> $ 10)` parses as two forms — a `|`
+     * symbol and a list — inflating the textual argument count. We can't trust the count
+     * in that case, so skip the check rather than report a false positive.
+     */
+    private fun containsShortFnMarker(forms: List<PhelForm>): Boolean {
+        for (i in 1 until forms.size) {
+            if (PhelPsiUtils.asSymbol(forms[i])?.text == "|") return true
+        }
+        return false
     }
 
     /**

--- a/src/main/kotlin/org/phellang/language/psi/utils/PhelPsiUtils.kt
+++ b/src/main/kotlin/org/phellang/language/psi/utils/PhelPsiUtils.kt
@@ -39,6 +39,29 @@ object PhelPsiUtils {
         }
     }
 
+    /**
+     * The forms of [list] with `#_`-discarded forms removed. A `#_` (FORM_COMMENT) leaf
+     * discards the next form, and they stack (`#_#_` drops two), so callers that count
+     * call arguments must not treat a discarded form as a real argument. Without this,
+     * `(push #_skip coll x)` reads as three args instead of two.
+     */
+    @JvmStatic
+    fun activeForms(list: PhelList): List<PhelForm> {
+        val result = mutableListOf<PhelForm>()
+        var pendingDiscards = 0
+        var child = list.firstChild
+        while (child != null) {
+            when {
+                child.node?.elementType == PhelTypes.FORM_COMMENT -> pendingDiscards++
+                child is PhelForm -> {
+                    if (pendingDiscards > 0) pendingDiscards-- else result.add(child)
+                }
+            }
+            child = child.nextSibling
+        }
+        return result
+    }
+
     @JvmStatic
     fun getName(symbol: PhelSymbol): String? {
         return PhelErrorHandler.safeOperation {

--- a/src/main/kotlin/org/phellang/tools/generator/KotlinCodeGenerator.kt
+++ b/src/main/kotlin/org/phellang/tools/generator/KotlinCodeGenerator.kt
@@ -140,7 +140,10 @@ internal object PhelFunctionRenderer {
 
     fun render(apiFunction: ApiFunction): String {
         val priority = PriorityRules.determinePriority(apiFunction)
-        val signature = apiFunction.signatures.firstOrNull() ?: ""
+        // Join every arity (newline-separated) so multi-arity fns like `conj` keep all
+        // their shapes: the arity-mismatch inspection parses these via PhelArity.parseAll,
+        // and the documentation provider renders the newlines as <br />.
+        val signature = apiFunction.signatures.joinToString("\n")
         val tailText = TailTextGenerator.generate(apiFunction.description)
         val summary = MarkdownToHtmlTransformer.transform(apiFunction.description)
         val example = apiFunction.meta?.example?.let { StringEscaper.escapeHtml(it) }

--- a/src/test/kotlin/org/phellang/integration/inspection/PhelArityMismatchInspectionIntegrationTest.kt
+++ b/src/test/kotlin/org/phellang/integration/inspection/PhelArityMismatchInspectionIntegrationTest.kt
@@ -5,6 +5,7 @@ import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiRecursiveElementVisitor
 import org.phellang.integration.PhelIntegrationTestCase
+import org.phellang.completion.indexing.PhelProjectSymbolIndex
 import org.phellang.inspection.PhelArityMismatchInspection
 import org.phellang.language.psi.files.PhelFile
 
@@ -58,8 +59,114 @@ class PhelArityMismatchInspectionIntegrationTest : PhelIntegrationTestCase() {
         assertTrue("locally shadowed name should not be flagged: $warnings", warnings.isEmpty())
     }
 
+    fun testQualifiedUserlandCallPrefersOwnNamespaceOverStdlib() {
+        // `count` is a 1-arg stdlib fn, but here `m/count` is a userland 3-arg fn in this
+        // file's namespace. The qualified call must resolve to the userland arity, not the
+        // same-named stdlib function -- otherwise we'd wrongly flag a correct call.
+        val warnings = inspect("(ns app\\m)\n(defn count [a b c] a)\n(m/count 1 2 3)\n")
+        assertTrue("qualified userland call should resolve to its own namespace: $warnings", warnings.isEmpty())
+    }
+
+    fun testQualifiedUserlandCallWithWrongArityIsFlagged() {
+        val warnings = inspect("(ns app\\m)\n(defn ff [a b] a)\n(m/ff 1)\n")
+        assertTrue("wrong-arity qualified userland call should be flagged: $warnings", warnings.any { it.contains("'m/ff'") })
+    }
+
+    fun testVariadicStdlibApplyIsNotFlagged() {
+        // `apply` is variadic ((apply f expr*)); both the 2-arg and 4-arg forms are valid
+        // and must not be flagged. Regression guard for the `*`-suffix variadic notation.
+        val warnings = inspect(
+            "(ns app\\m)\n(apply + [1 2 3])\n(apply + 1 2 [3])\n(apply + 1 2 3 4 [5])\n"
+        )
+        assertTrue("variadic apply calls should not be flagged: $warnings", warnings.isEmpty())
+    }
+
+    fun testVariadicStdlibUpdateIsNotFlagged() {
+        // `update` is (update ds k f & args): 3 required + variadic rest. Both the docs'
+        // 3-arg form and an extra-arg form are valid.
+        val warnings = inspect(
+            "(ns app\\m)\n(update {:count 5} :count inc)\n(update m :k + 1 2)\n"
+        )
+        assertTrue("variadic update calls should not be flagged: $warnings", warnings.isEmpty())
+    }
+
+    fun testVariadicStdlibUpdateBelowMinArityIsFlagged() {
+        // Fewer than the 3 required fixed args (ds k f) must still be flagged.
+        val warnings = inspect("(ns app\\m)\n(update {:count 5} :count)\n")
+        assertTrue("update with too few args should be flagged: $warnings", warnings.any { it.contains("'update'") })
+    }
+
+    fun testMultiArityStdlibConjIsNotFlagged() {
+        // conj has 4 arities: (conj) (conj coll) (conj coll value) (conj coll value & more).
+        // Every shape must be accepted -- previously only the first arity was stored.
+        val warnings = inspect(
+            """
+            (ns app\m)
+            (conj)
+            (conj [])
+            (conj [1 2] 3)
+            (conj [1 2] 3 4 5)
+            """.trimIndent() + "\n"
+        )
+        assertTrue("all conj arities should be accepted: $warnings", warnings.isEmpty())
+    }
+
+    fun testMultiArityStdlibMergeIsNotFlagged() {
+        // merge: (merge) (merge map) (merge map & more)
+        val warnings = inspect("(ns app\\m)\n(merge)\n(merge {:a 1})\n(merge {:a 1} {:b 2} {:c 3})\n")
+        assertTrue("all merge arities should be accepted: $warnings", warnings.isEmpty())
+    }
+
+    fun testDiscardedArgIsNotCounted() {
+        // `#_skip` discards the next form, so the real call is (push coll x) -- 2 args.
+        // The discarded form must not be counted as an argument.
+        val warnings = inspect("(ns app\\m)\n(push #_skip coll x)\n")
+        assertTrue("discarded arg before should not be counted: $warnings", warnings.isEmpty())
+    }
+
+    fun testTrailingDiscardedArgIsNotCounted() {
+        val warnings = inspect("(ns app\\m)\n(push coll x #_extra)\n")
+        assertTrue("trailing discarded arg should not be counted: $warnings", warnings.isEmpty())
+    }
+
+    fun testStackedDiscardsAreNotCounted() {
+        // `#_#_` discards the next two forms; (conj coll a b) survives with a 4-arity match.
+        val warnings = inspect("(ns app\\m)\n(conj coll a b #_#_ x y)\n")
+        assertTrue("stacked discards should not be counted: $warnings", warnings.isEmpty())
+    }
+
+    fun testDiscardTurningValidCallInvalidIsFlagged() {
+        // Discarding a required arg makes (push coll) a 1-arg call -- still wrong.
+        val warnings = inspect("(ns app\\m)\n(push coll #_x)\n")
+        assertTrue("discard dropping a required arg should be flagged: $warnings", warnings.any { it.contains("'push'") })
+    }
+
+    fun testShortFnArgIsNotMiscounted() {
+        // Phel's deprecated `|(...)` short-fn is a single anonymous-function argument.
+        // (some |(> $ 10) coll) is a 2-arg call, not 3.
+        val warnings = inspect("(ns app\\m)\n(some |(> $ 10) coll)\n")
+        assertTrue("|(...) short-fn arg should count as one form: $warnings", warnings.isEmpty())
+    }
+
+    fun testHashFnArgIsNotMiscounted() {
+        // The modern `#(...)` short-fn must likewise count as a single argument.
+        val warnings = inspect("(ns app\\m)\n(some #(when (> % 10) %) [5 15 8])\n")
+        assertTrue("#(...) short-fn arg should count as one form: $warnings", warnings.isEmpty())
+    }
+
+    fun testGenuineExtraArgIsStillFlagged() {
+        // some is 2-arg; a real 3-arg call must still be flagged.
+        val warnings = inspect("(ns app\\m)\n(some pred coll extra)\n")
+        assertTrue("genuine 3-arg call to 2-arg fn should be flagged: $warnings", warnings.any { it.contains("'some'") })
+    }
+
     private fun inspect(text: String): List<String> {
         val file = myFixture.configureByText("a.phel", text) as PhelFile
+        // Populate the project symbol index directly from this file's PSI. The lazy
+        // FilenameIndex-based build is order-sensitive across the shared light-fixture
+        // project (only the first index-dependent test in a class sees it built),
+        // so priming here keeps namespace-qualified resolution deterministic.
+        PhelProjectSymbolIndex.getInstance(project).refreshFileFromPsi(file)
         val holder = ProblemsHolder(InspectionManager.getInstance(project), file, true)
         val visitor = PhelArityMismatchInspection().buildVisitor(holder, true)
         file.accept(object : PsiRecursiveElementVisitor() {

--- a/src/test/kotlin/org/phellang/integration/inspection/PhelArityMismatchInspectionIntegrationTest.kt
+++ b/src/test/kotlin/org/phellang/integration/inspection/PhelArityMismatchInspectionIntegrationTest.kt
@@ -160,6 +160,20 @@ class PhelArityMismatchInspectionIntegrationTest : PhelIntegrationTestCase() {
         assertTrue("genuine 3-arg call to 2-arg fn should be flagged: $warnings", warnings.any { it.contains("'some'") })
     }
 
+    fun testUserlandFnWithVectorHeadedBodyKeepsItsArity() {
+        // `([10 20 30] i)` is a vector used as a function in the body of a 1-arg fn.
+        // The scanner must not mistake that body list for a multi-arity clause, which
+        // would make `idx` look like a 3-arg fn and flag the correct 1-arg call.
+        val warnings = inspect("(ns app\\m)\n(defn idx [i] ([10 20 30] i))\n(idx 1)\n")
+        assertTrue("single-arity fn with vector-headed body should not be flagged: $warnings", warnings.isEmpty())
+    }
+
+    fun testUserlandMultiArityFnAcceptsAllArities() {
+        // Genuine multi-arity userland fn: both 1-arg and 2-arg calls are valid.
+        val warnings = inspect("(ns app\\m)\n(defn f ([x] x) ([x y] y))\n(f 1)\n(f 1 2)\n")
+        assertTrue("both arities of a multi-arity userland fn should be accepted: $warnings", warnings.isEmpty())
+    }
+
     private fun inspect(text: String): List<String> {
         val file = myFixture.configureByText("a.phel", text) as PhelFile
         // Populate the project symbol index directly from this file's PSI. The lazy

--- a/src/test/kotlin/org/phellang/unit/completion/data/PhelArityTest.kt
+++ b/src/test/kotlin/org/phellang/unit/completion/data/PhelArityTest.kt
@@ -37,6 +37,34 @@ class PhelArityTest {
     }
 
     @Test
+    fun `parses star-suffix variadic signature`() {
+        // The registry spells some variadic fns with a trailing `*` (e.g. apply).
+        val arity = PhelArity.parseSignature("(apply f expr*)")
+        assertNotNull(arity)
+        assertTrue(arity!!.variadic)
+        assertEquals(listOf("f", "expr"), arity.params)
+        assertEquals(1, arity.fixedCount)
+    }
+
+    @Test
+    fun `star-suffix variadic accepts extra args`() {
+        val arities = PhelArity.parseAll("(apply f expr*)")
+        assertTrue(arities.accepts(2)) // (apply + [1 2 3])
+        assertTrue(arities.accepts(4)) // (apply + 1 2 [3])
+        assertFalse(arities.accepts(0))
+    }
+
+    @Test
+    fun `lone star is treated as a fixed param name`() {
+        // `*` is a real fn name; "(* & xs)" must not be mistaken for star-suffix variadic.
+        val arity = PhelArity.parseSignature("(* & xs)")
+        assertNotNull(arity)
+        assertTrue(arity!!.variadic)
+        assertEquals(listOf("xs"), arity.params)
+        assertEquals(0, arity.fixedCount)
+    }
+
+    @Test
     fun `parses multi-arity newline-separated`() {
         val arities = PhelArity.parseAll("(foo a)\n(foo a b)\n(foo a b & xs)")
         assertEquals(3, arities.size)


### PR DESCRIPTION
## Summary

The **Function arity mismatch** inspection (`PhelArityMismatchInspection`) — and the inlay parameter-hints provider that shares its arity resolution — fired several false **"Wrong number of args"** positives on valid Phel. This PR fixes each, while keeping genuine arity errors flagged.

### Fixes

- **Multi-arity stdlib functions kept only their first arity.** The registry generator used `signatures.firstOrNull()`, so `conj`, `merge`, `disj`, `drop-last`, `sort`, `sort-by`, `defexception`, … dropped every arity but the first (e.g. `conj` became just `(conj)`). Now all signatures are joined newline-separated — matching the userland scanner and the doc provider, both of which already expect that. Registry regenerated via `updatePhelRegistry` (api.json v0.42.0, so the diff is purely restored arities).
- **`*`-suffix variadics parsed as fixed-arity.** `(apply f expr*)` was read as fixed 2 → `(apply + 1 2 [3])` wrongly flagged. `PhelArity.parseSignature` now treats a trailing `*`-suffixed token as variadic, alongside `& rest` (a lone `*`, i.e. the multiply operator, is preserved as a fixed param).
- **Namespace-qualified userland calls resolved against same-named stdlib fns.** `(myns/count …)` matched stdlib `count`. `PhelArityResolver` now resolves `ns/fn` against the matching project namespace first.
- **`#_`-discarded forms were counted as arguments.** `(push #_skip coll x)` (a 2-arg call) read as 3. New `PhelPsiUtils.activeForms` drops forms discarded by a preceding `#_` (stacks for `#_#_`); used by both the inspection and the hints provider.
- **Deprecated `|(...)` short-fn inflated the arg count.** The lexer intentionally treats `|` as a plain symbol (there's a regression test asserting this), so `|(> $ 10)` parses as two forms. The inspection now skips the check when an argument is a bare `|` symbol, since the textual count can't be trusted there. The modern `#(...)` form already counts correctly.
- **A single-arity userland `defn` with a vector-headed body list was misread as multi-arity.** `(defn idx [i] ([10 20 30] i))` (a vector used as a function) was read as a 3-arity definition. The scanner now treats a `defn` with a direct parameter vector as single-arity and only scans for `([params] …)` clauses when there is no direct vector.

### Test plan

- `./gradlew build` — green (1194 tests).
- New unit tests in `PhelArityTest` (star-suffix variadic, lone-`*` guard).
- New integration tests in `PhelArityMismatchInspectionIntegrationTest` covering: multi-arity `conj`/`merge`, variadic `apply`/`update`, qualified userland resolution, `#_` discards (leading/trailing/stacked), `|(...)` and `#(...)` short-fns, and that genuine over-arity calls are still flagged.

All Phel semantics were verified against the official source (`api.json` and the `phel-lang` repo), not memory.
