### PR TITLE
fix(completion): respect the namespace prefix on explicit invocation

### DIFF
--- a/src/main/kotlin/org/phellang/completion/engine/PhelMainCompletionProvider.kt
+++ b/src/main/kotlin/org/phellang/completion/engine/PhelMainCompletionProvider.kt
@@ -1,6 +1,7 @@
 package org.phellang.completion.engine
 
 import com.intellij.codeInsight.completion.*
+import com.intellij.codeInsight.completion.PlainPrefixMatcher
 import com.intellij.codeInsight.lookup.LookupElementBuilder
 import com.intellij.psi.PsiElement
 import com.intellij.util.ProcessingContext
@@ -19,10 +20,11 @@ class PhelMainCompletionProvider : CompletionProvider<CompletionParameters?>() {
     override fun addCompletions(
         parameters: CompletionParameters,
         context: ProcessingContext,
-        result: CompletionResultSet
+        rawResult: CompletionResultSet
     ) {
         PhelErrorHandler.safeOperation("completion") {
             val element = parameters.position
+            val result = rawResult.withPhelPrefix(parameters)
 
             val completionContext = PhelCompletionContext(parameters)
 
@@ -69,6 +71,30 @@ class PhelMainCompletionProvider : CompletionProvider<CompletionParameters?>() {
                 }
             }
         }
+    }
+
+    /**
+     * Re-derives the completion prefix using Phel's identifier alphabet.
+     *
+     * The platform computes the initial prefix with Java's rules, so it stops at the first character
+     * that is not a Java identifier part. In Phel that severs a symbol at `/`, `-`, `?`, `!` and the
+     * rest of [PhelCompletionCharFilter]'s alphabet: invoking completion at `(s/|)` yields an *empty*
+     * prefix, so nothing filters on `s/` and the whole registry is offered. Typing the same text
+     * works only because the char filter widens the prefix while a lookup is already open — which is
+     * why this is invisible until you ask for completion at an existing symbol.
+     *
+     * [PlainPrefixMatcher] rather than the default: `s/upper-case` must match the literal prefix
+     * `s/`, and camel-hump matching has nothing to offer kebab-case Phel names anyway.
+     */
+    private fun CompletionResultSet.withPhelPrefix(parameters: CompletionParameters): CompletionResultSet {
+        val position = parameters.position
+        val caretInElement = parameters.offset - position.textRange.startOffset
+        if (caretInElement <= 0 || caretInElement > position.text.length) return this
+
+        val prefix = position.text.take(caretInElement)
+        if (prefix == prefixMatcher.prefix) return this
+
+        return withPrefixMatcher(PlainPrefixMatcher(prefix))
     }
 
     private fun addTemplateCompletions(result: CompletionResultSet) {

--- a/src/test/kotlin/org/phellang/integration/completion/PhelCompletionPrefixTest.kt
+++ b/src/test/kotlin/org/phellang/integration/completion/PhelCompletionPrefixTest.kt
@@ -1,0 +1,90 @@
+package org.phellang.integration.completion
+
+import com.intellij.codeInsight.completion.CompletionType
+import org.phellang.integration.PhelIntegrationTestCase
+
+/**
+ * Completion invoked *at* an existing symbol, rather than typed character by character.
+ *
+ * The two paths derive the prefix differently. While a lookup is open, [org.phellang.completion
+ * .PhelCompletionCharFilter] widens the prefix through Phel's identifier alphabet (`/`, `-`, `?`,
+ * `!`, …), so typing `s` then `/` filters correctly. But the *initial* prefix on an explicit
+ * invocation is computed by the platform using Java's identifier rules, which sever the symbol at
+ * `/` — the prefix came out empty, so nothing filtered on the `s/` already written and the entire
+ * registry was offered.
+ */
+class PhelCompletionPrefixTest : PhelIntegrationTestCase() {
+
+    fun testInvokingCompletionAfterAnAliasOffersOnlyThatNamespace() {
+        val suggestions = completeAt(
+            """
+            (ns app\m
+              (:require phel\string :as s))
+
+            (defn f [t] (s/<caret>))
+            """.trimIndent()
+        )
+
+        assertTrue(
+            "expected the alias to filter to phel\\string functions, got: ${suggestions.take(15)}",
+            suggestions.any { it.startsWith("s/") },
+        )
+        assertTrue(
+            "everything offered must respect the `s/` already written, got: " +
+                    "${suggestions.filterNot { it.startsWith("s/") }.take(10)}",
+            suggestions.all { it.startsWith("s/") },
+        )
+    }
+
+    fun testInvokingCompletionAfterAFullNamespaceOffersOnlyThatNamespace() {
+        val suggestions = completeAt(
+            """
+            (ns app\m
+              (:require phel\string))
+
+            (defn f [t] (string/<caret>))
+            """.trimIndent()
+        )
+
+        assertTrue(
+            "expected string/ functions, got: ${suggestions.take(15)}",
+            suggestions.any { it.startsWith("string/") },
+        )
+        assertTrue(
+            "nothing unrelated may leak past the `string/` prefix, got: " +
+                    "${suggestions.filterNot { it.startsWith("string/") }.take(10)}",
+            suggestions.all { it.startsWith("string/") },
+        )
+    }
+
+    fun testKebabCaseIsNotSeveredAtTheHyphen() {
+        // `-` is not a Java identifier char either, so the platform's prefix started *after* it.
+        val suggestions = completeAt(
+            """
+            (ns app\m)
+
+            (defn my-helper [] 1)
+            (defn my-other [] 2)
+            (defn g [] (my-<caret>))
+            """.trimIndent()
+        )
+
+        assertTrue(
+            "kebab-case locals must survive the prefix `my-`, got: ${suggestions.take(10)}",
+            suggestions.containsAll(listOf("my-helper", "my-other")),
+        )
+        assertTrue(
+            "nothing without the `my-` prefix may be offered, got: " +
+                    "${suggestions.filterNot { it.startsWith("my-") }.take(10)}",
+            suggestions.all { it.startsWith("my-") },
+        )
+    }
+
+    private fun completeAt(text: String): List<String> {
+        myFixture.configureByText("a.phel", text)
+        myFixture.complete(CompletionType.BASIC)
+        // Null when a single candidate matched and the platform inserted it outright; these fixtures
+        // are written so that at least two candidates always match, so a null here is a real failure.
+        return myFixture.lookupElementStrings ?: emptyList()
+    }
+}


### PR DESCRIPTION
## The bug

Invoking completion at an existing `(s/|)` — e.g. deleting `upper-case` from `s/upper-case` and hitting `Ctrl+Space` — **ignored the `s/` completely** and offered the entire registry: locals, special forms, every namespace.

Typing the same text worked fine, which is exactly what made this hard to notice.

## Why

The two paths derive the completion prefix differently.

- **Typing**: a lookup is already open, and `PhelCompletionCharFilter` widens the prefix through Phel's identifier alphabet (`/ - ? ! * + < > = & % $ :`). So `s` → `s/` filters correctly.
- **Explicit invocation**: the *initial* prefix is computed by the platform using **Java's** identifier rules. `/` is not a Java identifier char, so the symbol is severed there and the prefix comes out **empty** — nothing filters.

`-` is affected the same way, so kebab-case names were severed at the hyphen too.

## The fix

The result set now carries a `PlainPrefixMatcher` built from the symbol text actually before the caret.

This is what the repo's own architecture rule has prescribed all along:

> Completion logic: … use `PlainPrefixMatcher` for `namespace/function` matching.

It had simply never been implemented — `PlainPrefixMatcher` appeared nowhere in the source.

## Verification

`PhelCompletionPrefixTest` pins three cases: an aliased namespace (`:as s`), a full namespace, and kebab-case locals. With the fix reverted, it reproduces the bug — at `(s/|)` the baseline offers:

```
[t, f, catch, cat, def, defexception*, defexception, definterface*, definterface, defstruct*, …]
```

- [x] `./gradlew build --rerun-tasks` from clean — **1150 tests, 0 failures**
- [x] Baseline reproduces the bug; fix resolves it
- [x] `./gradlew runIde` — verified in the sandbox: deleting `upper-case` from `(s/upper-case t)` and hitting `Ctrl+Space` now offers **only** `s/…` functions
