### PR TITLE
perf: skip anon-function ancestor walk in files without #(

### DIFF
--- a/src/main/kotlin/org/phellang/annotator/analyzers/PhelCommentAnalyzer.kt
+++ b/src/main/kotlin/org/phellang/annotator/analyzers/PhelCommentAnalyzer.kt
@@ -16,7 +16,13 @@ object PhelCommentAnalyzer {
 
     private const val FORM_COMMENT_MARKER = "#_"
 
+    // Only `#(` opens an anonymous function (PhelHashFn); the deprecated `|(` is lexed as a
+    // plain symbol and never produces one.
+    private const val ANON_FN_MARKER = "#("
+
     private val HAS_FORM_COMMENT_KEY: Key<CachedValue<Boolean>> = Key.create("phel.hasFormComment")
+
+    private val HAS_ANON_FN_KEY: Key<CachedValue<Boolean>> = Key.create("phel.hasAnonFn")
 
     fun isCommentedOutByFormComment(element: PsiElement): Boolean {
         // Fast path: a file with no `#_` marker anywhere can't comment out any form, so skip
@@ -39,6 +45,12 @@ object PhelCommentAnalyzer {
     }
 
     fun isInsideAnonFunction(element: PsiElement): Boolean {
+        // Fast path: a file with no `#(` can't contain an anonymous function, so skip the
+        // ancestor walk that otherwise runs for every annotated symbol/keyword. When no
+        // containing file is available we fall through to the walk.
+        val file = element.containingFile
+        if (file != null && !fileHasAnonFunction(file)) return false
+
         var current = element.parent
         while (current != null) {
             if (current is PhelHashFn) {
@@ -47,6 +59,15 @@ object PhelCommentAnalyzer {
             current = current.parent
         }
         return false
+    }
+
+    private fun fileHasAnonFunction(file: PsiFile): Boolean {
+        return CachedValuesManager.getCachedValue(file, HAS_ANON_FN_KEY) {
+            CachedValueProvider.Result.create(
+                file.text.contains(ANON_FN_MARKER),
+                PsiModificationTracker.MODIFICATION_COUNT,
+            )
+        }
     }
 
     private fun isInCommentedFormByText(element: PsiElement): Boolean {


### PR DESCRIPTION
## Summary

`PhelCommentAnalyzer.isInsideAnonFunction` runs for **every** annotated symbol/keyword (it's called from the annotator dispatch) and walks the PSI ancestor chain to the root looking for a `PhelHashFn`. Only `#(` opens an anonymous function, so a file whose text contains no `#(` can never have one.

This gates the ancestor walk behind a cached (per `MODIFICATION_COUNT`) file-level text check — mirroring the existing `fileHasFormComment` fast path in the same class. In files with no `#(`, every symbol/keyword skips the walk entirely.

### Why it's safe

Behavior is unchanged by construction: the short-circuit only triggers when the file provably contains no `#(`, in which case no `PhelHashFn` ancestor can exist and the walk would return `false` anyway. When no containing file is available (e.g. pure-mock unit tests) it falls through to the original walk.

### Test plan

- `./gradlew build` — green.
- Existing `PhelCommentAnalyzerSimpleTest` (15 cases), `PhelAnnotatorPerformanceTest`, and `PhelSyntaxHighlighterTest` all pass unchanged.