### PR TITLE
perf: classify highlighter tokens via map lookup

### DIFF
--- a/src/main/kotlin/org/phellang/syntax/classification/PhelTokenClassifier.kt
+++ b/src/main/kotlin/org/phellang/syntax/classification/PhelTokenClassifier.kt
@@ -11,33 +11,57 @@ object PhelTokenClassifier {
         UNQUOTE, UNQUOTE_SPLICING, KEYWORD, METADATA, DOT_OPERATOR, SYMBOL, BAD_CHARACTER, UNKNOWN, REGEX, DEREF, TAG
     }
 
+    // Token types are interned singletons, so a direct map lookup classifies each token in
+    // O(1) instead of the sequential `when` chain that ran up to ~22 comparisons per token
+    // on the syntax-highlighting hot path. Each token type belongs to exactly one category,
+    // so the map is equivalent to the first-match ordering of the previous chain.
+    private val CATEGORY_BY_TOKEN: Map<IElementType, TokenCategory> = buildMap {
+        put(PhelTypes.LINE_COMMENT, TokenCategory.COMMENT)
+        put(PhelTypes.FORM_COMMENT, TokenCategory.COMMENT)
+        put(PhelTypes.STRING, TokenCategory.STRING)
+        put(PhelTypes.REGEX_START, TokenCategory.REGEX)
+        put(PhelTypes.REGEX_BODY, TokenCategory.REGEX)
+        put(PhelTypes.NUMBER, TokenCategory.NUMBER)
+        put(PhelTypes.BINNUM, TokenCategory.NUMBER)
+        put(PhelTypes.OCTNUM, TokenCategory.NUMBER)
+        put(PhelTypes.HEXNUM, TokenCategory.NUMBER)
+        put(PhelTypes.RADIXNUM, TokenCategory.NUMBER)
+        put(PhelTypes.SYMBOLIC_NUM, TokenCategory.NUMBER)
+        put(PhelTypes.RATIO, TokenCategory.NUMBER)
+        put(PhelTypes.BOOL, TokenCategory.BOOLEAN)
+        put(PhelTypes.NIL, TokenCategory.NIL)
+        put(PhelTypes.NAN, TokenCategory.NAN)
+        put(PhelTypes.CHAR, TokenCategory.CHARACTER)
+        put(PhelTypes.PAREN1, TokenCategory.PARENTHESES)
+        put(PhelTypes.PAREN2, TokenCategory.PARENTHESES)
+        put(PhelTypes.HASH_PAREN, TokenCategory.PARENTHESES)
+        put(PhelTypes.READER_COND, TokenCategory.PARENTHESES)
+        put(PhelTypes.READER_COND_SPLICE, TokenCategory.PARENTHESES)
+        put(PhelTypes.BRACKET1, TokenCategory.BRACKETS)
+        put(PhelTypes.BRACKET2, TokenCategory.BRACKETS)
+        put(PhelTypes.BRACE1, TokenCategory.BRACES)
+        put(PhelTypes.BRACE2, TokenCategory.BRACES)
+        put(PhelTypes.HASH_BRACE, TokenCategory.BRACES)
+        put(PhelTypes.QUOTE, TokenCategory.QUOTE)
+        put(PhelTypes.VAR_QUOTE, TokenCategory.QUOTE)
+        put(PhelTypes.SYNTAX_QUOTE, TokenCategory.SYNTAX_QUOTE)
+        put(PhelTypes.DEREF, TokenCategory.DEREF)
+        put(PhelTypes.TILDE, TokenCategory.UNQUOTE)
+        put(PhelTypes.TILDE_AT, TokenCategory.UNQUOTE_SPLICING)
+        put(PhelTypes.TAG, TokenCategory.TAG)
+        put(PhelTypes.KEYWORD, TokenCategory.KEYWORD)
+        put(PhelTypes.KEYWORD_TOKEN, TokenCategory.KEYWORD)
+        put(PhelTypes.COLON, TokenCategory.KEYWORD)
+        put(PhelTypes.COLONCOLON, TokenCategory.KEYWORD)
+        put(PhelTypes.HAT, TokenCategory.METADATA)
+        put(PhelTypes.DOT, TokenCategory.DOT_OPERATOR)
+        put(PhelTypes.DOTDASH, TokenCategory.DOT_OPERATOR)
+        put(PhelTypes.SYM, TokenCategory.SYMBOL)
+    }
+
     fun classifyToken(tokenType: IElementType): TokenCategory {
-        return when {
-            isComment(tokenType) -> TokenCategory.COMMENT
-            isString(tokenType) -> TokenCategory.STRING
-            isRegex(tokenType) -> TokenCategory.REGEX
-            isNumber(tokenType) -> TokenCategory.NUMBER
-            isBoolean(tokenType) -> TokenCategory.BOOLEAN
-            isNil(tokenType) -> TokenCategory.NIL
-            isNan(tokenType) -> TokenCategory.NAN
-            isCharacter(tokenType) -> TokenCategory.CHARACTER
-            isParentheses(tokenType) -> TokenCategory.PARENTHESES
-            isBrackets(tokenType) -> TokenCategory.BRACKETS
-            isBraces(tokenType) -> TokenCategory.BRACES
-            isSetOpener(tokenType) -> TokenCategory.BRACES
-            isQuote(tokenType) -> TokenCategory.QUOTE
-            isSyntaxQuote(tokenType) -> TokenCategory.SYNTAX_QUOTE
-            isDeref(tokenType) -> TokenCategory.DEREF
-            isUnquote(tokenType) -> TokenCategory.UNQUOTE
-            isUnquoteSplicing(tokenType) -> TokenCategory.UNQUOTE_SPLICING
-            isTag(tokenType) -> TokenCategory.TAG
-            isKeyword(tokenType) -> TokenCategory.KEYWORD
-            isMetadata(tokenType) -> TokenCategory.METADATA
-            isDotOperator(tokenType) -> TokenCategory.DOT_OPERATOR
-            isSymbol(tokenType) -> TokenCategory.SYMBOL
-            isBadCharacter(tokenType) -> TokenCategory.BAD_CHARACTER
-            else -> TokenCategory.UNKNOWN
-        }
+        CATEGORY_BY_TOKEN[tokenType]?.let { return it }
+        return if (isBadCharacter(tokenType)) TokenCategory.BAD_CHARACTER else TokenCategory.UNKNOWN
     }
 
     fun isComment(tokenType: IElementType): Boolean {


### PR DESCRIPTION
## Summary

`PhelTokenClassifier.classifyToken` runs for **every token** on the syntax-highlighting hot path. It used a sequential `when` of up to ~22 `IElementType` comparisons — the common `SYMBOL` case fell through ~19 of them before matching.

This replaces the chain with a precomputed `IElementType -> TokenCategory` map (token types are interned singletons, so map lookup is O(1)). Each token type belongs to exactly one category, so the map is equivalent to the previous first-match ordering.

It also avoids the `tokenType.toString()` string allocation in the bad-character fallback for the common case (known tokens now return before reaching it).

The per-type `isX` helper functions are unchanged (still used elsewhere).

### Test plan

- `./gradlew build` — green.
- `PhelTokenClassifierTest`, `PhelSyntaxHighlighterTest`, `PhelTokenAttributeMapperTest`, and `PhelSyntaxHighlightingWorkflowTest` all pass unchanged.