### PR TITLE
ref: split the largest classes along SRP lines

### DIFF
--- a/src/main/kotlin/org/phellang/completion/infrastructure/PhelProjectCompletionHelper.kt
+++ b/src/main/kotlin/org/phellang/completion/infrastructure/PhelProjectCompletionHelper.kt
@@ -1,16 +1,12 @@
 package org.phellang.completion.infrastructure
 
 import com.intellij.codeInsight.completion.CompletionResultSet
-import com.intellij.psi.util.PsiTreeUtil
 import org.phellang.registry.PhelProjectSymbol
 import org.phellang.registry.SymbolType
 import org.phellang.registry.indexing.PhelProjectSymbolIndex
-import org.phellang.language.psi.PhelForm
-import org.phellang.language.psi.PhelKeyword
 import org.phellang.language.psi.PhelList
 import org.phellang.language.psi.PhelNamespaceUtils
-import org.phellang.language.psi.PhelProjectNamespaceFinder
-import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.PhelRequireClauseAnalyzer
 import org.phellang.language.psi.files.PhelFile
 import org.phellang.registry.PhelCompletionPriority
 
@@ -21,7 +17,7 @@ object PhelProjectCompletionHelper {
         result: CompletionResultSet, file: PhelFile, aliasMap: Map<String, String>
     ) {
         val index = PhelProjectSymbolIndex.getInstance(file.project)
-        val importedNamespaces = extractImportedNamespaces(file)
+        val importedNamespaces = PhelRequireClauseAnalyzer.imports(file)
         val currentFileNamespace = PhelNamespaceUtils.findNamespaceDeclaration(file)?.let {
             extractNamespaceFromDeclaration(it)
         }
@@ -70,64 +66,12 @@ object PhelProjectCompletionHelper {
         }
     }
 
-    private fun extractImportedNamespaces(file: PhelFile): List<ImportInfo> {
-        val imports = mutableListOf<ImportInfo>()
-        val nsDeclaration = PhelNamespaceUtils.findNamespaceDeclaration(file) ?: return imports
-        val requireForms = PhelNamespaceUtils.findRequireForms(nsDeclaration)
-
-        for (requireForm in requireForms) {
-            val forms = requireForm.forms
-
-            // Skip the :require keyword (first form)
-            var i = 1
-            while (i < forms.size) {
-                val form = forms[i]
-
-                // Get the namespace symbol
-                val namespaceSymbol = if (form is PhelSymbol) form
-                else PsiTreeUtil.findChildOfType(form, PhelSymbol::class.java)
-
-                if (namespaceSymbol != null) {
-                    val fullNamespace = namespaceSymbol.text
-                    val shortNamespace = PhelProjectNamespaceFinder.extractShortNamespace(fullNamespace)
-                    var alias: String?
-
-                    // Check if next form is :as keyword
-                    if (i + 1 < forms.size) {
-                        val nextForm = forms[i + 1]
-                        val asKeyword =
-                            nextForm as? PhelKeyword ?: PsiTreeUtil.findChildOfType(nextForm, PhelKeyword::class.java)
-
-                        if (asKeyword?.text == ":as" && i + 2 < forms.size) {
-                            // Get the alias symbol
-                            val aliasForm = forms[i + 2]
-                            val aliasSymbol = if (aliasForm is PhelSymbol) aliasForm
-                            else PsiTreeUtil.findChildOfType(aliasForm, PhelSymbol::class.java)
-
-                            if (aliasSymbol != null) {
-                                alias = aliasSymbol.text
-                                i += 3  // Skip namespace, :as, and alias
-                                imports.add(ImportInfo(fullNamespace, shortNamespace, alias))
-                                continue
-                            }
-                        }
-                    }
-
-                    imports.add(ImportInfo(fullNamespace, shortNamespace, null))
-                }
-                i++
-            }
-        }
-
-        return imports
-    }
-
     private fun extractNamespaceFromDeclaration(nsDeclaration: PhelList): String? {
         return PhelNamespaceUtils.extractShortNamespaceFromDeclaration(nsDeclaration)
     }
 
     private fun transformWithAlias(
-        symbol: PhelProjectSymbol, importInfo: ImportInfo, aliasMap: Map<String, String>
+        symbol: PhelProjectSymbol, importInfo: PhelRequireClauseAnalyzer.RequireImport, aliasMap: Map<String, String>
     ): String {
         // If the import has an alias, use it
         if (importInfo.alias != null) {
@@ -146,15 +90,6 @@ object PhelProjectCompletionHelper {
     private fun addProjectSymbolCompletion(
         result: CompletionResultSet, symbol: PhelProjectSymbol, displayName: String
     ) {
-        val priority = when (symbol.type) {
-            SymbolType.FUNCTION -> PhelCompletionPriority.PROJECT_SYMBOLS
-            SymbolType.MACRO -> PhelCompletionPriority.PROJECT_SYMBOLS
-            SymbolType.VALUE -> PhelCompletionPriority.PROJECT_SYMBOLS
-            SymbolType.STRUCT -> PhelCompletionPriority.PROJECT_SYMBOLS
-            SymbolType.INTERFACE -> PhelCompletionPriority.PROJECT_SYMBOLS
-            SymbolType.EXCEPTION -> PhelCompletionPriority.PROJECT_SYMBOLS
-        }
-
         val description = when (symbol.type) {
             SymbolType.FUNCTION -> "function"
             SymbolType.MACRO -> "macro"
@@ -165,11 +100,8 @@ object PhelProjectCompletionHelper {
         }
 
         PhelCompletionUtils.addRankedCompletionWithNamespace(
-            result, displayName, symbol.signature, description, priority, symbol.namespace
+            result, displayName, symbol.signature, description, PhelCompletionPriority.PROJECT_SYMBOLS, symbol.namespace
         )
     }
 
-    private data class ImportInfo(
-        val fullNamespace: String, val shortNamespace: String, val alias: String?
-    )
 }

--- a/src/main/kotlin/org/phellang/core/psi/PhelFormWalker.kt
+++ b/src/main/kotlin/org/phellang/core/psi/PhelFormWalker.kt
@@ -1,0 +1,45 @@
+package org.phellang.core.psi
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.language.psi.PhelAccess
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.PhelVec
+
+/**
+ * Walking the enclosing forms of a symbol, and reading a form's head.
+ *
+ * Both are fiddly because a head or a parameter may be a bare [PhelSymbol] or the same symbol
+ * wrapped in a [PhelAccess] (the reader's interop-access form), and because `.children` on a list
+ * mixes forms with wrappers. Every analyzer needs this, and each used to re-derive it.
+ */
+internal object PhelFormWalker {
+
+    /** The [PhelList] ancestors of [element], innermost first. */
+    fun enclosingLists(element: PsiElement): Sequence<PhelList> = generateSequence(element.parent) { it.parent }
+        .filterIsInstance<PhelList>()
+
+    /** The text of a list's first element — `defn` for `(defn foo [])` — or null when it has no head symbol. */
+    fun headText(list: PhelList): String? = list.children.firstOrNull()?.let(::symbolTextOf)
+
+    /** The symbol text of [element], whether it is a symbol, an access wrapper, or a form around one. */
+    fun symbolTextOf(element: PsiElement): String? = when (element) {
+        is PhelSymbol -> element.text
+        is PhelAccess -> element.text
+        else -> PsiTreeUtil.findChildOfType(element, PhelSymbol::class.java)?.text
+    }
+
+    /** True when [element] can name a symbol — i.e. it is a symbol or the access wrapper around one. */
+    fun isSymbolLike(element: PsiElement): Boolean = element is PhelSymbol || element is PhelAccess
+
+    /** The vector at [element], whether it IS one or wraps one. */
+    fun vectorOf(element: PsiElement): PhelVec? = when (element) {
+        is PhelVec -> element
+        else -> PsiTreeUtil.findChildOfType(element, PhelVec::class.java)
+    }
+
+    /** True when [candidate] either IS [target] or is the form wrapper around it. */
+    fun isSameOrWrapperOf(candidate: PsiElement?, target: PhelVec): Boolean =
+        candidate === target || candidate === target.parent
+}

--- a/src/main/kotlin/org/phellang/core/psi/PhelLetBindingAnalyzer.kt
+++ b/src/main/kotlin/org/phellang/core/psi/PhelLetBindingAnalyzer.kt
@@ -1,0 +1,56 @@
+package org.phellang.core.psi
+
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelSpecialForms
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.PhelVec
+import org.phellang.language.psi.utils.PhelPsiUtils
+
+/**
+ * Bindings introduced by `let`-like forms: `(let [x 1] …)`, `loop`, `for`, `binding`, `when-let`.
+ *
+ * A binding vector alternates names and values — `[name1 value1 name2 value2]` — so only the even
+ * positions declare anything.
+ */
+internal object PhelLetBindingAnalyzer {
+
+    private val LET_LIKE_FORMS = PhelSpecialForms.LET_LIKE
+
+    /** True when [symbol] IS one of the names a let-like form binds. */
+    fun isLetBinding(symbol: PhelSymbol): Boolean {
+        val bindingVec = PsiTreeUtil.getParentOfType(symbol, PhelVec::class.java) ?: return false
+        val containingList = PsiTreeUtil.getParentOfType(bindingVec, PhelList::class.java) ?: return false
+
+        val forms = PsiTreeUtil.getChildrenOfType(containingList, org.phellang.language.psi.PhelForm::class.java)
+        if (forms == null || forms.size < 2) return false
+
+        val head = PhelPsiUtils.asSymbol(forms[0]) ?: return false
+        if (head.text !in LET_LIKE_FORMS) return false
+
+        // The vector must be the form's *binding* vector (its second element), reached either
+        // directly or through a PhelForm wrapper — not some vector in the body.
+        if (!PhelFormWalker.isSameOrWrapperOf(forms[1], bindingVec)) return false
+
+        val bindings = PsiTreeUtil.getChildrenOfType(bindingVec, org.phellang.language.psi.PhelForm::class.java)
+            ?: return false
+
+        return (bindings.indices step 2).any { PhelPsiUtils.asSymbol(bindings[it]) === symbol }
+    }
+
+    /** True when [symbolText] names a binding of some enclosing let-like form — i.e. a *reference*. */
+    fun isReferenceToLetBinding(symbol: PhelSymbol, symbolText: String): Boolean {
+        return PhelFormWalker.enclosingLists(symbol)
+            .filter { PhelFormWalker.headText(it) in LET_LIKE_FORMS }
+            .mapNotNull { it.children.getOrNull(1) as? PhelVec }
+            .any { bindingVec -> bindsName(bindingVec, symbolText) }
+    }
+
+    private fun bindsName(bindingVec: PhelVec, symbolText: String): Boolean {
+        val children = bindingVec.children
+        return (children.indices step 2).any { i ->
+            val child = children[i]
+            PhelFormWalker.isSymbolLike(child) && child.text == symbolText
+        }
+    }
+}

--- a/src/main/kotlin/org/phellang/core/psi/PhelLocalBindingScope.kt
+++ b/src/main/kotlin/org/phellang/core/psi/PhelLocalBindingScope.kt
@@ -1,0 +1,47 @@
+package org.phellang.core.psi
+
+import com.intellij.psi.PsiElement
+import org.phellang.language.psi.PhelForm
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelSpecialForms
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.PhelVec
+import org.phellang.language.psi.utils.PhelPsiUtils
+
+/**
+ * Whether a name is bound locally — by an enclosing `let`/`loop`/`for`/`binding`, or as a function
+ * parameter — at the point [symbol] appears.
+ *
+ * Both the arity inspection and the parameter-hint provider need this to suppress output for a name
+ * that shadows a same-named core function, and had identical copies of it.
+ */
+internal object PhelLocalBindingScope {
+
+    private val BINDING_INTRO_FORMS = PhelSpecialForms.LET_LIKE
+    private val FUNCTION_INTRO_FORMS = PhelSpecialForms.FUNCTION_DEFINING
+
+    fun resolvesToLocalBinding(symbol: PhelSymbol, name: String): Boolean {
+        var current: PsiElement? = symbol.parent
+        while (current != null) {
+            if (current is PhelList) {
+                val forms = current.forms
+                val head = PhelPsiUtils.asSymbol(forms.firstOrNull())?.text
+                if (head in BINDING_INTRO_FORMS && bindingVecContains(forms, name)) return true
+                if (head in FUNCTION_INTRO_FORMS && paramVecContains(forms, name)) return true
+            }
+            current = current.parent
+        }
+        return false
+    }
+
+    /** Names sit at the even positions of a `[name value …]` binding vector. */
+    private fun bindingVecContains(forms: List<PhelForm>, name: String): Boolean {
+        val bindings = (forms.getOrNull(1) as? PhelVec)?.forms ?: return false
+        return (bindings.indices step 2).any { PhelPsiUtils.asSymbol(bindings[it])?.text == name }
+    }
+
+    private fun paramVecContains(forms: List<PhelForm>, name: String): Boolean {
+        val paramVec = forms.drop(1).firstNotNullOfOrNull { it as? PhelVec } ?: return false
+        return paramVec.forms.any { PhelPsiUtils.asSymbol(it)?.text == name }
+    }
+}

--- a/src/main/kotlin/org/phellang/core/psi/PhelLocalFunctionIndex.kt
+++ b/src/main/kotlin/org/phellang/core/psi/PhelLocalFunctionIndex.kt
@@ -1,0 +1,66 @@
+package org.phellang.core.psi
+
+import com.intellij.openapi.util.Key
+import com.intellij.psi.util.CachedValue
+import com.intellij.psi.util.CachedValueProvider
+import com.intellij.psi.util.CachedValuesManager
+import com.intellij.psi.util.PsiModificationTracker
+import org.phellang.language.psi.PhelAccess
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelSpecialForms
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.files.PhelFile
+
+/** The names of functions a file defines, used to paint a call to one of them as a local reference. */
+internal object PhelLocalFunctionIndex {
+
+    private val LOCAL_FUNCTION_NAMES_KEY: Key<CachedValue<Set<String>>> = Key.create("phel.localFunctionNames")
+
+    private val FUNCTION_DEFINING_FORMS = PhelSpecialForms.FUNCTION_DEFINING
+
+    /** True when [symbolText] calls a function this file defines — and [symbol] is not that definition. */
+    fun isReferenceToLocalFunction(symbol: PhelSymbol, symbolText: String, definitionForms: Set<String>): Boolean {
+        if (isFunctionName(symbol, definitionForms)) return false
+
+        val file = symbol.containingFile as? PhelFile ?: return false
+        return symbolText in namesDefinedIn(file)
+    }
+
+    /**
+     * Top-level `fn`/`defn`-family names in [file].
+     *
+     * Cached: highlighting probes this once per regular symbol, and re-walking every top-level form
+     * each time would make the scan quadratic in the size of the file.
+     */
+    private fun namesDefinedIn(file: PhelFile): Set<String> =
+        CachedValuesManager.getCachedValue(file, LOCAL_FUNCTION_NAMES_KEY) {
+            CachedValueProvider.Result.create(
+                computeNames(file),
+                PsiModificationTracker.MODIFICATION_COUNT,
+            )
+        }
+
+    private fun computeNames(file: PhelFile): Set<String> = file.children
+        .filterIsInstance<PhelList>()
+        .filter { PhelFormWalker.headText(it) in FUNCTION_DEFINING_FORMS }
+        .mapNotNull { it.children.getOrNull(1) }
+        .filter(PhelFormWalker::isSymbolLike)
+        .mapNotNull { it.text }
+        .toSet()
+
+    /** True when [symbol] is the *name* in `(defn <symbol> …)` rather than a call to it. */
+    private fun isFunctionName(symbol: PhelSymbol, definitionForms: Set<String>): Boolean {
+        val parent = symbol.parent
+
+        // The name may be wrapped in a PhelAccess, in which case the list is one level further up.
+        val list = if (parent is PhelAccess) parent.parent as? PhelList else parent as? PhelList
+        list ?: return false
+
+        val children = list.children
+        if (children.size < 2) return false
+        if (PhelFormWalker.headText(list) !in definitionForms) return false
+
+        val second = children[1]
+        return second === symbol || (second is PhelAccess && second === parent)
+    }
+}

--- a/src/main/kotlin/org/phellang/core/psi/PhelParameterAnalyzer.kt
+++ b/src/main/kotlin/org/phellang/core/psi/PhelParameterAnalyzer.kt
@@ -1,0 +1,132 @@
+package org.phellang.core.psi
+
+import com.intellij.openapi.util.Key
+import com.intellij.psi.util.CachedValue
+import com.intellij.psi.util.CachedValueProvider
+import com.intellij.psi.util.CachedValuesManager
+import com.intellij.psi.util.PsiModificationTracker
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.language.psi.PhelForm
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelSpecialForms
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.PhelVec
+
+/** Everything about function parameters: locating the parameter vector, and naming what it binds. */
+internal object PhelParameterAnalyzer {
+
+    private val FUNCTION_PARAMS_KEY: Key<CachedValue<Set<String>>> = Key.create("phel.functionParameters")
+
+    private val FUNCTION_DEFINING_FORMS = PhelSpecialForms.FUNCTION_DEFINING
+
+    /** True when [symbol] is declared in the parameter vector of a function-defining form. */
+    fun isFunctionParameter(symbol: PhelSymbol, excludeSymbols: Set<String>): Boolean {
+        val paramVec = enclosingVector(symbol) ?: return false
+        if (!isParameterVector(paramVec)) return false
+
+        return symbol.text !in excludeSymbols
+    }
+
+    /** The parameter names visible to [symbol] from its enclosing function, empty when outside one. */
+    fun parametersInScopeOf(symbol: PhelSymbol): Set<String> {
+        val function = enclosingFunction(symbol) ?: return emptySet()
+        return parameterNamesOf(function)
+    }
+
+    /**
+     * The parameter vector a function-defining form declares.
+     *
+     * `fn` carries it at index 1; `defn` and friends carry the first vector after the name, past any
+     * docstring or metadata — `(defn name "doc" {:meta} [params] …)`.
+     */
+    @JvmStatic
+    fun findParameterVector(functionList: PhelList): PhelVec? {
+        val children = functionList.children
+        val functionType = children.firstOrNull()?.let(PhelFormWalker::symbolTextOf) ?: return null
+
+        return when (functionType) {
+            "fn" -> children.getOrNull(1)?.let(PhelFormWalker::vectorOf)
+            "defn", "defn-", "defmacro", "defmacro-" ->
+                children.drop(2).firstNotNullOfOrNull(PhelFormWalker::vectorOf)
+
+            else -> null
+        }
+    }
+
+    /** Names bound by every arity of [functionList]. Cached: highlighting asks once per symbol. */
+    private fun parameterNamesOf(functionList: PhelList): Set<String> =
+        CachedValuesManager.getCachedValue(functionList, FUNCTION_PARAMS_KEY) {
+            CachedValueProvider.Result.create(
+                computeParameterNames(functionList),
+                PsiModificationTracker.MODIFICATION_COUNT,
+            )
+        }
+
+    private fun computeParameterNames(functionList: PhelList): Set<String> {
+        val names = mutableSetOf<String>()
+
+        // Single arity: the vector sits directly in the function list.
+        findParameterVector(functionList)?.let { names += namesIn(it) }
+
+        // Multi-arity: each child is an arity list `([params] body)` whose head is the vector.
+        functionList.children
+            .mapNotNull { it as? PhelList ?: PsiTreeUtil.findChildOfType(it, PhelList::class.java) }
+            .mapNotNull { arity -> arity.children.firstOrNull()?.let(PhelFormWalker::vectorOf) }
+            .forEach { names += namesIn(it) }
+
+        return names
+    }
+
+    /** `&` marks a rest parameter rather than naming one, so it is never a binding. */
+    private fun namesIn(paramVec: PhelVec): List<String> = paramVec.children
+        .filter(PhelFormWalker::isSymbolLike)
+        .mapNotNull { it.text }
+        .filter { it.isNotEmpty() && it != "&" }
+
+    fun enclosingVector(symbol: PhelSymbol): PhelVec? =
+        PsiTreeUtil.getParentOfType(symbol, PhelVec::class.java)
+
+    private fun enclosingFunction(symbol: PhelSymbol): PhelList? = PhelFormWalker.enclosingLists(symbol)
+        .firstOrNull { PhelFormWalker.headText(it) in FUNCTION_DEFINING_FORMS }
+
+    /**
+     * True when [paramVec] is a function's parameter vector rather than an ordinary vector in its
+     * body. Two shapes qualify: the vector of a single-arity form, and the head of an arity list
+     * inside a multi-arity form — `(defn name ([] body) ([x] body))`.
+     */
+    private fun isParameterVector(paramVec: PhelVec): Boolean {
+        val immediate = PsiTreeUtil.getParentOfType(paramVec, PhelList::class.java) ?: return false
+        val immediateForms = PsiTreeUtil.getChildrenOfType(immediate, PhelForm::class.java) ?: return false
+        val head = immediateForms.firstOrNull()?.let(PhelFormWalker::symbolTextOf)
+
+        if (head in FUNCTION_DEFINING_FORMS) {
+            return when (head) {
+                "fn" -> PhelFormWalker.isSameOrWrapperOf(immediateForms.getOrNull(1), paramVec)
+                else -> isDefnParameterVector(immediateForms, paramVec)
+            }
+        }
+
+        // Multi-arity: paramVec heads an arity list whose parent is the function-defining form.
+        if (PhelFormWalker.isSameOrWrapperOf(immediateForms.firstOrNull(), paramVec)) {
+            val outer = PsiTreeUtil.getParentOfType(immediate, PhelList::class.java) ?: return false
+            val outerForms = PsiTreeUtil.getChildrenOfType(outer, PhelForm::class.java) ?: return false
+            return outerForms.firstOrNull()?.let(PhelFormWalker::symbolTextOf) in FUNCTION_DEFINING_FORMS
+        }
+
+        return false
+    }
+
+    /**
+     * The parameter vector of a `defn` is the *first* vector after the name. Meeting a different
+     * vector first means [targetVec] lives in the body, not the signature.
+     */
+    private fun isDefnParameterVector(forms: Array<PhelForm>, targetVec: PhelVec): Boolean {
+        for (form in forms.drop(2)) {
+            if (PhelFormWalker.isSameOrWrapperOf(form, targetVec)) return true
+
+            val other = PsiTreeUtil.findChildOfType(form, PhelVec::class.java)
+            if (other != null && other !== targetVec) return false
+        }
+        return false
+    }
+}

--- a/src/main/kotlin/org/phellang/core/psi/PhelSymbolAnalyzer.kt
+++ b/src/main/kotlin/org/phellang/core/psi/PhelSymbolAnalyzer.kt
@@ -1,31 +1,26 @@
 package org.phellang.core.psi
 
-import com.intellij.openapi.util.Key
-import com.intellij.psi.PsiElement
-import com.intellij.psi.util.CachedValue
-import com.intellij.psi.util.CachedValueProvider
-import com.intellij.psi.util.CachedValuesManager
-import com.intellij.psi.util.PsiModificationTracker
 import com.intellij.psi.util.PsiTreeUtil
-import org.phellang.registry.PhelFunctionRegistry
 import org.phellang.registry.PhelCompletionPriority
-import org.phellang.language.psi.*
-import org.phellang.language.psi.files.PhelFile
+import org.phellang.registry.PhelFunctionRegistry
+import org.phellang.language.psi.PhelForm
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.PhelVec
 import org.phellang.language.psi.utils.SymbolCategory
-import org.phellang.language.psi.utils.PhelPsiUtils
 
+/**
+ * What a Phel symbol *is* — a special form, a definition, a parameter, a binding, or a reference to
+ * one. The questions highlighting, completion and resolution all ask.
+ *
+ * The analysis itself lives in focused collaborators; this is the API they are reached through:
+ *
+ * * [PhelParameterAnalyzer]   — parameter vectors and the names they bind
+ * * [PhelLetBindingAnalyzer]  — `let`-like binding vectors
+ * * [PhelLocalFunctionIndex]  — functions defined in the current file
+ * * [PhelFormWalker]          — walking enclosing forms and reading their heads
+ */
 object PhelSymbolAnalyzer {
-
-    private val LOCAL_FUNCTION_NAMES_KEY: Key<CachedValue<Set<String>>> =
-        Key.create("phel.localFunctionNames")
-    private val FUNCTION_PARAMS_KEY: Key<CachedValue<Set<String>>> =
-        Key.create("phel.functionParameters")
-
-    /** Forms that introduce a parameter vector — used by isFunctionParameter. */
-    private val FUNCTION_DEFINING_FORMS = PhelSpecialForms.FUNCTION_DEFINING
-
-    /** Forms that introduce a binding vector — used by isLetBinding. */
-    private val LET_LIKE_FORMS = PhelSpecialForms.LET_LIKE
 
     /** Top-level forms that bind a name in their second position (the symbol being defined). */
     private val DEFINITION_FORMS = setOf(
@@ -33,6 +28,7 @@ object PhelSymbolAnalyzer {
         "defstruct", "definterface", "defexception", "declare", "deftest",
     )
 
+    /** True when [symbolText] belongs to [category] according to the generated function registry. */
     @JvmStatic
     fun isSymbolType(symbolText: String?, category: SymbolCategory): Boolean {
         if (symbolText == null) return false
@@ -47,458 +43,74 @@ object PhelSymbolAnalyzer {
         return PhelFunctionRegistry.hasFunctionWithName(priority, symbolText)
     }
 
+    /** True when [symbol] declares a name: a parameter, a `let` binding, or a top-level definition. */
     @JvmStatic
     fun isDefinition(symbol: PhelSymbol): Boolean {
-        // Check if this symbol is a function parameter
-        if (isFunctionParameter(symbol)) {
-            return true
-        }
+        if (isFunctionParameter(symbol) || isLetBinding(symbol)) return true
 
-        // Check if this symbol is a let binding
-        if (isLetBinding(symbol)) {
-            return true
-        }
+        return isDefinedName(symbol)
+    }
 
-        // Check if this symbol is the name being defined in a special form
+    /** True when [symbol] is the name in `(def <symbol> …)` / `(defn <symbol> …)`. */
+    private fun isDefinedName(symbol: PhelSymbol): Boolean {
         val containingList = PsiTreeUtil.getParentOfType(symbol, PhelList::class.java) ?: return false
 
         val firstForm = PsiTreeUtil.findChildOfType(containingList, PhelForm::class.java) ?: return false
+        val head = PsiTreeUtil.findChildOfType(firstForm, PhelSymbol::class.java) ?: return false
+        if (head.text !in DEFINITION_FORMS) return false
 
-        val firstSymbol = PsiTreeUtil.findChildOfType(firstForm, PhelSymbol::class.java) ?: return false
-
-        if (firstSymbol.text !in DEFINITION_FORMS) {
-            return false
-        }
-
-        // Check if this symbol is the second element (the name being defined)
         val forms = PsiTreeUtil.getChildrenOfType(containingList, PhelForm::class.java) ?: return false
         if (forms.size <= 1) return false
 
         val definedName = PsiTreeUtil.findChildOfType(forms[1], PhelSymbol::class.java) ?: return false
-
         return symbol === definedName
     }
 
     @JvmStatic
-    fun isInParameterVector(symbol: PhelSymbol): Boolean {
-        return isFunctionParameter(symbol, excludeSymbols = emptySet())
-    }
+    fun isInParameterVector(symbol: PhelSymbol): Boolean =
+        PhelParameterAnalyzer.isFunctionParameter(symbol, excludeSymbols = emptySet())
+
+    /** `&` introduces a rest parameter rather than naming one, so it is excluded by default. */
+    @JvmStatic
+    fun isFunctionParameter(symbol: PhelSymbol, excludeSymbols: Set<String> = setOf("&")): Boolean =
+        PhelParameterAnalyzer.isFunctionParameter(symbol, excludeSymbols)
 
     @JvmStatic
-    fun isFunctionParameter(symbol: PhelSymbol, excludeSymbols: Set<String> = setOf("&")): Boolean {
-        val paramVec = findContainingParameterVector(symbol) ?: return false
-
-        // Check if this vector is a parameter vector in a function definition
-        if (!isParameterVectorInFunctionDefinition(paramVec)) {
-            return false
-        }
-
-        // Additional check: exclude specified symbols
-        return symbol.text !in excludeSymbols
-    }
+    fun isLetBinding(symbol: PhelSymbol): Boolean = PhelLetBindingAnalyzer.isLetBinding(symbol)
 
     @JvmStatic
-    fun isLetBinding(symbol: PhelSymbol): Boolean {
-        // Check if symbol is inside a binding vector
-        val bindingVec = PsiTreeUtil.getParentOfType(symbol, PhelVec::class.java) ?: return false
+    fun findParameterVector(functionList: PhelList): PhelVec? =
+        PhelParameterAnalyzer.findParameterVector(functionList)
 
-        // Check if the binding vector is part of a let form
-        val containingList = PsiTreeUtil.getParentOfType(bindingVec, PhelList::class.java) ?: return false
-
-        val forms = PsiTreeUtil.getChildrenOfType(containingList, PhelForm::class.java)
-        if (forms == null || forms.size < 2) return false
-
-        // Check if first symbol is a binding form
-        val firstSymbol = PhelPsiUtils.asSymbol(forms[0])
-            ?: return false
-        if (firstSymbol.text !in LET_LIKE_FORMS) return false
-
-        // Check if binding vector is at forms[1] — either directly or via a PhelForm wrapper.
-        if (forms[1] !== bindingVec && forms[1] !== bindingVec.parent) return false
-
-        // Binding symbols sit at even indices: [name value name value ...]
-        val bindings = PsiTreeUtil.getChildrenOfType(bindingVec, PhelForm::class.java) ?: return false
-
-        var i = 0
-        while (i < bindings.size) {
-            val bindingSymbol = PhelPsiUtils.asSymbol(bindings[i])
-            if (bindingSymbol === symbol) {
-                return true
-            }
-            i += 2
-        }
-
-        return false
-    }
-
+    /** True when [symbol] *uses* a local binding — a binding's own declaration is not a reference. */
     @JvmStatic
     fun isParameterReference(symbol: PhelSymbol): Boolean {
         val symbolText = symbol.text ?: return false
+        if (isFunctionParameter(symbol) || isLetBinding(symbol)) return false
 
-        // A binding/parameter *definition* is not a reference to one.
-        if (isFunctionParameter(symbol) || isLetBinding(symbol)) {
-            return false
-        }
-
-        return isLocalReferenceOnly(symbol, symbolText)
+        return isLocalReference(symbol, symbolText)
     }
 
     /**
-     * True when [symbol] is a fn/let binding definition **or** a reference to one — i.e. any
-     * occurrence highlighting paints as a local symbol. Computes each underlying check once;
-     * prefer this over calling `isParameterReference`, `isFunctionParameter` and `isLetBinding`
-     * separately, which re-walks the PSI for the two definition checks.
+     * True when [symbol] is a local binding *or* a reference to one — i.e. anything occurrence
+     * highlighting paints as local.
+     *
+     * Prefer this over calling [isParameterReference], [isFunctionParameter] and [isLetBinding]
+     * separately: it computes each underlying check once instead of re-walking the PSI for them.
      */
     @JvmStatic
     fun isLocalBindingOrReference(symbol: PhelSymbol): Boolean {
         val symbolText = symbol.text ?: return false
-        if (isFunctionParameter(symbol) || isLetBinding(symbol)) {
-            return true
-        }
-        return isLocalReferenceOnly(symbol, symbolText)
+        if (isFunctionParameter(symbol) || isLetBinding(symbol)) return true
+
+        return isLocalReference(symbol, symbolText)
     }
 
-    /** Reference-only lookup: assumes the caller already ruled out a binding/param definition. */
-    private fun isLocalReferenceOnly(symbol: PhelSymbol, symbolText: String): Boolean {
-        // Look for function parameters in the containing function
-        val containingFunction = findContainingFunction(symbol)
-        if (containingFunction != null) {
-            val parameters = extractFunctionParameters(containingFunction)
-            if (parameters.contains(symbolText)) {
-                return true
-            }
-        }
+    /** Assumes the caller has already ruled out [symbol] being a binding's own declaration. */
+    private fun isLocalReference(symbol: PhelSymbol, symbolText: String): Boolean {
+        if (symbolText in PhelParameterAnalyzer.parametersInScopeOf(symbol)) return true
+        if (PhelLetBindingAnalyzer.isReferenceToLetBinding(symbol, symbolText)) return true
 
-        // Look for let bindings in the containing scopes
-        if (isReferenceToLetBinding(symbol, symbolText)) {
-            return true
-        }
-
-        // Look for references to locally defined functions in the same file
-        return isReferenceToLocalFunction(symbol, symbolText)
+        return PhelLocalFunctionIndex.isReferenceToLocalFunction(symbol, symbolText, DEFINITION_FORMS)
     }
-
-    private fun findContainingFunction(symbol: PhelSymbol): PhelList? {
-        var current = symbol.parent
-        while (current != null) {
-            // Skip non-list elements
-            if (current !is PhelList) {
-                current = current.parent
-                continue
-            }
-
-            val children = current.children
-            if (children.isEmpty()) {
-                current = current.parent
-                continue
-            }
-
-            val firstChild = children[0]
-            if (firstChild !is PhelSymbol && firstChild !is PhelAccess) {
-                current = current.parent
-                continue
-            }
-
-            val functionType = firstChild.text
-            if (functionType in FUNCTION_DEFINING_FORMS) {
-                return current
-            }
-
-            current = current.parent
-        }
-        return null
-    }
-
-    private fun extractFunctionParameters(functionList: PhelList): Set<String> {
-        // Cached per function: isLocalReferenceOnly calls this for every regular symbol inside
-        // a function, and the parameter set is the same for all of them.
-        return CachedValuesManager.getCachedValue(functionList, FUNCTION_PARAMS_KEY) {
-            CachedValueProvider.Result.create(
-                computeFunctionParameters(functionList),
-                PsiModificationTracker.MODIFICATION_COUNT,
-            )
-        }
-    }
-
-    private fun computeFunctionParameters(functionList: PhelList): Set<String> {
-        val parameters = mutableSetOf<String>()
-
-        // Single-arity: paramVec lives directly in the function list.
-        findParameterVector(functionList)?.let { collectParameterNames(it, parameters) }
-
-        // Multi-arity: every child arity is a list `([params] body)` whose head is the param vec.
-        for (child in functionList.children) {
-            val arityList = (child as? PhelList)
-                ?: PsiTreeUtil.findChildOfType(child, PhelList::class.java)
-                ?: continue
-            val arityChildren = arityList.children
-            if (arityChildren.isEmpty()) continue
-            val arityHeadVec = (arityChildren[0] as? PhelVec)
-                ?: PsiTreeUtil.findChildOfType(arityChildren[0], PhelVec::class.java)
-                ?: continue
-            collectParameterNames(arityHeadVec, parameters)
-        }
-
-        return parameters
-    }
-
-    private fun collectParameterNames(paramVec: PhelVec, into: MutableSet<String>) {
-        for (paramChild in paramVec.children) {
-            if (paramChild !is PhelSymbol && paramChild !is PhelAccess) continue
-            val paramName = paramChild.text
-            if (paramName.isNullOrEmpty() || paramName == "&") continue
-            into.add(paramName)
-        }
-    }
-
-    private fun isReferenceToLetBinding(symbol: PhelSymbol, symbolText: String): Boolean {
-        var current = symbol.parent
-        while (current != null) {
-            // Skip non-list elements
-            if (current !is PhelList) {
-                current = current.parent
-                continue
-            }
-
-            val children = current.children
-            if (children.isEmpty()) {
-                current = current.parent
-                continue
-            }
-
-            val firstChild = children[0]
-            if (firstChild !is PhelSymbol && firstChild !is PhelAccess) {
-                current = current.parent
-                continue
-            }
-
-            val bindingType = firstChild.text
-            if (bindingType !in LET_LIKE_FORMS) {
-                current = current.parent
-                continue
-            }
-
-            // Check if symbolText is in the binding vector
-            if (children.size <= 1) {
-                current = current.parent
-                continue
-            }
-
-            val bindingElement = children[1]
-            if (bindingElement !is PhelVec) {
-                current = current.parent
-                continue
-            }
-
-            // Search for the symbol in binding positions (even indices)
-            val bindingChildren = bindingElement.children
-            for (i in bindingChildren.indices step 2) {
-                val bindingChild = bindingChildren[i]
-                if ((bindingChild is PhelSymbol || bindingChild is PhelAccess) && bindingChild.text == symbolText) {
-                    return true
-                }
-            }
-
-            current = current.parent
-        }
-        return false
-    }
-
-    private fun isReferenceToLocalFunction(symbol: PhelSymbol, symbolText: String): Boolean {
-        // Don't highlight if this is the function definition itself
-        if (isLocalFunctionDefinition(symbol)) {
-            return false
-        }
-
-        val file = symbol.containingFile as? PhelFile ?: return false
-        return symbolText in localFunctionNames(file)
-    }
-
-    /**
-     * Names of top-level `fn`/`defn`-family definitions in [file]. Highlighting probes this
-     * once per regular symbol, so the per-file scan is cached and invalidated by edits rather
-     * than re-walking every top-level form for every symbol.
-     */
-    private fun localFunctionNames(file: PhelFile): Set<String> {
-        return CachedValuesManager.getCachedValue(file, LOCAL_FUNCTION_NAMES_KEY) {
-            CachedValueProvider.Result.create(
-                computeLocalFunctionNames(file),
-                PsiModificationTracker.MODIFICATION_COUNT,
-            )
-        }
-    }
-
-    private fun computeLocalFunctionNames(file: PhelFile): Set<String> {
-        val names = HashSet<String>()
-        for (child in file.children) {
-            if (child !is PhelList) continue
-
-            val children = child.children
-            if (children.size < 2) continue
-
-            val firstChild = children[0]
-            if (firstChild !is PhelSymbol && firstChild !is PhelAccess) continue
-            if (firstChild.text !in FUNCTION_DEFINING_FORMS) continue
-
-            val secondChild = children[1]
-            if (secondChild is PhelSymbol || secondChild is PhelAccess) {
-                secondChild.text?.let { names.add(it) }
-            }
-        }
-        return names
-    }
-
-    private fun isLocalFunctionDefinition(symbol: PhelSymbol): Boolean {
-        val parent = symbol.parent
-
-        // Handle case where symbol is wrapped in PhelAccessImpl
-        val listParent = if (parent is PhelAccess) {
-            parent.parent as? PhelList
-        } else {
-            parent as? PhelList
-        }
-
-        listParent ?: return false
-        
-        val children = listParent.children
-        if (children.size < 2) return false
-        
-        val firstChild = children[0]
-        val secondChild = children[1]
-
-        // Check if this is a function definition form
-        if (firstChild !is PhelSymbol && firstChild !is PhelAccess) return false
-        
-        val functionType = firstChild.text
-        if (functionType !in DEFINITION_FORMS) return false
-
-        // Check if the symbol is the function name (second child)
-        // The symbol might be wrapped in PhelAccess, so check both direct and wrapped cases
-        val isSecondChild = secondChild == symbol || (secondChild is PhelAccess && secondChild == parent)
-        
-        return isSecondChild
-    }
-
-    @JvmStatic
-    fun findParameterVector(functionList: PhelList): PhelVec? {
-        val children = functionList.children
-        if (children.isEmpty()) return null
-
-        val functionType = symbolTextOf(children[0]) ?: return null
-
-        return when (functionType) {
-            "fn" -> {
-                // For (fn [params] ...), parameter vector is at index 1
-                if (children.size >= 2) vecOf(children[1]) else null
-            }
-
-            "defn", "defn-", "defmacro", "defmacro-" -> {
-                // For defn forms, find the first vector after the function name
-                // Skip docstring and metadata: (defn name "doc" {:meta} [params] ...)
-                for (i in 2 until children.size) {
-                    val vec = vecOf(children[i])
-                    if (vec != null) return vec
-                }
-                null
-            }
-
-            else -> null
-        }
-    }
-
-    /** Returns the symbol text of [child], whether [child] is a PhelSymbol/PhelAccess directly
-     *  or a PhelForm wrapping one. */
-    private fun symbolTextOf(child: PsiElement): String? = when (child) {
-        is PhelSymbol -> child.text
-        is PhelAccess -> child.text
-        else -> PsiTreeUtil.findChildOfType(child, PhelSymbol::class.java)?.text
-    }
-
-    /** Returns the PhelVec at [child], whether [child] IS a PhelVec or wraps one in a PhelForm. */
-    private fun vecOf(child: PsiElement): PhelVec? = when (child) {
-        is PhelVec -> child
-        else -> PsiTreeUtil.findChildOfType(child, PhelVec::class.java)
-    }
-
-    /**
-     * Find the parameter vector in a defn/defn-/defmacro form.
-     * The parameter vector is the first PhelVec after the function name,
-     * skipping any docstring or metadata map.
-     */
-    private fun findParameterVectorInDefn(forms: Array<PhelForm>, targetVec: PhelVec): Boolean {
-        // Start from index 2 (after defn and function name)
-        for (i in 2 until forms.size) {
-            val form = forms[i]
-
-            // Check if this form IS our target vector
-            if (form === targetVec) {
-                return true
-            }
-
-            // Check if this form contains our target vector
-            if (form === targetVec.parent) {
-                return true
-            }
-
-            // If we encounter a vector that's not our target, it means our target
-            // is not the parameter vector (it might be inside the function body)
-            val foundVec = PsiTreeUtil.findChildOfType(form, PhelVec::class.java)
-            if (foundVec != null && foundVec !== targetVec) {
-                return false
-            }
-        }
-        return false
-    }
-
-    private fun findContainingParameterVector(symbol: PhelSymbol): PhelVec? {
-        var current = symbol.parent
-        while (current != null) {
-            if (current is PhelVec) {
-                return current
-            }
-            current = current.parent
-        }
-        return null
-    }
-
-    private fun isParameterVectorInFunctionDefinition(paramVec: PhelVec): Boolean {
-        val immediate = PsiTreeUtil.getParentOfType(paramVec, PhelList::class.java) ?: return false
-        val immediateForms = PsiTreeUtil.getChildrenOfType(immediate, PhelForm::class.java) ?: return false
-        val immediateHead = headSymbolText(immediateForms)
-
-        // Direct case: paramVec lives in the function-defining list itself.
-        //   (fn [params] body)            → paramVec at forms[1]
-        //   (defn name [params] body)     → first vec after the name (skip doc/meta)
-        //   (defmacro name [params] body) → ditto
-        if (immediateHead in FUNCTION_DEFINING_FORMS) {
-            return when (immediateHead) {
-                "fn" -> immediateForms.size >= 2 && isSameOrWrapperOf(immediateForms[1], paramVec)
-                else -> findParameterVectorInDefn(immediateForms, paramVec)
-            }
-        }
-
-        // Multi-arity case: paramVec is the head of an arity list, and the arity list's
-        // parent is a function-defining form.
-        //   (defn name ([] body) ([x] body))
-        //   (fn   ([] body) ([x] body))
-        if (immediateForms.isNotEmpty() && isSameOrWrapperOf(immediateForms[0], paramVec)) {
-            val outer = PsiTreeUtil.getParentOfType(immediate, PhelList::class.java) ?: return false
-            val outerForms = PsiTreeUtil.getChildrenOfType(outer, PhelForm::class.java) ?: return false
-            return headSymbolText(outerForms) in FUNCTION_DEFINING_FORMS
-        }
-
-        return false
-    }
-
-    /** First-position symbol text for a list's child forms, tolerant of flat/wrapped layouts. */
-    private fun headSymbolText(forms: Array<PhelForm>): String? {
-        if (forms.isEmpty()) return null
-        return (forms[0] as? PhelSymbol)?.text
-            ?: (forms[0] as? PhelAccess)?.text
-            ?: PsiTreeUtil.findChildOfType(forms[0], PhelSymbol::class.java)?.text
-    }
-
-    /** True when [candidate] either IS [target] or is the PhelForm wrapper around it. */
-    private fun isSameOrWrapperOf(candidate: PsiElement?, target: PhelVec): Boolean =
-        candidate === target || candidate === target.parent
 }

--- a/src/main/kotlin/org/phellang/documentation/resolvers/PhelDocHtml.kt
+++ b/src/main/kotlin/org/phellang/documentation/resolvers/PhelDocHtml.kt
@@ -1,0 +1,36 @@
+package org.phellang.documentation.resolvers
+
+import org.phellang.registry.PhelProjectSymbol
+
+/**
+ * Renders the hover-popup HTML. Kept apart from [PhelSymbolDocumentationResolver], which decides
+ * *which* documentation applies; this only knows how to present it.
+ */
+internal object PhelDocHtml {
+
+    /** Wraps rendered [content] as a complete popup document. */
+    fun page(content: String): String = "<html><body>$content</body></html>"
+
+    /** A local binding or parameter: just its name and the analyzer's one-line category. */
+    fun localSymbol(name: String, category: String): String =
+        "<h3>$name</h3><br />$category<br /><br />"
+
+    /** A symbol with no registry/project entry: its name and whatever description we could find. */
+    fun basic(name: String, description: String): String =
+        "<h3>$name</h3><br />$description<br /><br />"
+
+    /** A project-defined symbol: qualified name, signature, docstring and where it lives. */
+    fun projectSymbol(symbol: PhelProjectSymbol): String = buildString {
+        append("<h3>${symbol.qualifiedName}</h3><br />")
+
+        // Multi-arity signatures are newline-separated; render each on its own line.
+        append("<code>${symbol.signature.replace("\n", "<br />")}</code><br /><br />")
+
+        if (!symbol.docstring.isNullOrBlank()) {
+            append(symbol.docstring)
+            append("<br />")
+        }
+
+        append("<br /><i>${symbol.type.keyword} in ${symbol.namespace}</i><br /><br />")
+    }
+}

--- a/src/main/kotlin/org/phellang/documentation/resolvers/PhelSymbolDocumentationResolver.kt
+++ b/src/main/kotlin/org/phellang/documentation/resolvers/PhelSymbolDocumentationResolver.kt
@@ -2,7 +2,6 @@ package org.phellang.documentation.resolvers
 
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
-import org.phellang.registry.PhelProjectSymbol
 import org.phellang.completion.documentation.PhelApiDocumentation
 import org.phellang.completion.documentation.PhelBasicDocumentation
 import org.phellang.registry.indexing.PhelProjectSymbolIndex
@@ -34,7 +33,7 @@ class PhelSymbolDocumentationResolver {
             else -> resolveApiDocumentation(symbol, symbolName)
         }
 
-        return formatAsHtml(content)
+        return PhelDocHtml.page(content)
     }
 
     private fun isInsideReferVector(symbol: PhelSymbol): Boolean {
@@ -68,10 +67,8 @@ class PhelSymbolDocumentationResolver {
         return PhelSymbolAnalyzer.isLocalBindingOrReference(symbol)
     }
 
-    private fun generateLocalSymbolDoc(symbol: PhelSymbol, symbolName: String): String {
-        val category = PhelBasicDocumentation.generateBasicDocForElement(symbol)
-        return "<h3>$symbolName</h3><br />$category<br /><br />"
-    }
+    private fun generateLocalSymbolDoc(symbol: PhelSymbol, symbolName: String): String =
+        PhelDocHtml.localSymbol(symbolName, PhelBasicDocumentation.generateBasicDocForElement(symbol))
 
     private fun resolveApiDocumentation(symbol: PhelSymbol, symbolName: String): String {
         val qualifier = PhelPsiUtils.getQualifier(symbol)
@@ -127,37 +124,13 @@ class PhelSymbolDocumentationResolver {
         val index = PhelProjectSymbolIndex.getInstance(project)
         val projectSymbol = index.findSymbol(shortNamespace, functionName) ?: return null
 
-        return generateProjectSymbolDocumentation(projectSymbol)
-    }
-
-    private fun generateProjectSymbolDocumentation(symbol: PhelProjectSymbol): String {
-        return buildString {
-            // Title (qualified name)
-            append("<h3>${symbol.qualifiedName}</h3>")
-            append("<br />")
-
-            // Signature (convert newlines to <br> for multi-arity functions)
-            val signatureHtml = symbol.signature.replace("\n", "<br />")
-            append("<code>$signatureHtml</code><br /><br />")
-
-            // Description (docstring) if available
-            if (!symbol.docstring.isNullOrBlank()) {
-                append(symbol.docstring)
-                append("<br />")
-            }
-
-            // File location as subtle info
-            append("<br />")
-            append("<i>${symbol.type.keyword} in ${symbol.namespace}</i>")
-            append("<br /><br />")
-        }
+        return PhelDocHtml.projectSymbol(projectSymbol)
     }
 
     private fun generateBasicDocumentation(symbol: PhelSymbol, symbolName: String): String {
-        val docstring = extractDefinitionDocstring(symbol)
-        val category = PhelBasicDocumentation.generateBasicDocForElement(symbol)
-        val description = docstring?.takeIf { it.isNotBlank() } ?: category
-        return "<h3>$symbolName</h3><br />$description<br /><br />"
+        val docstring = extractDefinitionDocstring(symbol)?.takeIf { it.isNotBlank() }
+        val description = docstring ?: PhelBasicDocumentation.generateBasicDocForElement(symbol)
+        return PhelDocHtml.basic(symbolName, description)
     }
 
     /**
@@ -190,7 +163,4 @@ class PhelSymbolDocumentationResolver {
         return raw.substring(1, raw.length - 1)
     }
 
-    private fun formatAsHtml(content: String): String {
-        return "<html><body>$content</body></html>"
-    }
 }

--- a/src/main/kotlin/org/phellang/inlay/PhelParameterHintsProvider.kt
+++ b/src/main/kotlin/org/phellang/inlay/PhelParameterHintsProvider.kt
@@ -9,14 +9,11 @@ import com.intellij.codeInsight.hints.declarative.SharedBypassCollector
 import com.intellij.openapi.editor.Editor
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
+import org.phellang.core.psi.PhelLocalBindingScope
 import org.phellang.registry.PhelArity
 import org.phellang.registry.PhelArityResolver
 import org.phellang.registry.selectFor
-import org.phellang.language.psi.PhelForm
 import org.phellang.language.psi.PhelList
-import org.phellang.language.psi.PhelSpecialForms
-import org.phellang.language.psi.PhelSymbol
-import org.phellang.language.psi.PhelVec
 import org.phellang.language.psi.utils.PhelPsiUtils
 
 class PhelParameterHintsProvider : InlayHintsProvider {
@@ -38,7 +35,7 @@ class PhelParameterHintsProvider : InlayHintsProvider {
             if (headName.startsWith("php/") || headName.startsWith(".") || headName.startsWith("php-")) {
                 return
             }
-            if (resolvesToLocalBinding(headSymbol, headName)) return
+            if (PhelLocalBindingScope.resolvesToLocalBinding(headSymbol, headName)) return
 
             val args = forms.drop(1)
             val arities = PhelArityResolver.resolve(headSymbol.project, headName) ?: return
@@ -68,51 +65,8 @@ class PhelParameterHintsProvider : InlayHintsProvider {
             }
         }
 
-        /** True when [name] resolves to an enclosing let/loop binding or fn parameter. */
-        private fun resolvesToLocalBinding(head: PhelSymbol, name: String): Boolean {
-            var current: PsiElement? = head.parent
-            while (current != null) {
-                if (current is PhelList) {
-                    val forms = current.forms
-                    val parentHead = PhelPsiUtils.asSymbol(forms.firstOrNull())?.text
-                    if (parentHead != null) {
-                        if (parentHead in BINDING_INTRO_FORMS && bindingVecContains(forms, name)) return true
-                        if (parentHead in FUNCTION_INTRO_FORMS && paramVecContains(forms, name)) return true
-                    }
-                }
-                current = current.parent
-            }
-            return false
-        }
-
-        private fun bindingVecContains(forms: List<PhelForm>, name: String): Boolean {
-            val vec = forms.getOrNull(1) as? PhelVec ?: return false
-            val bindings = vec.forms
-            var i = 0
-            while (i < bindings.size) {
-                if (PhelPsiUtils.asSymbol(bindings[i])?.text == name) return true
-                i += 2
-            }
-            return false
-        }
-
-        private fun paramVecContains(forms: List<PhelForm>, name: String): Boolean {
-            for (form in forms.drop(1)) {
-                if (form is PhelVec) {
-                    for (p in form.forms) {
-                        if (PhelPsiUtils.asSymbol(p)?.text == name) return true
-                    }
-                    return false
-                }
-            }
-            return false
-        }
     }
 }
-
-private val BINDING_INTRO_FORMS = PhelSpecialForms.LET_LIKE
-
-private val FUNCTION_INTRO_FORMS = PhelSpecialForms.FUNCTION_DEFINING
 
 // Special forms and macros where param-name hints would be noise.
 private val SKIP_HEADS = setOf(

--- a/src/main/kotlin/org/phellang/inspection/PhelArityCallSite.kt
+++ b/src/main/kotlin/org/phellang/inspection/PhelArityCallSite.kt
@@ -1,0 +1,128 @@
+package org.phellang.inspection
+
+import com.intellij.psi.PsiElement
+import org.phellang.language.psi.PhelForm
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelSpecialForms
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.PhelVec
+import org.phellang.language.psi.utils.PhelPsiUtils
+
+/**
+ * Decides whether a list is a real function call whose argument count can be checked, or one of the
+ * many shapes where the textual count is untrustworthy or the head isn't a registry function.
+ *
+ * Every rule here exists to prevent a *false* arity warning; the arity check itself is in
+ * [PhelArityMismatchInspection]. Kept separate because "is this even a call site" is a distinct
+ * question from "does this call have the right number of arguments".
+ */
+internal object PhelArityCallSite {
+
+    /** True when the arity check must not run for [list] with head [name]. */
+    fun shouldSkip(list: PhelList, head: PhelSymbol, name: String, forms: List<PhelForm>): Boolean {
+        if (name in SKIP_HEADS) return true
+        if (name.startsWith("php/") || name.startsWith(".") || name.startsWith("php-")) return true
+        // The dummy identifier the platform injects at the caret mid-completion.
+        if (name.contains("IntelliJIdeaRulezzz")) return true
+
+        if (isInQuoteContext(list)) return true
+        if (isThreadedArgList(list)) return true
+        if (resolvesToLocalBinding(head, name)) return true
+        if (containsShortFnMarker(forms)) return true
+
+        return false
+    }
+
+    /**
+     * True when any argument is a bare `|` symbol — the marker for Phel's deprecated `|(...)`
+     * short-fn syntax. The lexer treats `|` as a plain symbol, so `|(> $ 10)` parses as two forms
+     * (a `|` symbol and a list), inflating the textual argument count. Skip rather than misreport.
+     */
+    private fun containsShortFnMarker(forms: List<PhelForm>): Boolean =
+        forms.drop(1).any { PhelPsiUtils.asSymbol(it)?.text == "|" }
+
+    /**
+     * True when [list] is a data form — inside `quote`, `var`, or a `'` / `` ` `` reader macro — and
+     * therefore not a call site.
+     */
+    private fun isInQuoteContext(list: PhelList): Boolean {
+        var current: PsiElement? = list
+        while (current != null) {
+            if (current is PhelForm && current.readerMacros.any { it.text == "'" || it.text == "`" }) {
+                return true
+            }
+            if (current is PhelList && current !== list) {
+                val head = PhelPsiUtils.asSymbol(current.forms.firstOrNull())?.text
+                if (head == "quote" || head == "var") return true
+            }
+            current = current.parent
+        }
+        return false
+    }
+
+    /**
+     * True when [list] is an *argument* of a threading macro (`->`, `->>`, `as->`, `some->`, …). The
+     * macro shifts the runtime argument count, so the textual count can't be trusted.
+     */
+    private fun isThreadedArgList(list: PhelList): Boolean {
+        val parentList = enclosingList(list) ?: return false
+        val parentForms = parentList.forms
+        val head = PhelPsiUtils.asSymbol(parentForms.firstOrNull())?.text ?: return false
+        if (head !in THREADING_HEADS) return false
+
+        val headRange = parentForms.firstOrNull()?.textRange ?: return false
+        // [list] is an argument (not the head form) of the threading macro.
+        return !headRange.contains(list.textRange.startOffset)
+    }
+
+    /**
+     * True when [name] resolves to a local binding — a `let`/`loop`/`for`/`binding` name or a
+     * function parameter — visible at [head]. Such a name shadows any same-named core function, so
+     * the registry's arity must not be applied.
+     */
+    private fun resolvesToLocalBinding(head: PhelSymbol, name: String): Boolean {
+        var current: PsiElement? = head.parent
+        while (current != null) {
+            if (current is PhelList) {
+                val forms = current.forms
+                val parentHead = PhelPsiUtils.asSymbol(forms.firstOrNull())?.text
+                if (parentHead in BINDING_INTRO_FORMS && bindingVecContains(forms, name)) return true
+                if (parentHead in FUNCTION_INTRO_FORMS && paramVecContains(forms, name)) return true
+            }
+            current = current.parent
+        }
+        return false
+    }
+
+    private fun enclosingList(list: PhelList): PhelList? =
+        generateSequence(list.parent) { it.parent }.filterIsInstance<PhelList>().firstOrNull()
+
+    /** Names sit at the even positions of a `[name value …]` binding vector. */
+    private fun bindingVecContains(forms: List<PhelForm>, name: String): Boolean {
+        val bindings = (forms.getOrNull(1) as? PhelVec)?.forms ?: return false
+        return (bindings.indices step 2).any { PhelPsiUtils.asSymbol(bindings[it])?.text == name }
+    }
+
+    private fun paramVecContains(forms: List<PhelForm>, name: String): Boolean {
+        val paramVec = forms.drop(1).firstNotNullOfOrNull { it as? PhelVec } ?: return false
+        return paramVec.forms.any { PhelPsiUtils.asSymbol(it)?.text == name }
+    }
+
+    private val THREADING_HEADS = setOf(
+        "->", "->>", "as->", "some->", "some->>", "cond->", "cond->>", "doto",
+    )
+
+    private val BINDING_INTRO_FORMS = PhelSpecialForms.LET_LIKE
+    private val FUNCTION_INTRO_FORMS = PhelSpecialForms.FUNCTION_DEFINING
+
+    /** Special forms and macros that legitimately accept variable arg shapes. */
+    private val SKIP_HEADS = setOf(
+        "if", "if-not", "when", "when-not", "if-let", "when-let", "if-some", "when-some",
+        "do", "let", "loop", "recur", "fn", "defn", "defn-", "def", "def-", "defmacro", "defmacro-",
+        "defstruct", "definterface", "defexception", "declare", "ns", "quote", "var",
+        "try", "catch", "finally", "throw", "case", "cond", "condp", "and", "or",
+        "->", "->>", "as->", "some->", "some->>", "doto", "binding", "for", "foreach", "dofor",
+        "comment", "deftest", "is", "are", "testing", "with-output-buffer",
+        "import", "require", "use", "set!", "..", ".",
+    )
+}

--- a/src/main/kotlin/org/phellang/inspection/PhelArityCallSite.kt
+++ b/src/main/kotlin/org/phellang/inspection/PhelArityCallSite.kt
@@ -1,6 +1,7 @@
 package org.phellang.inspection
 
 import com.intellij.psi.PsiElement
+import org.phellang.core.psi.PhelLocalBindingScope
 import org.phellang.language.psi.PhelForm
 import org.phellang.language.psi.PhelList
 import org.phellang.language.psi.PhelSpecialForms
@@ -27,7 +28,7 @@ internal object PhelArityCallSite {
 
         if (isInQuoteContext(list)) return true
         if (isThreadedArgList(list)) return true
-        if (resolvesToLocalBinding(head, name)) return true
+        if (PhelLocalBindingScope.resolvesToLocalBinding(head, name)) return true
         if (containsShortFnMarker(forms)) return true
 
         return false
@@ -75,45 +76,13 @@ internal object PhelArityCallSite {
         return !headRange.contains(list.textRange.startOffset)
     }
 
-    /**
-     * True when [name] resolves to a local binding — a `let`/`loop`/`for`/`binding` name or a
-     * function parameter — visible at [head]. Such a name shadows any same-named core function, so
-     * the registry's arity must not be applied.
-     */
-    private fun resolvesToLocalBinding(head: PhelSymbol, name: String): Boolean {
-        var current: PsiElement? = head.parent
-        while (current != null) {
-            if (current is PhelList) {
-                val forms = current.forms
-                val parentHead = PhelPsiUtils.asSymbol(forms.firstOrNull())?.text
-                if (parentHead in BINDING_INTRO_FORMS && bindingVecContains(forms, name)) return true
-                if (parentHead in FUNCTION_INTRO_FORMS && paramVecContains(forms, name)) return true
-            }
-            current = current.parent
-        }
-        return false
-    }
 
     private fun enclosingList(list: PhelList): PhelList? =
         generateSequence(list.parent) { it.parent }.filterIsInstance<PhelList>().firstOrNull()
 
-    /** Names sit at the even positions of a `[name value …]` binding vector. */
-    private fun bindingVecContains(forms: List<PhelForm>, name: String): Boolean {
-        val bindings = (forms.getOrNull(1) as? PhelVec)?.forms ?: return false
-        return (bindings.indices step 2).any { PhelPsiUtils.asSymbol(bindings[it])?.text == name }
-    }
-
-    private fun paramVecContains(forms: List<PhelForm>, name: String): Boolean {
-        val paramVec = forms.drop(1).firstNotNullOfOrNull { it as? PhelVec } ?: return false
-        return paramVec.forms.any { PhelPsiUtils.asSymbol(it)?.text == name }
-    }
-
     private val THREADING_HEADS = setOf(
         "->", "->>", "as->", "some->", "some->>", "cond->", "cond->>", "doto",
     )
-
-    private val BINDING_INTRO_FORMS = PhelSpecialForms.LET_LIKE
-    private val FUNCTION_INTRO_FORMS = PhelSpecialForms.FUNCTION_DEFINING
 
     /** Special forms and macros that legitimately accept variable arg shapes. */
     private val SKIP_HEADS = setOf(

--- a/src/main/kotlin/org/phellang/inspection/PhelArityMismatchInspection.kt
+++ b/src/main/kotlin/org/phellang/inspection/PhelArityMismatchInspection.kt
@@ -3,19 +3,21 @@ package org.phellang.inspection
 import com.intellij.codeInspection.LocalInspectionTool
 import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.codeInspection.ProblemsHolder
-import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
 import org.phellang.registry.PhelArityResolver
 import org.phellang.registry.accepts
 import org.phellang.registry.describe
-import org.phellang.core.psi.PhelSymbolAnalyzer
-import org.phellang.language.psi.PhelForm
 import org.phellang.language.psi.PhelList
-import org.phellang.language.psi.PhelSpecialForms
-import org.phellang.language.psi.PhelSymbol
 import org.phellang.language.psi.utils.PhelPsiUtils
 import org.phellang.language.psi.PhelVisitor
 
+/**
+ * Warns when a call passes the wrong number of arguments to a known function.
+ *
+ * Whether a list is even a checkable call site — not a quoted form, a threading argument, a
+ * shadowing local binding, or a variadic special form — is decided by [PhelArityCallSite]; this
+ * class only compares the argument count against the resolved arities.
+ */
 class PhelArityMismatchInspection : LocalInspectionTool() {
 
     override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
@@ -23,17 +25,10 @@ class PhelArityMismatchInspection : LocalInspectionTool() {
             override fun visitList(o: PhelList) {
                 val forms = PhelPsiUtils.activeForms(o)
                 if (forms.isEmpty()) return
+
                 val head = PhelPsiUtils.asSymbol(forms[0]) ?: return
                 val name = head.text ?: return
-
-                if (name in SKIP_HEADS) return
-                if (name.startsWith("php/") || name.startsWith(".") || name.startsWith("php-")) return
-                if (name.contains("IntelliJIdeaRulezzz")) return
-
-                if (isInQuoteContext(o)) return
-                if (isThreadedArgList(o)) return
-                if (resolvesToLocalBinding(head, name)) return
-                if (containsShortFnMarker(forms)) return
+                if (PhelArityCallSite.shouldSkip(o, head, name, forms)) return
 
                 val arities = PhelArityResolver.resolve(head.project, name) ?: return
                 if (arities.isEmpty()) return
@@ -49,180 +44,4 @@ class PhelArityMismatchInspection : LocalInspectionTool() {
             }
         }
     }
-
-    /**
-     * True when any argument is a bare `|` symbol — the marker for Phel's deprecated
-     * `|(...)` short-fn syntax. The lexer treats `|` as a plain symbol (it does not
-     * recognize the removed short-fn opener), so `|(> $ 10)` parses as two forms — a `|`
-     * symbol and a list — inflating the textual argument count. We can't trust the count
-     * in that case, so skip the check rather than report a false positive.
-     */
-    private fun containsShortFnMarker(forms: List<PhelForm>): Boolean {
-        for (i in 1 until forms.size) {
-            if (PhelPsiUtils.asSymbol(forms[i])?.text == "|") return true
-        }
-        return false
-    }
-
-    /**
-     * True when [list] is a data form (inside a `quote`, `var`, syntax-quote `` ` ``,
-     * or quote `'` reader macro) and therefore not a call site.
-     */
-    private fun isInQuoteContext(list: PhelList): Boolean {
-        var current: PsiElement? = list
-        while (current != null) {
-            if (current is PhelForm) {
-                for (macro in current.readerMacros) {
-                    val t = macro.text
-                    if (t == "'" || t == "`") return true
-                }
-            }
-            if (current is PhelList && current !== list) {
-                val head = PhelPsiUtils.asSymbol(current.forms.firstOrNull())?.text
-                if (head == "quote" || head == "var") return true
-            }
-            current = current.parent
-        }
-        return false
-    }
-
-    /**
-     * True when [list] is positioned as an argument inside a threading macro
-     * (`->`, `->>`, `as->`, `some->`, `some->>`, `cond->`, `cond->>`, `doto`).
-     * In that case the actual argument count seen at runtime is shifted, so we
-     * cannot trust the textual arg count and must skip the check.
-     */
-    private fun isThreadedArgList(list: PhelList): Boolean {
-        val parentList = findEnclosingList(list) ?: return false
-        val parentForms = parentList.forms
-        val head = PhelPsiUtils.asSymbol(parentForms.firstOrNull())?.text ?: return false
-        if (head !in THREADING_HEADS) return false
-        val firstFormRange = parentForms.firstOrNull()?.textRange ?: return false
-        // True when [list] is an argument (i.e., not the head form) of the threading macro.
-        return !firstFormRange.contains(list.textRange.startOffset)
-    }
-
-    private fun findEnclosingList(list: PhelList): PhelList? {
-        var current: PsiElement? = list.parent
-        while (current != null) {
-            if (current is PhelList) return current
-            current = current.parent
-        }
-        return null
-    }
-
-    /**
-     * True when [name] resolves to a local binding (let/loop/for/binding, or `fn`/`defn`
-     * parameter) visible at [head]. Such a name shadows any same-named core fn, so
-     * the registry arity must not be applied.
-     */
-    private fun resolvesToLocalBinding(head: PhelSymbol, name: String): Boolean {
-        var current: PsiElement? = head.parent
-        while (current != null) {
-            if (current is PhelList) {
-                val parentForms = current.forms
-                val parentHead = PhelPsiUtils.asSymbol(parentForms.firstOrNull())?.text
-                if (parentHead != null) {
-                    if (parentHead in BINDING_INTRO_FORMS && bindingVecContains(parentForms, name)) return true
-                    if (parentHead in FUNCTION_INTRO_FORMS && paramVecContains(parentForms, name)) return true
-                }
-            }
-            current = current.parent
-        }
-        return false
-    }
-
-    private fun bindingVecContains(forms: List<PhelForm>, name: String): Boolean {
-        val vec = forms.getOrNull(1) as? org.phellang.language.psi.PhelVec ?: return false
-        val bindings = vec.forms
-        var i = 0
-        while (i < bindings.size) {
-            if (PhelPsiUtils.asSymbol(bindings[i])?.text == name) return true
-            i += 2
-        }
-        return false
-    }
-
-    private fun paramVecContains(forms: List<PhelForm>, name: String): Boolean {
-        for (form in forms.drop(1)) {
-            if (form is org.phellang.language.psi.PhelVec) {
-                for (p in form.forms) {
-                    if (PhelPsiUtils.asSymbol(p)?.text == name) return true
-                }
-                return false
-            }
-        }
-        return false
-    }
-
 }
-
-private val THREADING_HEADS = setOf(
-    "->", "->>", "as->", "some->", "some->>", "cond->", "cond->>", "doto",
-)
-
-private val BINDING_INTRO_FORMS = PhelSpecialForms.LET_LIKE
-
-private val FUNCTION_INTRO_FORMS = PhelSpecialForms.FUNCTION_DEFINING
-
-// Special forms / macros that legitimately accept variable arg shapes.
-// Skipping avoids false positives.
-private val SKIP_HEADS = setOf(
-    "if",
-    "if-not",
-    "when",
-    "when-not",
-    "if-let",
-    "when-let",
-    "if-some",
-    "when-some",
-    "do",
-    "let",
-    "loop",
-    "recur",
-    "fn",
-    "defn",
-    "defn-",
-    "def",
-    "def-",
-    "defmacro",
-    "defmacro-",
-    "defstruct",
-    "definterface",
-    "defexception",
-    "declare",
-    "ns",
-    "quote",
-    "var",
-    "try",
-    "catch",
-    "finally",
-    "throw",
-    "case",
-    "cond",
-    "condp",
-    "and",
-    "or",
-    "->",
-    "->>",
-    "as->",
-    "some->",
-    "some->>",
-    "doto",
-    "binding",
-    "for",
-    "foreach",
-    "dofor",
-    "comment",
-    "deftest",
-    "is",
-    "are",
-    "testing",
-    "with-output-buffer",
-    "import",
-    "require",
-    "use",
-    "set!",
-    "..",
-    "."
-)

--- a/src/main/kotlin/org/phellang/language/psi/PhelNamespaceUtils.kt
+++ b/src/main/kotlin/org/phellang/language/psi/PhelNamespaceUtils.kt
@@ -110,140 +110,21 @@ object PhelNamespaceUtils {
         }
     }
 
-    private fun computeUsedClasses(file: PhelFile): Set<String> {
-        val nsDeclaration = findNamespaceDeclaration(file) ?: return emptySet()
-        val useForms = findUseForms(nsDeclaration)
-        if (useForms.isEmpty()) return emptySet()
+    private fun computeUsedClasses(file: PhelFile): Set<String> = PhelUseClauseAnalyzer.computeUsedClasses(file)
 
-        val classes = mutableSetOf<String>()
-        for (useForm in useForms) {
-            val forms = useForm.forms
-            for (i in 1 until forms.size) {
-                val form = forms[i]
-                val symbol = PhelPsiUtils.asSymbol(form)
-                val text = symbol?.text ?: continue
-                val shortName = extractShortClassName(text) ?: continue
-                classes.add(shortName)
-            }
-        }
-        return classes
-    }
+    fun isUseClassSymbol(symbol: PhelSymbol): Boolean = PhelUseClauseAnalyzer.isUseClassSymbol(symbol)
 
-    /**
-     * True when [symbol] is one of the PHP class entries inside a `(:use ...)` clause
-     * (i.e. not the `:use` keyword itself). Used to wire go-to-definition from the
-     * imported class name straight to its PHP class declaration.
-     *
-     * Handles every spelling Phel accepts for the entry — bare (`Countable`),
-     * dot-separated (`Phel.Compiler.CompilerFacade`, the modern form) and the legacy
-     * backslash form (`Phel\Compiler\CompilerFacade`) — since each lexes as a single
-     * symbol.
-     */
-    fun isUseClassSymbol(symbol: PhelSymbol): Boolean {
-        val clause = PsiTreeUtil.getParentOfType(symbol, PhelList::class.java) ?: return false
-        val forms = clause.forms
-        if (forms.isEmpty()) return false
+    fun extractShortClassName(text: String): String? = PhelUseClauseAnalyzer.extractShortClassName(text)
 
-        val firstKeyword = forms[0] as? PhelKeyword
-            ?: PsiTreeUtil.findChildOfType(forms[0], PhelKeyword::class.java)
-        if (firstKeyword?.text != ":use") return false
-
-        // Reject the keyword form itself; accept any class-entry form (forms[1..n]).
-        return forms.drop(1).any { it === symbol || PsiTreeUtil.isAncestor(it, symbol, false) }
-    }
-
-    /**
-     * `\Phel\Compiler\CompilerFacade` -> `CompilerFacade`. Null when [text] has no class name
-     * (empty, or nothing but separators). Backslashes are PHP's FQCN separator, so they are
-     * expected here — this is not legacy Phel-namespace handling.
-     */
-    fun extractShortClassName(text: String): String? {
-        val trimmed = text.trimStart('\\')
-        if (trimmed.isEmpty()) return null
-        val short = trimmed.substringAfterLast('\\')
-        return short.ifEmpty { null }
-    }
-
-    /**
-     * Indexes a file's `(:use ...)` clause as short class name -> fully-qualified name, with the
-     * FQN normalized to a leading `\` (`Foo\Bar` -> `\Foo\Bar`).
-     *
-     * The first entry wins if a file imports two classes with the same short name — that case is
-     * already broken PHP, and first-wins keeps this agreeing with go-to-definition.
-     */
-    fun buildUseFqnIndex(file: PhelFile): Map<String, String> {
-        val nsDeclaration = findNamespaceDeclaration(file) ?: return emptyMap()
-        val index = mutableMapOf<String, String>()
-        for (useForm in findUseForms(nsDeclaration)) {
-            val forms = useForm.forms
-            for (i in 1 until forms.size) {
-                val form = forms[i]
-                val sym = PhelPsiUtils.asSymbol(form)
-                val raw = sym?.text ?: continue
-                val shortName = extractShortClassName(raw) ?: continue
-                val fqn = if (raw.startsWith("\\")) raw else "\\$raw"
-                index.putIfAbsent(shortName, fqn)
-            }
-        }
-        return index
-    }
+    fun buildUseFqnIndex(file: PhelFile): Map<String, String> = PhelUseClauseAnalyzer.buildUseFqnIndex(file)
 
     fun extractAliasMap(file: PhelFile): Map<String, String> {
         return CachedValuesManager.getCachedValue(file, ALIAS_MAP_KEY) {
             CachedValueProvider.Result.create(
-                computeAliasMap(file),
+                PhelRequireClauseAnalyzer.computeAliasMap(file),
                 PsiModificationTracker.MODIFICATION_COUNT,
             )
         }
-    }
-
-    private fun computeAliasMap(file: PhelFile): Map<String, String> {
-        val aliasMap = mutableMapOf<String, String>()
-
-        val nsDeclaration = findNamespaceDeclaration(file) ?: return aliasMap
-        val requireForms = findRequireForms(nsDeclaration)
-
-        for (requireForm in requireForms) {
-            val forms = requireForm.forms
-
-            var i = 1
-            while (i < forms.size) {
-                val form = forms[i]
-
-                // Get the namespace symbol
-                val namespaceSymbol = if (form is PhelSymbol) form
-                else PsiTreeUtil.findChildOfType(form, PhelSymbol::class.java)
-
-                if (namespaceSymbol != null) {
-                    val namespace = namespaceSymbol.text
-
-                    // Check if next form is :as keyword
-                    if (i + 1 < forms.size) {
-                        val nextForm = forms[i + 1]
-                        val asKeyword = nextForm as? PhelKeyword
-                            ?: PsiTreeUtil.findChildOfType(nextForm, PhelKeyword::class.java)
-
-                        if (asKeyword?.text == ":as" && i + 2 < forms.size) {
-                            // Get the alias symbol
-                            val aliasForm = forms[i + 2]
-                            val aliasSymbol = if (aliasForm is PhelSymbol) aliasForm
-                            else PsiTreeUtil.findChildOfType(aliasForm, PhelSymbol::class.java)
-
-                            if (aliasSymbol != null) {
-                                val alias = aliasSymbol.text
-                                val shortNamespace = PhelProjectNamespaceFinder.extractShortNamespace(namespace)
-                                aliasMap[alias] = shortNamespace
-                                i += 3  // Skip namespace, :as, and alias
-                                continue
-                            }
-                        }
-                    }
-                }
-                i++
-            }
-        }
-
-        return aliasMap
     }
 
     /**
@@ -323,90 +204,15 @@ object PhelNamespaceUtils {
     fun extractReferredSymbols(file: PhelFile): Set<String> {
         return CachedValuesManager.getCachedValue(file, REFERRED_SYMBOLS_KEY) {
             CachedValueProvider.Result.create(
-                computeReferredSymbols(file),
+                PhelRequireClauseAnalyzer.computeReferredSymbols(file),
                 PsiModificationTracker.MODIFICATION_COUNT,
             )
         }
     }
 
-    private fun computeReferredSymbols(file: PhelFile): Set<String> {
-        val referredSymbols = mutableSetOf<String>()
+    fun isReferredSymbol(file: PhelFile, symbolName: String): Boolean =
+        extractReferredSymbols(file).contains(symbolName)
 
-        val nsDeclaration = findNamespaceDeclaration(file) ?: return referredSymbols
-        val requireForms = findRequireForms(nsDeclaration)
-
-        for (requireForm in requireForms) {
-            val forms = requireForm.forms
-
-            var i = 1
-            while (i < forms.size) {
-                val form = forms[i]
-
-                // Check if this is a :refer keyword
-                val keyword = form as? PhelKeyword
-                    ?: PsiTreeUtil.findChildOfType(form, PhelKeyword::class.java)
-
-                if (keyword?.text == ":refer" && i + 1 < forms.size) {
-                    // Next form should be a vector with symbols
-                    val vectorForm = forms[i + 1]
-
-                    // Extract symbols from the vector (vec contains PhelSymbol children)
-                    val symbols = PsiTreeUtil.findChildrenOfType(vectorForm, PhelSymbol::class.java)
-                    for (symbol in symbols) {
-                        val symbolText = symbol.text
-                        // Skip namespace-qualified symbols (either separator) and PHP FQNs.
-                        if (symbolText != null && !symbolText.contains("\\") && !symbolText.contains("/")) {
-                            referredSymbols.add(symbolText)
-                        }
-                    }
-
-                    i += 2 // Skip :refer and the vector
-                    continue
-                }
-
-                i++
-            }
-        }
-
-        return referredSymbols
-    }
-
-    fun isReferredSymbol(file: PhelFile, symbolName: String): Boolean {
-        return extractReferredSymbols(file).contains(symbolName)
-    }
-
-    /**
-     * If [symbolName] is referred from a `(:require [ns :refer [...]])` clause in [file],
-     * returns the source namespace (the head of that require clause). Returns null when
-     * the symbol isn't refer'd from any require, so callers can fall back to other lookups.
-     */
-    fun findReferSource(file: PhelFile, symbolName: String): String? {
-        val nsDeclaration = findNamespaceDeclaration(file) ?: return null
-        val requireForms = findRequireForms(nsDeclaration)
-
-        for (requireForm in requireForms) {
-            val forms = requireForm.forms
-            if (forms.isEmpty()) continue
-
-            val sourceNamespace = (forms[0] as? PhelSymbol)?.text
-                ?: PsiTreeUtil.findChildOfType(forms[0], PhelSymbol::class.java)?.text
-                ?: continue
-
-            var i = 1
-            while (i < forms.size) {
-                val keyword = (forms[i] as? PhelKeyword)
-                    ?: PsiTreeUtil.findChildOfType(forms[i], PhelKeyword::class.java)
-                if (keyword?.text == ":refer" && i + 1 < forms.size) {
-                    val symbols = PsiTreeUtil.findChildrenOfType(forms[i + 1], PhelSymbol::class.java)
-                    if (symbols.any { it.text == symbolName }) {
-                        return sourceNamespace
-                    }
-                    i += 2
-                    continue
-                }
-                i++
-            }
-        }
-        return null
-    }
+    fun findReferSource(file: PhelFile, symbolName: String): String? =
+        PhelRequireClauseAnalyzer.findReferSource(file, symbolName)
 }

--- a/src/main/kotlin/org/phellang/language/psi/PhelRequireClauseAnalyzer.kt
+++ b/src/main/kotlin/org/phellang/language/psi/PhelRequireClauseAnalyzer.kt
@@ -1,0 +1,110 @@
+package org.phellang.language.psi
+
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.language.psi.files.PhelFile
+import org.phellang.language.psi.utils.PhelPsiUtils
+
+/**
+ * Reads the `(:require ...)` clauses of a file's `(ns ...)` form: the `:as` aliases and the `:refer`
+ * imports. Both walk a require spec's forms looking for a keyword and its following operand, so the
+ * traversal is shared.
+ *
+ * Pure computation — [PhelNamespaceUtils] owns the per-file caching and delegates here.
+ */
+internal object PhelRequireClauseAnalyzer {
+
+    /** alias -> short namespace, e.g. `s -> string` for `(:require phel\string :as s)`. */
+    fun computeAliasMap(file: PhelFile): Map<String, String> {
+        val nsDeclaration = PhelNamespaceUtils.findNamespaceDeclaration(file) ?: return emptyMap()
+
+        val aliasMap = mutableMapOf<String, String>()
+        for (requireForm in PhelNamespaceUtils.findRequireForms(nsDeclaration)) {
+            val forms = requireForm.forms
+            forEachSpec(forms) { namespaceText, aliasAt ->
+                if (aliasAt != null) {
+                    val short = PhelProjectNamespaceFinder.extractShortNamespace(namespaceText)
+                    aliasMap[aliasAt] = short
+                }
+            }
+        }
+        return aliasMap
+    }
+
+    /** Symbols brought in unqualified via `(:require [ns :refer [a b c]])`. */
+    fun computeReferredSymbols(file: PhelFile): Set<String> {
+        val nsDeclaration = PhelNamespaceUtils.findNamespaceDeclaration(file) ?: return emptySet()
+
+        val referred = mutableSetOf<String>()
+        for (requireForm in PhelNamespaceUtils.findRequireForms(nsDeclaration)) {
+            referSymbolsIn(requireForm.forms).forEach { referred += it }
+        }
+        return referred
+    }
+
+    /**
+     * The namespace a `:refer`-imported [symbolName] comes from — the head of the require clause
+     * that refers it — or null when it isn't refer'd from any require.
+     */
+    fun findReferSource(file: PhelFile, symbolName: String): String? {
+        val nsDeclaration = PhelNamespaceUtils.findNamespaceDeclaration(file) ?: return null
+
+        for (requireForm in PhelNamespaceUtils.findRequireForms(nsDeclaration)) {
+            val forms = requireForm.forms
+            val sourceNamespace = forms.firstOrNull()?.let(PhelPsiUtils::asSymbol)?.text ?: continue
+            if (symbolName in referSymbolsIn(forms)) return sourceNamespace
+        }
+        return null
+    }
+
+    /** The symbols in every `:refer [ …]` vector within one require spec's [forms]. */
+    private fun referSymbolsIn(forms: List<PhelForm>): Set<String> {
+        val result = mutableSetOf<String>()
+        var i = 1
+        while (i < forms.size) {
+            if (keywordTextAt(forms, i) == ":refer" && i + 1 < forms.size) {
+                PsiTreeUtil.findChildrenOfType(forms[i + 1], PhelSymbol::class.java)
+                    .mapNotNull { it.text }
+                    // A qualified symbol or PHP FQN in a :refer vector is not a bare referred name.
+                    .filter { !it.contains('\\') && !it.contains('/') }
+                    .forEach { result += it }
+                i += 2
+            } else {
+                i++
+            }
+        }
+        return result
+    }
+
+    /**
+     * Visits each namespace spec in a require clause's [forms], reporting the namespace text and,
+     * when the spec is `<ns> :as <alias>`, the alias. Advances past the `:as alias` pair so it is
+     * not re-read as another namespace.
+     */
+    private inline fun forEachSpec(forms: List<PhelForm>, action: (namespaceText: String, aliasAt: String?) -> Unit) {
+        var i = 1
+        while (i < forms.size) {
+            val namespaceSymbol = PhelPsiUtils.asSymbol(forms[i])
+            if (namespaceSymbol == null) {
+                i++
+                continue
+            }
+
+            val alias = aliasFollowing(forms, i)
+            action(namespaceSymbol.text, alias)
+            i += if (alias != null) 3 else 1
+        }
+    }
+
+    /** The alias in `<ns> :as <alias>` starting at [index], or null when no `:as` follows. */
+    private fun aliasFollowing(forms: List<PhelForm>, index: Int): String? {
+        if (index + 2 >= forms.size) return null
+        if (keywordTextAt(forms, index + 1) != ":as") return null
+        return PhelPsiUtils.asSymbol(forms[index + 2])?.text
+    }
+
+    private fun keywordTextAt(forms: List<PhelForm>, index: Int): String? {
+        val form = forms.getOrNull(index) ?: return null
+        val keyword = form as? PhelKeyword ?: PsiTreeUtil.findChildOfType(form, PhelKeyword::class.java)
+        return keyword?.text
+    }
+}

--- a/src/main/kotlin/org/phellang/language/psi/PhelRequireClauseAnalyzer.kt
+++ b/src/main/kotlin/org/phellang/language/psi/PhelRequireClauseAnalyzer.kt
@@ -13,22 +13,28 @@ import org.phellang.language.psi.utils.PhelPsiUtils
  */
 internal object PhelRequireClauseAnalyzer {
 
-    /** alias -> short namespace, e.g. `s -> string` for `(:require phel\string :as s)`. */
-    fun computeAliasMap(file: PhelFile): Map<String, String> {
-        val nsDeclaration = PhelNamespaceUtils.findNamespaceDeclaration(file) ?: return emptyMap()
+    /** One `(:require ...)` entry: the namespace as written, its short form, and its `:as` alias. */
+    data class RequireImport(val fullNamespace: String, val shortNamespace: String, val alias: String?)
 
-        val aliasMap = mutableMapOf<String, String>()
+    /** Every namespace imported by [file]'s `(:require ...)` clauses. */
+    fun imports(file: PhelFile): List<RequireImport> {
+        val nsDeclaration = PhelNamespaceUtils.findNamespaceDeclaration(file) ?: return emptyList()
+
+        val imports = mutableListOf<RequireImport>()
         for (requireForm in PhelNamespaceUtils.findRequireForms(nsDeclaration)) {
-            val forms = requireForm.forms
-            forEachSpec(forms) { namespaceText, aliasAt ->
-                if (aliasAt != null) {
-                    val short = PhelProjectNamespaceFinder.extractShortNamespace(namespaceText)
-                    aliasMap[aliasAt] = short
-                }
+            forEachSpec(requireForm.forms) { namespaceText, aliasAt ->
+                val short = PhelProjectNamespaceFinder.extractShortNamespace(namespaceText)
+                imports += RequireImport(namespaceText, short, aliasAt)
             }
         }
-        return aliasMap
+        return imports
     }
+
+    /** alias -> short namespace, e.g. `s -> string` for `(:require phel\string :as s)`. */
+    fun computeAliasMap(file: PhelFile): Map<String, String> =
+        imports(file)
+            .filter { it.alias != null }
+            .associate { it.alias!! to it.shortNamespace }
 
     /** Symbols brought in unqualified via `(:require [ns :refer [a b c]])`. */
     fun computeReferredSymbols(file: PhelFile): Set<String> {

--- a/src/main/kotlin/org/phellang/language/psi/PhelUseClauseAnalyzer.kt
+++ b/src/main/kotlin/org/phellang/language/psi/PhelUseClauseAnalyzer.kt
@@ -1,0 +1,79 @@
+package org.phellang.language.psi
+
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.language.psi.files.PhelFile
+import org.phellang.language.psi.utils.PhelPsiUtils
+
+/**
+ * Reads the `(:use ...)` clauses of a file's `(ns ...)` form. Phel's `:use` brings PHP *classes*
+ * (not Phel namespaces) into scope, so they can be named without the leading `\` — e.g.
+ * `(:use \DateTime \Exception)` enables `(DateTime. …)` and `DateTime/createFromFormat`.
+ *
+ * Pure computation — [PhelNamespaceUtils] owns the per-file caching and delegates here.
+ */
+internal object PhelUseClauseAnalyzer {
+
+    /**
+     * The short class names declared via `(:use ...)`. Both `\Foo\Bar` and `Foo\Bar` yield `Bar` —
+     * the name a user actually types in `(Bar. …)`, `(.method bar)` or `Bar/staticFn`.
+     */
+    fun computeUsedClasses(file: PhelFile): Set<String> {
+        return classEntries(file)
+            .mapNotNull { extractShortClassName(it.text) }
+            .toSet()
+    }
+
+    /**
+     * `\Phel\Compiler\CompilerFacade` -> `CompilerFacade`. Null when [text] has no class name
+     * (empty, or nothing but separators). Backslashes are PHP's FQCN separator — this is not legacy
+     * Phel-namespace handling.
+     */
+    fun extractShortClassName(text: String): String? {
+        val trimmed = text.trimStart('\\')
+        if (trimmed.isEmpty()) return null
+        return trimmed.substringAfterLast('\\').ifEmpty { null }
+    }
+
+    /**
+     * The file's `(:use ...)` entries indexed as short class name -> fully-qualified name, the FQN
+     * normalized to a leading `\` (`Foo\Bar` -> `\Foo\Bar`).
+     *
+     * First entry wins on a duplicate short name — that case is already broken PHP, and first-wins
+     * keeps this agreeing with go-to-definition.
+     */
+    fun buildUseFqnIndex(file: PhelFile): Map<String, String> {
+        val index = mutableMapOf<String, String>()
+        for (entry in classEntries(file)) {
+            val raw = entry.text
+            val shortName = extractShortClassName(raw) ?: continue
+            val fqn = if (raw.startsWith("\\")) raw else "\\$raw"
+            index.putIfAbsent(shortName, fqn)
+        }
+        return index
+    }
+
+    /**
+     * True when [symbol] is one of the class entries in a `(:use ...)` clause — not the `:use`
+     * keyword itself. Wires go-to-definition from the imported class name to its PHP declaration.
+     */
+    fun isUseClassSymbol(symbol: PhelSymbol): Boolean {
+        val clause = PsiTreeUtil.getParentOfType(symbol, PhelList::class.java) ?: return false
+        val forms = clause.forms
+        if (forms.isEmpty()) return false
+
+        val firstKeyword = forms[0] as? PhelKeyword
+            ?: PsiTreeUtil.findChildOfType(forms[0], PhelKeyword::class.java)
+        if (firstKeyword?.text != ":use") return false
+
+        return forms.drop(1).any { it === symbol || PsiTreeUtil.isAncestor(it, symbol, false) }
+    }
+
+    /** The class-entry symbols across all `(:use ...)` clauses in [file]. */
+    private fun classEntries(file: PhelFile): List<PhelSymbol> {
+        val nsDeclaration = PhelNamespaceUtils.findNamespaceDeclaration(file) ?: return emptyList()
+
+        return PhelNamespaceUtils.findUseForms(nsDeclaration)
+            .flatMap { it.forms.drop(1) }
+            .mapNotNull(PhelPsiUtils::asSymbol)
+    }
+}

--- a/src/main/kotlin/org/phellang/language/psi/references/PhelDefinitionFinder.kt
+++ b/src/main/kotlin/org/phellang/language/psi/references/PhelDefinitionFinder.kt
@@ -1,0 +1,85 @@
+package org.phellang.language.psi.references
+
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiManager
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.core.psi.PhelSymbolAnalyzer
+import org.phellang.language.psi.PhelForm
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.PhelVec
+import org.phellang.language.psi.PhelVendorUtils
+import org.phellang.language.psi.files.PhelFile
+import org.phellang.language.psi.utils.SymbolCategory
+
+/**
+ * Matches a name against the definitions a Phel file declares — `(def x …)`, `(defn f [..] …)` and
+ * friends — plus the parameter vectors those forms introduce.
+ *
+ * Shared by every resolver: scanning a file's lists for a matching definition is the one operation
+ * they all perform, and it was previously written out four separate times.
+ */
+internal object PhelDefinitionFinder {
+
+    /** Keywords that define new symbols. */
+    private val DEFINING_KEYWORDS = setOf(
+        "def", "defn", "defn-", "defmacro", "defmacro-",
+        "defstruct", "definterface", "def-"
+    )
+
+    /** The definitions of [symbolName] declared anywhere in [root]. */
+    fun collectDefinitionsIn(root: PsiElement, symbolName: String): List<PsiElement> {
+        return PsiTreeUtil.findChildrenOfType(root, PhelList::class.java)
+            .mapNotNull { findDefinitionInList(it, symbolName) }
+    }
+
+    /** The definitions of [symbolName] across every vendor file backing [namespace]. */
+    fun collectVendorDefinitions(project: Project, namespace: String, symbolName: String): List<PsiElement> {
+        // Phel 0.35+: a namespace may be backed by several vendor files
+        // (e.g. phel.core spans core.phel + core/*.phel).
+        val vendorFiles = PhelVendorUtils.findStandardLibraryFiles(project, namespace)
+        if (vendorFiles.isEmpty()) return emptyList()
+
+        val psiManager = PsiManager.getInstance(project)
+        return vendorFiles
+            .mapNotNull { psiManager.findFile(it) as? PhelFile }
+            .flatMap { collectDefinitionsIn(it, symbolName) }
+    }
+
+    /** The name symbol of `(def name …)` / `(defn name …)` when it is [symbolName], else null. */
+    fun findDefinitionInList(list: PhelList, symbolName: String): PsiElement? {
+        val forms = list.forms
+        if (forms.size < 2) return null
+
+        val defKeyword = PsiTreeUtil.findChildOfType(forms[0], PhelSymbol::class.java) ?: return null
+        if (!isDefiningKeyword(defKeyword.text)) return null
+
+        val definedName = PsiTreeUtil.findChildOfType(forms[1], PhelSymbol::class.java) ?: return null
+        return definedName.takeIf { symbolName == it.text }
+    }
+
+    fun isDefiningKeyword(keyword: String?): Boolean {
+        if (keyword == null) return false
+
+        return keyword in DEFINING_KEYWORDS ||
+                PhelSymbolAnalyzer.isSymbolType(keyword, SymbolCategory.SPECIAL_FORMS) ||
+                PhelSymbolAnalyzer.isSymbolType(keyword, SymbolCategory.MACROS)
+    }
+
+    /**
+     * The parameter vector a function-defining form introduces, or null when [keyword] doesn't
+     * introduce one. `fn` carries it at index 1; `defn` and friends carry it after the name, past
+     * any docstring or metadata — `(defn name "doc" {:meta} [params] …)`.
+     */
+    fun findParameterVector(forms: List<PhelForm>, keyword: String): PhelVec? = when (keyword) {
+        "fn" -> forms.getOrNull(1)?.let(::asVector)
+        "defn", "defn-", "defmacro", "defmacro-" ->
+            forms.drop(2).firstNotNullOfOrNull(::asVector)
+
+        else -> null
+    }
+
+    private fun asVector(form: PhelForm): PhelVec? =
+        form as? PhelVec ?: PsiTreeUtil.findChildOfType(form, PhelVec::class.java)
+}

--- a/src/main/kotlin/org/phellang/language/psi/references/PhelDefinitionSearcher.kt
+++ b/src/main/kotlin/org/phellang/language/psi/references/PhelDefinitionSearcher.kt
@@ -1,0 +1,30 @@
+package org.phellang.language.psi.references
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiManager
+import com.intellij.psi.search.FilenameIndex
+import com.intellij.psi.search.GlobalSearchScope
+import org.phellang.language.psi.PhelSymbol
+
+/** Finds unqualified definitions of a name: first in the file being edited, then across the project. */
+internal object PhelDefinitionSearcher {
+
+    fun findInCurrentFile(symbol: PhelSymbol, symbolName: String): List<PsiElement> {
+        val file = symbol.containingFile ?: return emptyList()
+        return PhelDefinitionFinder.collectDefinitionsIn(file, symbolName)
+    }
+
+    fun findInProject(symbol: PhelSymbol, symbolName: String): List<PsiElement> {
+        val project = symbol.project
+        val currentFile = symbol.containingFile
+        val psiManager = PsiManager.getInstance(project)
+
+        return FilenameIndex.getAllFilesByExt(project, "phel", GlobalSearchScope.projectScope(project))
+            .mapNotNull { psiManager.findFile(it) }
+            .filter { it != currentFile }
+            // Fast reject: a file whose text never mentions the name cannot define it, so skip the
+            // PSI walk for the many files that don't reference this symbol.
+            .filter { it.text.contains(symbolName) }
+            .flatMap { PhelDefinitionFinder.collectDefinitionsIn(it, symbolName) }
+    }
+}

--- a/src/main/kotlin/org/phellang/language/psi/references/PhelLocalScopeResolver.kt
+++ b/src/main/kotlin/org/phellang/language/psi/references/PhelLocalScopeResolver.kt
@@ -1,0 +1,92 @@
+package org.phellang.language.psi.references
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelSpecialForms
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.PhelVec
+
+/**
+ * Resolves a symbol to a binding introduced in an enclosing scope: a `let`-like binding vector, or a
+ * function's parameter vector.
+ */
+internal object PhelLocalScopeResolver {
+
+    /** The nearest enclosing binding or parameter that declares [symbolName], or null. */
+    fun resolve(symbol: PhelSymbol, symbolName: String): PsiElement? {
+        var current: PsiElement? = symbol
+
+        while (current != null) {
+            PsiTreeUtil.getParentOfType(current, PhelList::class.java)
+                ?.let { findInLetBindings(it, symbolName) }
+                ?.let { return it }
+
+            findInFunctionParameters(current, symbolName)?.let { return it }
+
+            current = current.parent
+        }
+
+        return null
+    }
+
+    /** Every parameter named [symbolName] anywhere in [file] — polyvariant resolve shows them all. */
+    fun findAllParametersIn(file: PsiElement, symbolName: String): List<PsiElement> {
+        return PsiTreeUtil.findChildrenOfType(file, PhelList::class.java)
+            .flatMap { list -> parametersOf(list).orEmpty() }
+            .filter { symbolName == it.text }
+    }
+
+    /**
+     * The binding named [symbolName] in [letForm]'s binding vector.
+     *
+     * Only forms whose second element is a `[name value …]` vector are relevant. `catch` was once
+     * listed here but its second element is the exception class, so it never matched; `when-let` was
+     * missing, so its bindings failed to resolve. The shared [PhelSpecialForms.LET_LIKE] set fixes both.
+     */
+    private fun findInLetBindings(letForm: PhelList, symbolName: String): PsiElement? {
+        val forms = letForm.forms
+        if (forms.size < 2) return null
+
+        val firstSymbol = PsiTreeUtil.findChildOfType(forms[0], PhelSymbol::class.java) ?: return null
+        if (firstSymbol.text !in PhelSpecialForms.LET_LIKE) return null
+
+        val bindingsVec = forms[1] as? PhelVec
+            ?: PsiTreeUtil.findChildOfType(forms[1], PhelVec::class.java)
+            ?: return null
+
+        // Bindings are pairs: [name1 value1 name2 value2 …] — names sit at even indices.
+        val bindings = bindingsVec.forms
+        return (bindings.indices step 2)
+            .mapNotNull { PsiTreeUtil.findChildOfType(bindings[it], PhelSymbol::class.java) }
+            .firstOrNull { symbolName == it.text }
+    }
+
+    /** Walks every enclosing function form, not just the innermost, so shadowed params still resolve. */
+    private fun findInFunctionParameters(context: PsiElement, symbolName: String): PsiElement? {
+        var current: PsiElement? = context
+
+        while (current != null) {
+            val fnForm = PsiTreeUtil.getParentOfType(current, PhelList::class.java) ?: return null
+
+            parametersOf(fnForm)
+                ?.firstOrNull { symbolName == it.text }
+                ?.let { return it }
+
+            current = fnForm.parent
+        }
+
+        return null
+    }
+
+    /** The parameter symbols a function-defining form declares, or null when it declares none. */
+    private fun parametersOf(list: PhelList): List<PhelSymbol>? {
+        val forms = list.forms
+        if (forms.size < 2) return null
+
+        val keyword = PsiTreeUtil.findChildOfType(forms[0], PhelSymbol::class.java)?.text ?: return null
+        val paramVec = PhelDefinitionFinder.findParameterVector(forms, keyword) ?: return null
+
+        return paramVec.forms.mapNotNull { PsiTreeUtil.findChildOfType(it, PhelSymbol::class.java) }
+    }
+}

--- a/src/main/kotlin/org/phellang/language/psi/references/PhelQualifiedSymbolResolver.kt
+++ b/src/main/kotlin/org/phellang/language/psi/references/PhelQualifiedSymbolResolver.kt
@@ -1,0 +1,117 @@
+package org.phellang.language.psi.references
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiManager
+import com.intellij.psi.search.FilenameIndex
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.language.psi.PhelKeyword
+import org.phellang.language.psi.PhelNamespaceUtils
+import org.phellang.language.psi.PhelProjectNamespaceFinder
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.files.PhelFile
+import org.phellang.language.psi.utils.PhelPsiUtils
+
+/**
+ * Resolves a namespace-qualified symbol — `utils/greet`, `m/square`, `string/join` — to its
+ * definition, covering direct imports, `:as` aliases, namespaces that were never imported (matched
+ * by short name), and the standard library.
+ *
+ * PHP interop (`ClassName/method`) is *not* handled here: the caller tries [PhpClassResolver] first,
+ * since a PHP class qualifier must never be matched against a Phel namespace.
+ */
+internal object PhelQualifiedSymbolResolver {
+
+    fun resolve(symbol: PhelSymbol, qualifier: String, symbolName: String): List<PsiElement> {
+        val containingFile = symbol.containingFile as? PhelFile ?: return emptyList()
+        val project = symbol.project
+
+        // An import may alias the qualifier (`:as m`), in which case the namespace to search for is
+        // the aliased one rather than the text the user typed.
+        val importedNamespace = resolveQualifierToNamespace(containingFile, qualifier)
+        val searchNamespace = importedNamespace
+            ?.let(PhelProjectNamespaceFinder::extractShortNamespace)
+            ?: qualifier
+
+        val results = mutableListOf<PsiElement>()
+        results += PhelDefinitionFinder.collectVendorDefinitions(project, searchNamespace, symbolName)
+        results += findInProjectFiles(project, qualifier, importedNamespace, symbolName)
+        return results
+    }
+
+    private fun findInProjectFiles(
+        project: com.intellij.openapi.project.Project,
+        qualifier: String,
+        importedNamespace: String?,
+        symbolName: String,
+    ): List<PsiElement> {
+        val psiManager = PsiManager.getInstance(project)
+        val phelFiles = FilenameIndex.getAllFilesByExt(project, "phel", GlobalSearchScope.projectScope(project))
+
+        return phelFiles
+            .mapNotNull { psiManager.findFile(it) as? PhelFile }
+            .filter { declaresSearchedNamespace(it, qualifier, importedNamespace) }
+            .flatMap { PhelDefinitionFinder.collectDefinitionsIn(it, symbolName) }
+    }
+
+    private fun declaresSearchedNamespace(file: PhelFile, qualifier: String, importedNamespace: String?): Boolean {
+        val fileNamespace = PhelNamespaceUtils.extractNamespaceFromFile(file) ?: return false
+
+        // Match on the full namespace when the import told us what it is; otherwise the qualifier is
+        // all we have, so match files whose short namespace equals it.
+        return if (importedNamespace != null) {
+            fileNamespace == importedNamespace
+        } else {
+            PhelProjectNamespaceFinder.extractShortNamespace(fileNamespace) == qualifier
+        }
+    }
+
+    /**
+     * The full namespace a qualifier refers to, via the file's `(:require ...)` clauses — resolving
+     * `:as` aliases as well as direct imports. Null when no import matches, in which case the caller
+     * falls back to matching files by short namespace.
+     */
+    private fun resolveQualifierToNamespace(file: PhelFile, qualifier: String): String? {
+        val nsDeclaration = PhelNamespaceUtils.findNamespaceDeclaration(file) ?: return null
+
+        for (requireForm in PhelNamespaceUtils.findRequireForms(nsDeclaration)) {
+            val forms = requireForm.forms
+
+            var i = 1
+            while (i < forms.size) {
+                val namespaceSymbol = PhelPsiUtils.asSymbol(forms.getOrNull(i))
+                if (namespaceSymbol == null) {
+                    i++
+                    continue
+                }
+
+                val fullNamespace = namespaceSymbol.text
+                val alias = aliasFollowing(forms, i)
+
+                if (alias != null) {
+                    if (alias == qualifier) return fullNamespace
+                    i += 3   // namespace, :as, alias
+                    continue
+                }
+
+                if (PhelProjectNamespaceFinder.extractShortNamespace(fullNamespace) == qualifier) {
+                    return fullNamespace
+                }
+                i++
+            }
+        }
+
+        return null
+    }
+
+    /** The alias in `<ns> :as <alias>` starting at [index], or null when no `:as` follows. */
+    private fun aliasFollowing(forms: List<org.phellang.language.psi.PhelForm>, index: Int): String? {
+        if (index + 2 >= forms.size) return null
+
+        val next = forms[index + 1]
+        val asKeyword = next as? PhelKeyword ?: PsiTreeUtil.findChildOfType(next, PhelKeyword::class.java)
+        if (asKeyword?.text != ":as") return null
+
+        return PhelPsiUtils.asSymbol(forms[index + 2])?.text
+    }
+}

--- a/src/main/kotlin/org/phellang/language/psi/references/PhelReference.kt
+++ b/src/main/kotlin/org/phellang/language/psi/references/PhelReference.kt
@@ -1,871 +1,172 @@
 package org.phellang.language.psi.references
 
 import com.intellij.openapi.util.TextRange
-import com.intellij.psi.*
-import com.intellij.psi.search.FilenameIndex
-import com.intellij.psi.search.GlobalSearchScope
-import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementResolveResult
+import com.intellij.psi.PsiPolyVariantReference
+import com.intellij.psi.PsiReferenceBase
+import com.intellij.psi.ResolveResult
 import com.intellij.util.IncorrectOperationException
+import org.phellang.core.psi.PhelSymbolAnalyzer
+import org.phellang.language.psi.PhelNamespaceUtils
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.utils.PhelPsiUtils
 import java.util.Collections
 import java.util.IdentityHashMap
-import org.phellang.language.psi.utils.SymbolCategory
-import org.phellang.language.psi.utils.PhelPsiUtils
-import org.phellang.core.psi.PhelSymbolAnalyzer
-import org.phellang.language.psi.files.PhelFile
-import org.phellang.language.psi.PhelForm
-import org.phellang.language.psi.PhelList
-import org.phellang.language.psi.PhelNamespaceUtils
-import org.phellang.language.psi.PhelProjectNamespaceFinder
-import org.phellang.language.psi.PhelSymbol
-import org.phellang.language.psi.PhelVec
-import org.phellang.language.psi.PhelVendorUtils
 
 /**
- * Reference implementation for Phel symbols that supports resolving to multiple targets.
- * This handles cases where a symbol might refer to multiple definitions, such as:
- * - Function overloads
- * - Macro vs function with same name
- * - Forward declarations + definitions
- * - Redefinitions
+ * Reference for a Phel symbol, resolving to *every* matching target rather than just one — a name
+ * can be a function and a macro, a forward declaration and its definition, or simply redefined.
+ *
+ * This class owns only the [PsiReferenceBase] contract and the order in which the resolvers are
+ * consulted; each way of finding a target lives in its own resolver:
+ *
+ * * [PhelRequireNamespaceResolver] — the namespace head of a `(:require ...)` spec
+ * * [PhpClassResolver]             — PHP interop (`(:use ...)` entries, `Class/method`)
+ * * [PhelQualifiedSymbolResolver]  — `ns/name`, including `:as` aliases
+ * * [PhelLocalScopeResolver]       — `let` bindings and function parameters
+ * * [PhelDefinitionSearcher]       — top-level definitions in this file, then the project
+ * * [PhelUsageFinder]              — the reverse direction, when the symbol *is* the definition
  */
 class PhelReference @JvmOverloads constructor(
     element: PhelSymbol,
     /** True: find usages of this definition. False: resolve this usage to its definitions. */
     private val findUsages: Boolean = PhelSymbolAnalyzer.isDefinition(element)
 ) : PsiReferenceBase<PhelSymbol>(element, calculateRangeInElement(element)), PsiPolyVariantReference {
+
     private val symbolName: String? = PhelPsiUtils.getName(element)
 
     override fun multiResolve(incompleteCode: Boolean): Array<ResolveResult> {
-        if (symbolName == null || symbolName.isEmpty()) {
-            return ResolveResult.EMPTY_ARRAY
-        }
+        val name = symbolName?.takeIf { it.isNotEmpty() } ?: return ResolveResult.EMPTY_ARRAY
 
-        val results: MutableList<ResolveResult> = ArrayList()
-
-        if (findUsages) {
-            // Find all usages of this symbol (for definitions)
-            val usages = findAllUsages()
-            for (usage in usages) {
-                results.add(PsiElementResolveResult(usage))
-            }
+        val targets = if (findUsages) {
+            PhelUsageFinder.findUsages(myElement, name)
         } else {
-            // Find definitions (original behavior)
-            findDefinitions(results)
+            findDefinitions(name)
         }
 
-        return results.toTypedArray<ResolveResult>()
+        return targets.map(::PsiElementResolveResult).toTypedArray()
     }
 
-    private fun findDefinitions(results: MutableList<ResolveResult>) {
-        // Namespace reference inside an `(ns ... (:require foo\bar))` clause.
-        // Go-to-definition should jump to the required module's `(ns ...)` form,
-        // mirroring how IntelliJ resolves imports in other languages.
-        val namespaceTargets = resolveRequireNamespace()
-        if (namespaceTargets.isNotEmpty()) {
-            for (target in namespaceTargets) {
-                results.add(PsiElementResolveResult(target))
-            }
-            return
-        }
+    /**
+     * The first resolver to produce a target wins, so the order encodes precedence: a require head
+     * and a `(:use ...)` class must never fall through to Phel-side name matching, and a qualified
+     * symbol must not be matched against local scope.
+     */
+    private fun findDefinitions(name: String): List<PsiElement> {
+        PhelRequireNamespaceResolver.resolve(myElement)
+            .takeIf { it.isNotEmpty() }
+            ?.let { return it }
 
-        // A PHP class entry inside `(:use ...)` resolves only to its PHP declaration.
-        // Short-circuit here so Phel-side lookups can't false-match a bare class name
-        // (e.g. `InvalidArgumentException`) against its own in-file usages.
+        // A PHP class in `(:use ...)` resolves only to its PHP declaration — otherwise a bare class
+        // name such as `InvalidArgumentException` false-matches its own usages in this file.
         if (PhelNamespaceUtils.isUseClassSymbol(myElement)) {
-            addPhpClassResults(results)
-            return
+            return resolvePhpTargets()
         }
 
-        // Check if this is a namespace-qualified symbol (e.g., utils/greet, m/square)
-        val qualifier = PhelPsiUtils.getQualifier(myElement)
-        if (qualifier != null) {
-            // This is a qualified symbol - resolve by namespace
-            val namespacedDefinitions = resolveQualifiedSymbol(qualifier)
-            for (def in namespacedDefinitions) {
-                results.add(PsiElementResolveResult(def))
-            }
-            // For qualified symbols, don't search local scope or other files
-            return
+        PhelPsiUtils.getQualifier(myElement)?.let { qualifier ->
+            // PHP interop first: a PHP class qualifier must never be matched against a Phel namespace.
+            resolvePhpTargets().takeIf { it.isNotEmpty() }?.let { return it }
+            return PhelQualifiedSymbolResolver.resolve(myElement, qualifier, name)
         }
 
-        // Unqualified symbol - use original resolution logic.
-        // Collect definitions from every scope, de-duplicating by PSI identity so the
-        // same element added by two scopes is only reported once (polyvariant resolve).
+        return findUnqualifiedDefinitions(name)
+    }
+
+    /** Every scope an unqualified name can be declared in, de-duplicated by PSI identity. */
+    private fun findUnqualifiedDefinitions(name: String): List<PsiElement> {
         val seen = Collections.newSetFromMap(IdentityHashMap<PsiElement, Boolean>())
-        fun addUnique(element: PsiElement) {
-            if (seen.add(element)) results.add(PsiElementResolveResult(element))
-        }
+        val results = mutableListOf<PsiElement>()
 
-        // 1. Local scope (let/loop/fn bindings visible at the reference).
-        resolveInLocalScope()?.let(::addUnique)
+        fun addAll(elements: List<PsiElement>) = elements.forEach { if (seen.add(it)) results.add(it) }
 
-        // 2. Current file definitions (def, defn, defmacro, etc.) and function parameters.
-        resolveInCurrentFile().forEach(::addUnique)
-        findAllFunctionParameters().forEach(::addUnique)
+        addAll(listOfNotNull(PhelLocalScopeResolver.resolve(myElement, name)))
+        addAll(PhelDefinitionSearcher.findInCurrentFile(myElement, name))
+        myElement.containingFile?.let { addAll(PhelLocalScopeResolver.findAllParametersIn(it, name)) }
+        addAll(PhelDefinitionSearcher.findInProject(myElement, name))
 
-        // 3. Project-wide definitions (other files).
-        resolveInProject().forEach(::addUnique)
-
-        // 4. Phel standard library (vendor folder) - for core functions like map, filter, etc.
+        // The standard library is only consulted when nothing else matched — `map`, `filter` and the
+        // rest of phel\core would otherwise shadow a project's own definitions.
         if (results.isEmpty()) {
-            val vendorDefinitions = resolveInVendor(myElement.project, "core")
-            for (def in vendorDefinitions) {
-                results.add(PsiElementResolveResult(def))
-            }
+            addAll(PhelDefinitionFinder.collectVendorDefinitions(myElement.project, "core", name))
         }
 
-        // 5. PHP interop fall-through. Only runs when nothing Phel-side resolved AND the
-        //    text looks like an interop shorthand — keeps the cost off the hot path for
-        //    ordinary Phel symbols and is a no-op when the PHP plugin isn't installed.
+        // PHP interop is the last fall-through: a no-op when the PHP plugin isn't installed, and kept
+        // off the hot path for ordinary Phel symbols.
         if (results.isEmpty()) {
-            addPhpClassResults(results)
-        }
-    }
-
-    private fun addPhpClassResults(results: MutableList<ResolveResult>) {
-        val element = myElement
-        // Prefer specific members (e.g. `Class.` -> __construct method) so go-to-def
-        // lands on the precise PHP node; fall back to the class otherwise.
-        val memberTargets = PhpClassResolver.resolveAsPhpMember(element)
-        if (memberTargets.isNotEmpty()) {
-            for (target in memberTargets) results.add(PsiElementResolveResult(target))
-            return
-        }
-        val phpTargets = PhpClassResolver.resolveAsPhpClass(element)
-        for (target in phpTargets) results.add(PsiElementResolveResult(target))
-    }
-
-    /**
-     * Resolves a namespace symbol that appears as the head of a `(:require ...)` spec
-     * to the `(ns ...)` declaration of the module it imports. Returns an empty list when
-     * the symbol isn't a require namespace head, so the caller falls through to ordinary
-     * symbol resolution.
-     *
-     * Handles both layouts Phel allows:
-     * * `(:require foo\bar baz\qux)`            — namespace directly under the clause
-     * * `(:require [foo\bar :as fb :refer […]])` — namespace as the head of a vector spec
-     */
-    private fun resolveRequireNamespace(): List<PsiElement> {
-        val symbol = myElement
-        if (!isRequireNamespaceHead(symbol)) return emptyList()
-
-        val namespaceText = symbol.text ?: return emptyList()
-        if (namespaceText.isEmpty()) return emptyList()
-
-        val project = symbol.project
-        val target = PhelNamespaceUtils.normalizeNamespace(namespaceText)
-        val psiManager = PsiManager.getInstance(project)
-        val results: MutableList<PsiElement> = ArrayList()
-
-        // 1. Project files
-        val phelFiles = FilenameIndex.getAllFilesByExt(
-            project, "phel", GlobalSearchScope.projectScope(project)
-        )
-        // A matching file's (ns …) form ends with this segment, so its text must contain it —
-        // skip the parse for files that can't be the target.
-        val targetShortName = PhelProjectNamespaceFinder.extractShortNamespace(namespaceText)
-        for (virtualFile in phelFiles) {
-            val psiFile = psiManager.findFile(virtualFile) as? PhelFile ?: continue
-            if (!psiFile.text.contains(targetShortName)) continue
-            val nsDeclaration = PhelNamespaceUtils.findNamespaceDeclaration(psiFile) ?: continue
-            val fileNamespace = PhelNamespaceUtils.extractNamespaceFromDeclaration(nsDeclaration) ?: continue
-            if (PhelNamespaceUtils.normalizeNamespace(fileNamespace) == target) {
-                results.add(namespaceNavigationTarget(nsDeclaration))
-            }
-        }
-        if (results.isNotEmpty()) return results
-
-        // 2. Phel standard library (vendor folder), e.g. (:require phel\str)
-        val vendorFiles = PhelVendorUtils.findStandardLibraryFiles(project, namespaceText)
-        for (vendorFile in vendorFiles) {
-            val psiFile = psiManager.findFile(vendorFile) as? PhelFile ?: continue
-            val nsDeclaration = PhelNamespaceUtils.findNamespaceDeclaration(psiFile)
-            if (nsDeclaration != null &&
-                PhelNamespaceUtils.extractNamespaceFromDeclaration(nsDeclaration)
-                    ?.let(PhelNamespaceUtils::normalizeNamespace) == target
-            ) {
-                results.add(namespaceNavigationTarget(nsDeclaration))
-            }
-        }
-        // Fall back to the first vendor file's ns form when none matched exactly
-        // (e.g. phel\core is split across many bucket files).
-        if (results.isEmpty()) {
-            for (vendorFile in vendorFiles) {
-                val psiFile = psiManager.findFile(vendorFile) as? PhelFile ?: continue
-                val nsDeclaration = PhelNamespaceUtils.findNamespaceDeclaration(psiFile) ?: continue
-                results.add(namespaceNavigationTarget(nsDeclaration))
-                break
-            }
+            addAll(resolvePhpTargets())
         }
 
         return results
     }
 
-    /** True when [symbol] is the namespace head of a `(:require ...)` spec. */
-    private fun isRequireNamespaceHead(symbol: PhelSymbol): Boolean {
-        // A dot-separated namespace like `phel.string` parses as a PhelAccess form
-        // (the `.` is interop-access syntax), so the form node under the clause may be
-        // that wrapper rather than the symbol itself.
-        val node: PsiElement = if (symbol.parent is org.phellang.language.psi.PhelAccess) symbol.parent else symbol
-        val parent = node.parent
-        // (:require foo\bar) / (:require phel.string) — namespace directly under the clause
-        if (parent is PhelList && isRequireClause(parent)) {
-            return true
-        }
-        // (:require [foo\bar :as fb]) — namespace is the vector spec's head
-        if (parent is PhelVec) {
-            val grandParent = parent.parent
-            if (grandParent is PhelList && isRequireClause(grandParent) && parent.forms.firstOrNull() === node) {
-                return true
-            }
-        }
-        return false
-    }
+    /** Prefer the specific member (`Class.` -> `__construct`) so go-to-def lands on the precise node. */
+    private fun resolvePhpTargets(): List<PsiElement> {
+        val members = PhpClassResolver.resolveAsPhpMember(myElement)
+        if (members.isNotEmpty()) return members
 
-    private fun isRequireClause(list: PhelList): Boolean {
-        val head = list.forms.firstOrNull() ?: return false
-        val keyword = head as? org.phellang.language.psi.PhelKeyword
-            ?: PsiTreeUtil.findChildOfType(head, org.phellang.language.psi.PhelKeyword::class.java)
-        return keyword?.text == ":require"
-    }
-
-    /** The `(ns <name> ...)` name symbol to navigate to, falling back to the whole form. */
-    private fun namespaceNavigationTarget(nsDeclaration: PhelList): PsiElement {
-        val nameForm = nsDeclaration.forms.getOrNull(1)
-        val nameSymbol = nameForm as? PhelSymbol
-            ?: nameForm?.let { PsiTreeUtil.findChildOfType(it, PhelSymbol::class.java) }
-        return nameSymbol ?: nsDeclaration
-    }
-
-    /**
-     * Resolves a qualified symbol (e.g., utils/greet, m/square, str/join) to its definition.
-     * This handles:
-     * - Direct namespace imports: utils/greet -> phel-project\utils/greet
-     * - Aliased imports: m/square -> phel-project\math/square (when m is alias for math)
-     * - Unimported namespaces: searches project files by short namespace name
-     * - Standard library functions: searches vendor/phel-lang/phel/src/phel/
-     */
-    private fun resolveQualifiedSymbol(qualifier: String): MutableCollection<PsiElement> {
-        val results: MutableList<PsiElement> = ArrayList()
-        val containingFile = myElement.containingFile as? PhelFile ?: return results
-        val project = myElement.project
-
-        // PHP interop static call (`ClassName/method`, `\Foo\Bar/CONST`, …).
-        // Try the specific member (method/constant) first so go-to-def lands on
-        // the precise PHP node; fall back to the class if the member lookup
-        // misses (or when the PHP plugin isn't available).
-        val memberTargets = PhpClassResolver.resolveAsPhpMember(myElement)
-        if (memberTargets.isNotEmpty()) {
-            results.addAll(memberTargets)
-            return results
-        }
-        val phpTargets = PhpClassResolver.resolveAsPhpClass(myElement)
-        if (phpTargets.isNotEmpty()) {
-            results.addAll(phpTargets)
-            return results
-        }
-
-        // First, try to resolve the qualifier via imports (handles aliases)
-        val targetNamespace = resolveQualifierToNamespace(containingFile, qualifier)
-
-        // Determine the actual namespace to search for
-        val resolvedQualifier = if (targetNamespace != null) {
-            PhelProjectNamespaceFinder.extractShortNamespace(targetNamespace)
-        } else {
-            qualifier
-        }
-
-        // Check if this is a standard library namespace - search vendor folder
-        val vendorResults = resolveInVendor(project, resolvedQualifier)
-        results.addAll(vendorResults)
-
-        // Also search project files
-        val phelFiles = FilenameIndex.getAllFilesByExt(
-            project, "phel", GlobalSearchScope.projectScope(project)
-        )
-        val psiManager = PsiManager.getInstance(project)
-
-        for (virtualFile in phelFiles) {
-            val psiFile = psiManager.findFile(virtualFile) as? PhelFile ?: continue
-
-            val fileNamespace = PhelNamespaceUtils.extractNamespaceFromFile(psiFile) ?: continue
-            val fileShortNamespace = PhelProjectNamespaceFinder.extractShortNamespace(fileNamespace)
-
-            // Match by full namespace (if resolved from imports) OR by short namespace name
-            val matches = if (targetNamespace != null) {
-                fileNamespace == targetNamespace
-            } else {
-                // No import found - match by short namespace name
-                fileShortNamespace == qualifier
-            }
-
-            if (matches) {
-                // Found the file! Search for the definition in this file
-                val lists = PsiTreeUtil.findChildrenOfType(psiFile, PhelList::class.java)
-                for (list in lists) {
-                    val definition = findDefinitionInList(list)
-                    if (definition != null) {
-                        results.add(definition)
-                    }
-                }
-            }
-        }
-
-        return results
-    }
-
-    /**
-     * Searches for the symbol definition in the Phel standard library (vendor folder).
-     */
-    private fun resolveInVendor(project: com.intellij.openapi.project.Project, namespace: String): List<PsiElement> {
-        val results: MutableList<PsiElement> = ArrayList()
-
-        // Phel 0.35+: a namespace may be backed by multiple vendor files
-        // (e.g. phel.core spans core.phel + core/*.phel)
-        val vendorFiles = PhelVendorUtils.findStandardLibraryFiles(project, namespace)
-        if (vendorFiles.isEmpty()) return results
-
-        val psiManager = PsiManager.getInstance(project)
-        for (vendorFile in vendorFiles) {
-            val psiFile = psiManager.findFile(vendorFile) as? PhelFile ?: continue
-            val lists = PsiTreeUtil.findChildrenOfType(psiFile, PhelList::class.java)
-            for (list in lists) {
-                val definition = findDefinitionInList(list)
-                if (definition != null) {
-                    results.add(definition)
-                }
-            }
-        }
-
-        return results
-    }
-
-    /**
-     * Resolves a qualifier to a full namespace name using the file's imports.
-     * Handles both direct imports and aliases.
-     *
-     * @param file The file containing the symbol
-     * @param qualifier The qualifier (e.g., "utils", "m", "str")
-     * @return The full namespace (e.g., "phel-project\\utils", "phel-project\\math", "phel\\str"),
-     *         or null if the qualifier is not found in imports
-     */
-    private fun resolveQualifierToNamespace(file: PhelFile, qualifier: String): String? {
-        val nsDeclaration = PhelNamespaceUtils.findNamespaceDeclaration(file) ?: return null
-        val requireForms = PhelNamespaceUtils.findRequireForms(nsDeclaration)
-        
-        if (requireForms.isEmpty()) {
-            return null // No imports, will fall back to short namespace matching
-        }
-
-        for (requireForm in requireForms) {
-            val forms = requireForm.forms
-
-            var i = 1
-            while (i < forms.size) {
-                val form = forms[i]
-                val namespaceSymbol = if (form is PhelSymbol) form
-                else PsiTreeUtil.findChildOfType(form, PhelSymbol::class.java)
-
-                if (namespaceSymbol != null) {
-                    val fullNamespace = namespaceSymbol.text
-                    val shortNamespace = PhelProjectNamespaceFinder.extractShortNamespace(fullNamespace)
-
-                    // Check for :as alias pattern
-                    if (i + 2 < forms.size) {
-                        val nextForm = forms[i + 1]
-                        val asKeyword = nextForm as? org.phellang.language.psi.PhelKeyword
-                            ?: PsiTreeUtil.findChildOfType(nextForm, org.phellang.language.psi.PhelKeyword::class.java)
-
-                        if (asKeyword?.text == ":as") {
-                            val aliasForm = forms[i + 2]
-                            val aliasSymbol = if (aliasForm is PhelSymbol) aliasForm
-                            else PsiTreeUtil.findChildOfType(aliasForm, PhelSymbol::class.java)
-
-                            if (aliasSymbol != null && aliasSymbol.text == qualifier) {
-                                // Qualifier matches an alias
-                                return fullNamespace
-                            }
-                            i += 3
-                            continue
-                        }
-                    }
-
-                    // Check if qualifier matches short namespace (direct import)
-                    if (shortNamespace == qualifier) {
-                        return fullNamespace
-                    }
-                }
-                i++
-            }
-        }
-
-        return null
-    }
-
-    private fun findAllUsages(): MutableCollection<PsiElement> {
-        val usages: MutableList<PsiElement> = ArrayList()
-
-        // For function parameters, let bindings, etc., only search within the local scope
-        if (PhelSymbolAnalyzer.isDefinition(myElement) && this.isLocalBinding) {
-            // For local bindings, search only within the containing form (function/let block)
-            val localUsages = findUsagesInLocalScope()
-            if (!localUsages.isEmpty()) {
-                usages.addAll(localUsages)
-                return usages // Local bindings skip project-wide search.
-            }
-        }
-
-        // Search current file for usages and other definitions
-        val containingFile = myElement.containingFile
-        if (containingFile is PhelFile) {
-            val allSymbols = PsiTreeUtil.findChildrenOfType(containingFile, PhelSymbol::class.java)
-
-            for (symbol in allSymbols) {
-                if (symbol !== null) {
-                    val name = PhelPsiUtils.getName(symbol)
-                    if (symbolName == name && symbol !== myElement) {
-                        // Include both usages AND other definitions (but not the element we clicked on)
-                        usages.add(symbol)
-                    }
-                }
-            }
-        }
-
-        // Search project-wide ONLY for top-level definitions (def, defn, etc.)
-        // Skip expensive project-wide search for local bindings
-        if (!this.isLocalBinding) {
-            val project = myElement.project
-            val projectScope = GlobalSearchScope.projectScope(project)
-
-            val phelFiles = FilenameIndex.getAllFilesByExt(project, "phel", projectScope)
-            for (virtualFile in phelFiles) {
-                if (virtualFile == containingFile.virtualFile) {
-                    continue  // Skip current file (already searched above)
-                }
-
-                val psiFile = PsiManager.getInstance(project).findFile(virtualFile)
-                if (psiFile !is PhelFile) continue
-                // Fast reject: skip files whose text doesn't contain the name at all.
-                if (symbolName != null && !psiFile.text.contains(symbolName)) continue
-
-                val allSymbols = PsiTreeUtil.findChildrenOfType(psiFile, PhelSymbol::class.java)
-
-                for (symbol in allSymbols) {
-                    val name = PhelPsiUtils.getName(symbol)
-                    if (symbolName == name) {
-                        // Include both usages AND definitions from other files
-                        usages.add(symbol)
-                    }
-                }
-            }
-        }
-
-        return usages
-    }
-
-    private val isLocalBinding: Boolean
-        /**
-         * Check if this symbol is a local binding (parameter, let binding, etc.)
-         * This checks if it's NOT a top-level definition (def, defn, etc.)
-         */
-        get() {
-            if (!PhelSymbolAnalyzer.isDefinition(myElement)) {
-                return false // Not a definition at all
-            }
-
-            // Check if it's inside a parameter vector or binding vector
-            PsiTreeUtil.getParentOfType(myElement, PhelVec::class.java)
-                ?: return false // Not in a vector, so likely a top-level definition
-
-            // If it's in a vector, it's likely a parameter or binding (local binding)
-            return true
-        }
-
-    private fun findUsagesInLocalScope(): MutableCollection<PsiElement> {
-        val usages: MutableList<PsiElement> = ArrayList()
-
-        // Find the containing function or let form
-        val containingForm = findContainingForm() ?: return usages
-
-        // Search only within this form
-        val localSymbols = PsiTreeUtil.findChildrenOfType(containingForm, PhelSymbol::class.java)
-
-        for (symbol in localSymbols) {
-            val name = PhelPsiUtils.getName(symbol)
-            if (symbolName == name && symbol !== myElement && !PhelSymbolAnalyzer.isDefinition(symbol)) {
-                // Include only usages (not other definitions) within local scope
-                usages.add(symbol)
-            }
-        }
-
-        return usages
-    }
-
-    private fun findContainingForm(): PhelList? {
-        var current = myElement.parent
-
-        while (current != null) {
-            if (current is PhelList) {
-                val list = current
-
-                // Check if this is a defining form
-                val firstForm = PsiTreeUtil.findChildOfType(list, PhelForm::class.java)
-                if (firstForm != null) {
-                    val firstSymbol = PsiTreeUtil.findChildOfType(firstForm, PhelSymbol::class.java)
-                    if (firstSymbol != null) {
-                        val keyword = firstSymbol.text
-                        if (PhelSymbolAnalyzer.isSymbolType(keyword, SymbolCategory.SPECIAL_FORMS) ||
-                            PhelSymbolAnalyzer.isSymbolType(keyword, SymbolCategory.CONTROL_FLOW)) {
-                            return list
-                        }
-                    }
-                }
-            }
-            current = current.parent
-        }
-
-        return null
+        return PhpClassResolver.resolveAsPhpClass(myElement)
     }
 
     override fun resolve(): PsiElement? {
         val results = multiResolve(false)
 
-        // For definitions finding usages, return null if multiple usages exist
-        // This forces IntelliJ to show the polyvariant selection modal
-        if (findUsages && results.size > 1) {
-            return null // Force modal for multiple usages
-        }
+        // Several usages of one definition: returning null makes the platform show its own chooser
+        // rather than silently jumping to the first.
+        if (findUsages && results.size > 1) return null
 
-        // For single targets or usage-to-definition, return the first result
-        return if (results.isNotEmpty()) results[0].element else null
+        return results.firstOrNull()?.element
     }
 
-    override fun isReferenceTo(element: PsiElement): Boolean {
-        val results = multiResolve(false)
-        for (result in results) {
-            if (element == result.element) {
-                return true
-            }
-        }
-        return false
-    }
+    override fun isReferenceTo(element: PsiElement): Boolean =
+        multiResolve(false).any { element == it.element }
 
     override fun getVariants(): Array<Any?> {
+        val name = symbolName ?: return emptyArray()
+
         val variants = mutableListOf<PsiElement>()
+        variants += listOfNotNull(PhelLocalScopeResolver.resolve(myElement, name))
+        variants += PhelDefinitionSearcher.findInCurrentFile(myElement, name)
 
-        val localDef = resolveInLocalScope()
-        if (localDef != null) variants.add(localDef)
-
-        variants.addAll(resolveInCurrentFile())
-
-        if (variants.size < 20) {
-            variants.addAll(resolveInProject())
+        if (variants.size < MAX_PROJECT_VARIANTS) {
+            variants += PhelDefinitionSearcher.findInProject(myElement, name)
         }
 
         return variants.toTypedArray()
     }
 
     @Throws(IncorrectOperationException::class)
-    override fun handleElementRename(newElementName: String): PsiElement? {
-        if (myElement is PhelSymbol) {
-            val symbol = myElement as PhelSymbol
+    override fun handleElementRename(newElementName: String): PsiElement {
+        val currentText = myElement.text ?: return myElement
 
-            // For qualified symbols like "ns/symbol", only rename the symbol part
-            val currentText = symbol.text
-            if (currentText != null && currentText.contains("/")) {
-                val slashIndex = currentText.lastIndexOf('/')
-                val qualifier = currentText.take(slashIndex + 1)
-                val newText = qualifier + newElementName
-                return symbol.setName(newText)
-            } else {
-                // For unqualified symbols, replace entire text
-                return symbol.setName(newElementName)
-            }
+        // A qualified symbol renames only its name part: `str/join` -> `str/<new>`.
+        val slashIndex = currentText.lastIndexOf('/')
+        val newText = if (slashIndex >= 0) {
+            currentText.take(slashIndex + 1) + newElementName
+        } else {
+            newElementName
         }
-        return null
+
+        return myElement.setName(newText)
     }
 
     @Throws(IncorrectOperationException::class)
-    override fun bindToElement(element: PsiElement): PsiElement? {
-        return myElement
-    }
-
-    // === Resolution Methods ===
-    private fun resolveInLocalScope(): PsiElement? {
-        var current: PsiElement? = myElement
-
-        // Walk up the PSI tree looking for binding contexts
-        while (current != null) {
-            // Check for let bindings
-            val letForm = PsiTreeUtil.getParentOfType(current, PhelList::class.java)
-            if (letForm != null) {
-                val binding = findInLetBindings(letForm)
-                if (binding != null) {
-                    return binding
-                }
-            }
-
-            // Check for function parameters
-            val fnParam = findInFunctionParameters(current)
-            if (fnParam != null) {
-                return fnParam
-            }
-
-            current = current.parent
-        }
-
-        return null
-    }
-
-    private fun resolveInCurrentFile(): MutableCollection<PsiElement> {
-        val results: MutableList<PsiElement> = ArrayList()
-        val file = myElement.containingFile
-
-        if (file != null) {
-            val lists = PsiTreeUtil.findChildrenOfType(file, PhelList::class.java)
-            for (list in lists) {
-                val definition = findDefinitionInList(list)
-                if (definition != null) {
-                    results.add(definition)
-                }
-            }
-        }
-
-        return results
-    }
-
-    private fun resolveInProject(): MutableCollection<PsiElement> {
-        val results: MutableList<PsiElement> = ArrayList()
-        val project = myElement.project
-
-        // Find all .phel files in the project
-        val phelFiles = FilenameIndex.getAllFilesByExt(
-            project, "phel", GlobalSearchScope.projectScope(project)
-        )
-
-        val psiManager = PsiManager.getInstance(project)
-
-        for (file in phelFiles) {
-            val psiFile = psiManager.findFile(file)
-            if (psiFile == null || psiFile == myElement.containingFile) continue
-            // Fast reject: a file whose text doesn't mention the name can't define it, so
-            // skip the PSI walk for the many files that don't reference this symbol.
-            if (symbolName != null && !psiFile.text.contains(symbolName)) continue
-
-            val lists = PsiTreeUtil.findChildrenOfType(psiFile, PhelList::class.java)
-            for (list in lists) {
-                val definition = findDefinitionInList(list)
-                if (definition != null) {
-                    results.add(definition)
-                }
-            }
-        }
-
-        return results
-    }
-
-    private fun findInLetBindings(letForm: PhelList): PsiElement? {
-        val forms = letForm.forms
-        if (forms.size < 2) return null
-
-        // Only binding forms whose second element is a `[name value ...]` vector are
-        // relevant here. `catch` was historically listed too, but its second element is
-        // the exception class (not a vector), so it never matched — and `when-let` was
-        // missing, so its bindings failed to resolve. The shared set fixes both.
-        val firstSymbol = PsiTreeUtil.findChildOfType(forms[0], PhelSymbol::class.java) ?: return null
-        val formType = firstSymbol.text
-        if (formType !in org.phellang.language.psi.PhelSpecialForms.LET_LIKE) {
-            return null
-        }
-
-        // Look at binding vector - forms[1] should BE the vector directly
-        val bindingsVec = if (forms[1] is PhelVec) {
-            forms[1] as PhelVec
-        } else {
-            // Fallback: look inside forms[1] for a vector
-            PsiTreeUtil.findChildOfType(forms[1], PhelVec::class.java)
-        }
-
-        if (bindingsVec == null) {
-            return null
-        }
-
-        val bindings = bindingsVec.forms
-
-        // Bindings are pairs: [symbol1 value1 symbol2 value2 ...]
-        var i = 0
-        while (i < bindings.size) {
-            val bindingSymbol = PsiTreeUtil.findChildOfType(bindings[i], PhelSymbol::class.java)
-            if (bindingSymbol != null && symbolName == bindingSymbol.text) {
-                return bindingSymbol
-            }
-            i += 2
-        }
-
-        return null
-    }
-
-    /**
-     * Find symbol in function parameters: (defn func-name [param1 param2] ...)
-     * This searches for ALL function parameters with matching names, not just in the current function.
-     */
-    private fun findInFunctionParameters(context: PsiElement): PsiElement? {
-        // Walk up the PSI tree to find ALL parent PhelList elements
-        // We need to check each one to see if it's a function definition
-        var current: PsiElement? = context
-
-        while (current != null) {
-            // Find the next parent PhelList
-            val fnForm = PsiTreeUtil.getParentOfType(current, PhelList::class.java) ?: break
-
-            val forms = fnForm.forms
-            if (forms.size >= 2) {
-                val fnKeyword = PsiTreeUtil.findChildOfType(forms[0], PhelSymbol::class.java)
-
-                if (fnKeyword != null) {
-                    val keyword = fnKeyword.text
-                    val paramVec = findParameterVectorInForms(forms, keyword)
-
-                    if (paramVec != null) {
-                        for (param in paramVec.forms) {
-                            val paramSymbol = PsiTreeUtil.findChildOfType(param, PhelSymbol::class.java)
-                            if (paramSymbol != null && symbolName == paramSymbol.text) {
-                                return paramSymbol
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Continue searching up the tree
-            current = fnForm.parent
-        }
-
-        return null
-    }
-
-    /**
-     * Find ALL function parameters with matching names in the current file.
-     * This is for polyvariant resolution - show all parameter definitions.
-     */
-    private fun findAllFunctionParameters(): MutableCollection<PsiElement> {
-        val results: MutableList<PsiElement> = ArrayList()
-        val file = myElement.containingFile
-
-        if (file != null) {
-            val lists = PsiTreeUtil.findChildrenOfType(file, PhelList::class.java)
-            for (list in lists) {
-                val forms = list.forms
-                if (forms.size < 2) continue
-
-                val fnKeyword = PsiTreeUtil.findChildOfType(forms[0], PhelSymbol::class.java) ?: continue
-                val keyword = fnKeyword.text
-                val paramVec = findParameterVectorInForms(forms, keyword) ?: continue
-
-                for (param in paramVec.forms) {
-                    val paramSymbol = PsiTreeUtil.findChildOfType(param, PhelSymbol::class.java)
-                    if (paramSymbol != null && symbolName == paramSymbol.text) {
-                        results.add(paramSymbol)
-                    }
-                }
-            }
-        }
-
-        return results
-    }
-
-    /**
-     * Find definition in a list form: (def name value), (defn name [...] ...), etc.
-     */
-    private fun findDefinitionInList(list: PhelList): PsiElement? {
-        val forms = list.forms
-        if (forms.size < 2) return null
-
-        // Check if this is a defining form
-        val defKeyword = PsiTreeUtil.findChildOfType(forms[0], PhelSymbol::class.java)
-        val keywordText = defKeyword?.text
-
-        if (defKeyword == null || !isDefiningKeyword(keywordText)) {
-            return null
-        }
-
-        // Get the defined name (second element)
-        val definedName = PsiTreeUtil.findChildOfType(forms[1], PhelSymbol::class.java)
-
-        if (definedName != null && symbolName == definedName.text) {
-            return definedName
-        }
-
-        return null
-    }
-
-    /**
-     * Checks if the keyword is a defining form (defn, def, defmacro, etc.).
-     */
-    private fun isDefiningKeyword(keyword: String?): Boolean {
-        if (keyword == null) return false
-
-        // Direct check for common defining keywords
-        return keyword in DEFINING_KEYWORDS ||
-            PhelSymbolAnalyzer.isSymbolType(keyword, SymbolCategory.SPECIAL_FORMS)
-             || PhelSymbolAnalyzer.isSymbolType(keyword, SymbolCategory.MACROS)
-    }
+    override fun bindToElement(element: PsiElement): PsiElement = myElement
 
     companion object {
-        /**
-         * Keywords that define new symbols.
-         */
-        private val DEFINING_KEYWORDS = setOf(
-            "def", "defn", "defn-", "defmacro", "defmacro-",
-            "defstruct", "definterface", "def-"
-        )
+        /** Project-wide variants are only collected while the list is still short enough to be useful. */
+        private const val MAX_PROJECT_VARIANTS = 20
 
-        /**
-         * Calculate the text range within the symbol that represents the reference.
-         * For qualified symbols like "ns/symbol", we only reference the symbol part.
-         */
+        /** A qualified symbol references only the part after the `/`; an unqualified one, all of it. */
         private fun calculateRangeInElement(element: PhelSymbol): TextRange {
             val text = element.text ?: return TextRange.EMPTY_RANGE
 
-            // For qualified symbols, reference only the name part after '/'
             val slashIndex = text.lastIndexOf('/')
             if (slashIndex >= 0 && slashIndex < text.length - 1) {
                 return TextRange.from(slashIndex + 1, text.length - slashIndex - 1)
             }
 
-            // For unqualified symbols, reference the entire text
             return TextRange.from(0, text.length)
-        }
-    }
-
-    private fun findParameterVectorInForms(forms: List<PhelForm>, keyword: String): PhelVec? {
-        return when (keyword) {
-            "fn" -> {
-                // For (fn [params] ...), parameter vector is at index 1
-                if (forms.size >= 2) {
-                    if (forms[1] is PhelVec) {
-                        forms[1] as PhelVec
-                    } else {
-                        PsiTreeUtil.findChildOfType(forms[1], PhelVec::class.java)
-                    }
-                } else null
-            }
-            "defn", "defn-", "defmacro", "defmacro-" -> {
-                // For defn forms, find the first vector after the function name
-                // Skip docstring and metadata: (defn name "doc" {:meta} [params] ...)
-                for (i in 2 until forms.size) {
-                    if (forms[i] is PhelVec) {
-                        return forms[i] as PhelVec
-                    }
-                    // Also check if the form contains a vector (for nested structures)
-                    val nestedVec = PsiTreeUtil.findChildOfType(forms[i], PhelVec::class.java)
-                    if (nestedVec != null) {
-                        return nestedVec
-                    }
-                }
-                null
-            }
-            else -> null
         }
     }
 }

--- a/src/main/kotlin/org/phellang/language/psi/references/PhelRequireNamespaceResolver.kt
+++ b/src/main/kotlin/org/phellang/language/psi/references/PhelRequireNamespaceResolver.kt
@@ -1,0 +1,108 @@
+package org.phellang.language.psi.references
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiManager
+import com.intellij.psi.search.FilenameIndex
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.language.psi.PhelAccess
+import org.phellang.language.psi.PhelKeyword
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelNamespaceUtils
+import org.phellang.language.psi.PhelProjectNamespaceFinder
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.PhelVec
+import org.phellang.language.psi.PhelVendorUtils
+import org.phellang.language.psi.files.PhelFile
+
+/**
+ * Resolves the namespace at the head of a `(:require ...)` spec to the `(ns ...)` form of the module
+ * it imports, so go-to-definition on an import jumps to that module — as it does in other languages.
+ *
+ * Returns an empty list when the symbol isn't a require head, letting the caller fall through to
+ * ordinary symbol resolution.
+ */
+internal object PhelRequireNamespaceResolver {
+
+    fun resolve(symbol: PhelSymbol): List<PsiElement> {
+        if (!isRequireNamespaceHead(symbol)) return emptyList()
+
+        val namespaceText = symbol.text?.takeIf { it.isNotEmpty() } ?: return emptyList()
+        val project = symbol.project
+        val target = PhelNamespaceUtils.normalizeNamespace(namespaceText)
+
+        val inProject = findInProjectFiles(symbol, namespaceText, target)
+        if (inProject.isNotEmpty()) return inProject
+
+        return findInVendor(symbol, namespaceText, target)
+    }
+
+    private fun findInProjectFiles(symbol: PhelSymbol, namespaceText: String, target: String): List<PsiElement> {
+        val project = symbol.project
+        val psiManager = PsiManager.getInstance(project)
+        val phelFiles = FilenameIndex.getAllFilesByExt(project, "phel", GlobalSearchScope.projectScope(project))
+
+        // A matching file's (ns …) form ends with this segment, so its text must contain it —
+        // skip the parse for files that cannot be the target.
+        val targetShortName = PhelProjectNamespaceFinder.extractShortNamespace(namespaceText)
+
+        return phelFiles
+            .mapNotNull { psiManager.findFile(it) as? PhelFile }
+            .filter { it.text.contains(targetShortName) }
+            .mapNotNull { PhelNamespaceUtils.findNamespaceDeclaration(it) }
+            .filter { declaresNamespace(it, target) }
+            .map(::navigationTarget)
+    }
+
+    private fun findInVendor(symbol: PhelSymbol, namespaceText: String, target: String): List<PsiElement> {
+        val project = symbol.project
+        val psiManager = PsiManager.getInstance(project)
+
+        val declarations = PhelVendorUtils.findStandardLibraryFiles(project, namespaceText)
+            .mapNotNull { psiManager.findFile(it) as? PhelFile }
+            .mapNotNull { PhelNamespaceUtils.findNamespaceDeclaration(it) }
+
+        val exact = declarations.filter { declaresNamespace(it, target) }.map(::navigationTarget)
+        if (exact.isNotEmpty()) return exact
+
+        // No exact match: fall back to the first vendor file's ns form, because a namespace such as
+        // phel\core is split across many bucket files and none of them declares it on its own.
+        return listOfNotNull(declarations.firstOrNull()?.let(::navigationTarget))
+    }
+
+    private fun declaresNamespace(nsDeclaration: PhelList, target: String): Boolean =
+        PhelNamespaceUtils.extractNamespaceFromDeclaration(nsDeclaration)
+            ?.let(PhelNamespaceUtils::normalizeNamespace) == target
+
+    /** The `(ns <name> ...)` name symbol to navigate to, falling back to the whole form. */
+    private fun navigationTarget(nsDeclaration: PhelList): PsiElement {
+        val nameForm = nsDeclaration.forms.getOrNull(1)
+        val nameSymbol = nameForm as? PhelSymbol
+            ?: nameForm?.let { PsiTreeUtil.findChildOfType(it, PhelSymbol::class.java) }
+        return nameSymbol ?: nsDeclaration
+    }
+
+    private fun isRequireNamespaceHead(symbol: PhelSymbol): Boolean {
+        // A dot-separated namespace like `phel.string` parses as a PhelAccess form (the `.` is
+        // interop-access syntax), so the node under the clause may be that wrapper, not the symbol.
+        val node: PsiElement = if (symbol.parent is PhelAccess) symbol.parent else symbol
+        val parent = node.parent
+
+        // (:require foo\bar) / (:require phel.string) — namespace directly under the clause
+        if (parent is PhelList && isRequireClause(parent)) return true
+
+        // (:require [foo\bar :as fb]) — namespace is the vector spec's head
+        if (parent is PhelVec) {
+            val grandParent = parent.parent
+            return grandParent is PhelList && isRequireClause(grandParent) && parent.forms.firstOrNull() === node
+        }
+
+        return false
+    }
+
+    private fun isRequireClause(list: PhelList): Boolean {
+        val head = list.forms.firstOrNull() ?: return false
+        val keyword = head as? PhelKeyword ?: PsiTreeUtil.findChildOfType(head, PhelKeyword::class.java)
+        return keyword?.text == ":require"
+    }
+}

--- a/src/main/kotlin/org/phellang/language/psi/references/PhelUsageFinder.kt
+++ b/src/main/kotlin/org/phellang/language/psi/references/PhelUsageFinder.kt
@@ -1,0 +1,103 @@
+package org.phellang.language.psi.references
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiManager
+import com.intellij.psi.search.FilenameIndex
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.core.psi.PhelSymbolAnalyzer
+import org.phellang.language.psi.PhelForm
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.PhelVec
+import org.phellang.language.psi.files.PhelFile
+import org.phellang.language.psi.utils.PhelPsiUtils
+import org.phellang.language.psi.utils.SymbolCategory
+
+/**
+ * Finds the usages of a definition — the reverse direction of [PhelReference], taken when the
+ * clicked symbol *is* the definition.
+ *
+ * A local binding (a parameter or `let` name) can only be used inside the form that introduces it,
+ * so its search stops there. Only top-level definitions justify the project-wide scan.
+ */
+internal object PhelUsageFinder {
+
+    fun findUsages(symbol: PhelSymbol, symbolName: String): List<PsiElement> {
+        if (isLocalBinding(symbol)) {
+            val localUsages = findInLocalScope(symbol, symbolName)
+            if (localUsages.isNotEmpty()) return localUsages
+        }
+
+        val usages = mutableListOf<PsiElement>()
+        usages += findInCurrentFile(symbol, symbolName)
+
+        if (!isLocalBinding(symbol)) {
+            usages += findAcrossProject(symbol, symbolName)
+        }
+
+        return usages
+    }
+
+    /** Both usages *and* other definitions in this file — but never the symbol that was clicked. */
+    private fun findInCurrentFile(symbol: PhelSymbol, symbolName: String): List<PsiElement> {
+        val containingFile = symbol.containingFile as? PhelFile ?: return emptyList()
+
+        return PsiTreeUtil.findChildrenOfType(containingFile, PhelSymbol::class.java)
+            .filter { it !== symbol && symbolName == PhelPsiUtils.getName(it) }
+    }
+
+    private fun findAcrossProject(symbol: PhelSymbol, symbolName: String): List<PsiElement> {
+        val project = symbol.project
+        val currentFile = symbol.containingFile?.virtualFile
+        val psiManager = PsiManager.getInstance(project)
+
+        return FilenameIndex.getAllFilesByExt(project, "phel", GlobalSearchScope.projectScope(project))
+            .filter { it != currentFile }
+            .mapNotNull { psiManager.findFile(it) as? PhelFile }
+            // Fast reject: a file whose text never mentions the name cannot use it, so skip the
+            // PSI walk for the many files that don't.
+            .filter { it.text.contains(symbolName) }
+            .flatMap { PsiTreeUtil.findChildrenOfType(it, PhelSymbol::class.java) }
+            .filter { symbolName == PhelPsiUtils.getName(it) }
+    }
+
+    /** Usages only — other definitions of the same name in scope are not usages of this one. */
+    private fun findInLocalScope(symbol: PhelSymbol, symbolName: String): List<PsiElement> {
+        val containingForm = findContainingForm(symbol) ?: return emptyList()
+
+        return PsiTreeUtil.findChildrenOfType(containingForm, PhelSymbol::class.java)
+            .filter { it !== symbol }
+            .filter { symbolName == PhelPsiUtils.getName(it) }
+            .filterNot { PhelSymbolAnalyzer.isDefinition(it) }
+    }
+
+    /** The nearest enclosing special form or control-flow form — the scope a binding is confined to. */
+    private fun findContainingForm(symbol: PhelSymbol): PhelList? {
+        var current = symbol.parent
+
+        while (current != null) {
+            if (current is PhelList && introducesScope(current)) return current
+            current = current.parent
+        }
+
+        return null
+    }
+
+    private fun introducesScope(list: PhelList): Boolean {
+        val firstForm = PsiTreeUtil.findChildOfType(list, PhelForm::class.java) ?: return false
+        val keyword = PsiTreeUtil.findChildOfType(firstForm, PhelSymbol::class.java)?.text ?: return false
+
+        return PhelSymbolAnalyzer.isSymbolType(keyword, SymbolCategory.SPECIAL_FORMS) ||
+                PhelSymbolAnalyzer.isSymbolType(keyword, SymbolCategory.CONTROL_FLOW)
+    }
+
+    /**
+     * A definition sitting inside a vector is a parameter or a `let` name — i.e. local. A top-level
+     * `(def x …)` has no enclosing vector.
+     */
+    private fun isLocalBinding(symbol: PhelSymbol): Boolean {
+        if (!PhelSymbolAnalyzer.isDefinition(symbol)) return false
+        return PsiTreeUtil.getParentOfType(symbol, PhelVec::class.java) != null
+    }
+}

--- a/src/main/kotlin/org/phellang/language/psi/references/PhpClassResolver.kt
+++ b/src/main/kotlin/org/phellang/language/psi/references/PhpClassResolver.kt
@@ -1,38 +1,23 @@
 package org.phellang.language.psi.references
 
-import com.intellij.openapi.diagnostic.Logger
-import com.intellij.openapi.progress.ProcessCanceledException
-import com.intellij.openapi.project.IndexNotReadyException
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
-import com.intellij.psi.util.PsiTreeUtil
 import org.phellang.language.psi.PhelInteropShorthands
 import org.phellang.language.psi.PhelNamespaceUtils
 import org.phellang.language.psi.PhelSymbol
 import org.phellang.language.psi.files.PhelFile
-import java.lang.reflect.InvocationTargetException
 
 /**
- * Reflection-based bridge to the JetBrains PHP plugin (PhpStorm / Ultimate with
- * the PHP plugin installed). Resolves a Phel interop symbol to its underlying
- * PHP class — or, where applicable, a specific class member — so go-to-definition
- * jumps straight into the PHP source.
- *
- * The PHP plugin is **not** a compile-time dependency — we never want to break
- * Phel support in IDEA Community / WebStorm / Rider just because PHP isn't on
- * the classpath. Instead we load `com.jetbrains.php.PhpIndex` reflectively on
- * first use; if absent (or anything else goes wrong) we return an empty list,
- * which is the same as "no PHP target found" and lets the existing Phel-only
- * resolution remain authoritative.
+ * Resolves a Phel interop symbol to its underlying PHP class — or a specific member — so
+ * go-to-definition jumps into the PHP source. This is the mapping half: turning a Phel symbol into
+ * the PHP FQN and member name to look up. The reflective lookup itself lives in [PhpIndexBridge],
+ * which also isolates the fact that the PHP plugin is an optional, reflectively-loaded dependency.
  */
 object PhpClassResolver {
 
-    private val LOG = Logger.getInstance(PhpClassResolver::class.java)
-
     /**
-     * Member kinds we surface from a PHP class. We deliberately exclude private/
-     * protected members from completion and resolution since Phel can only call
-     * what's public from outside the class.
+     * Member kinds surfaced from a PHP class. Private/protected members are excluded from completion
+     * and resolution, since Phel can only call what is public from outside the class.
      */
     enum class MemberKind { METHOD, CONSTANT, FIELD }
 
@@ -44,65 +29,39 @@ object PhpClassResolver {
         val element: PsiElement,
     )
 
-    @Volatile
-    private var phpIndexClass: Class<*>? = null
-
-    @Volatile
-    private var checkedForPhpPlugin: Boolean = false
-
-    // ──────────────────────────────────────────────────────────────────────────
-    // Class-level resolution (existing API; unchanged surface)
-    // ──────────────────────────────────────────────────────────────────────────
-
     fun resolveAsPhpClass(symbol: PhelSymbol): List<PsiElement> {
-        if (!checkedForPhpPlugin) loadPhpIndexClass()
-        if (phpIndexClass == null) return emptyList()
+        if (!PhpIndexBridge.isAvailable()) return emptyList()
         val fqn = computeTargetFqn(symbol) ?: return emptyList()
-        return findClassesByFqn(symbol.project, fqn).mapNotNull { it as? PsiElement }
+        return PhpIndexBridge.findClassesByFqn(symbol.project, fqn).mapNotNull { it as? PsiElement }
     }
 
     /**
-     * Resolves to a specific member (`Foo/method`, `Foo/CONST`, `\Foo\Bar/m`) or to
-     * the constructor when the symbol is the `(Class. ...)` head. Falls back to an
-     * empty list when the PHP plugin isn't available or the member can't be found —
-     * callers should then call [resolveAsPhpClass] for the class-level fallback.
+     * Resolves to a specific member (`Foo/method`, `Foo/CONST`, `\Foo\Bar/m`) or to the constructor
+     * when the symbol is the `(Class. ...)` head. Empty when the PHP plugin isn't available or the
+     * member can't be found — callers should then try [resolveAsPhpClass] for the class-level fallback.
      */
     fun resolveAsPhpMember(symbol: PhelSymbol): List<PsiElement> {
-        if (!checkedForPhpPlugin) loadPhpIndexClass()
-        if (phpIndexClass == null) return emptyList()
+        if (!PhpIndexBridge.isAvailable()) return emptyList()
 
         val text = symbol.text ?: return emptyList()
         val classFqn = computeTargetFqn(symbol) ?: return emptyList()
         val memberName = extractMemberName(text) ?: return emptyList()
-        val classes = findClassesByFqn(symbol.project, classFqn)
-        if (classes.isEmpty()) return emptyList()
 
-        return classes.flatMap { phpClass ->
-            findMemberInClass(phpClass, memberName)
-        }
+        return PhpIndexBridge.findClassesByFqn(symbol.project, classFqn)
+            .flatMap { PhpIndexBridge.findMemberInClass(it, memberName) }
     }
 
     /**
-     * Enumerates the public, *statically reachable* members of [classFqn] for use
-     * in completion. Inherited members are included. Returns an empty list when
-     * the PHP plugin isn't available.
+     * The public, statically reachable members of [classFqn] for completion, inherited members
+     * included, deduplicated by kind+name. Empty when the PHP plugin isn't available.
      */
     fun listMembers(project: Project, classFqn: String): List<PhpMemberInfo> {
-        if (!checkedForPhpPlugin) loadPhpIndexClass()
-        if (phpIndexClass == null) return emptyList()
-
-        val classes = findClassesByFqn(project, classFqn)
-        if (classes.isEmpty()) return emptyList()
+        if (!PhpIndexBridge.isAvailable()) return emptyList()
 
         val seen = mutableSetOf<String>()
-        val result = mutableListOf<PhpMemberInfo>()
-        for (phpClass in classes) {
-            for (info in collectMembers(phpClass)) {
-                val key = "${info.kind}:${info.name}"
-                if (seen.add(key)) result.add(info)
-            }
-        }
-        return result
+        return PhpIndexBridge.findClassesByFqn(project, classFqn)
+            .flatMap { PhpIndexBridge.collectMembers(it) }
+            .filter { seen.add("${it.kind}:${it.name}") }
     }
 
     // ──────────────────────────────────────────────────────────────────────────
@@ -170,7 +129,7 @@ object PhpClassResolver {
      * a specific member.
      */
     private fun extractMemberName(text: String): String? {
-        if (text.endsWith(".") && text.length > 1) return CONSTRUCTOR_NAME
+        if (text.endsWith(".") && text.length > 1) return PhpIndexBridge.CONSTRUCTOR_NAME
         if (!text.contains("/")) return null
         val tail = text.substringAfterLast('/')
         return tail.ifEmpty { null }
@@ -178,179 +137,4 @@ object PhpClassResolver {
 
     private fun findUseFqn(file: PhelFile, shortName: String): String? =
         PhelNamespaceUtils.buildUseFqnIndex(file)[shortName]
-
-    // ──────────────────────────────────────────────────────────────────────────
-    // PhpIndex reflection
-    // ──────────────────────────────────────────────────────────────────────────
-
-    /**
-     * Reflection wraps whatever the callee threw in an [InvocationTargetException], so a
-     * [ProcessCanceledException] coming out of a PHP stub-index query does *not* arrive here
-     * as a PCE and is invisible to every PCE-aware catch upstream. Swallowing it would break
-     * read-action cancellation (this runs under `PhelReference.multiResolve`). Unwrap and
-     * rethrow anything the platform owns; everything else is a genuine "the PHP plugin's API
-     * is not the shape we expect" and is handled by the caller.
-     */
-    internal fun rethrowIfPlatformControlFlow(t: Throwable) {
-        val cause = (t as? InvocationTargetException)?.targetException ?: t
-        if (cause is ProcessCanceledException || cause is IndexNotReadyException || cause is Error) {
-            throw cause
-        }
-    }
-
-    private fun findClassesByFqn(project: Project, fqn: String): List<Any> {
-        val phpIndex = phpIndexClass ?: return emptyList()
-        return try {
-            val instance = phpIndex.getMethod("getInstance", Project::class.java).invoke(null, project)
-            // `getAnyByFQN` resolves classes, interfaces, traits and enums alike — using
-            // `getClassesByFQN` would miss interfaces such as `PersistentMapInterface`.
-            val getByFqn = phpIndex.getMethod("getAnyByFQN", String::class.java)
-            @Suppress("UNCHECKED_CAST")
-            val phpTypes = getByFqn.invoke(instance, fqn) as? Collection<Any> ?: return emptyList()
-            phpTypes.toList()
-        } catch (t: Throwable) {
-            rethrowIfPlatformControlFlow(t)
-            LOG.warn("PHP type lookup failed for '$fqn'", t)
-            emptyList()
-        }
-    }
-
-    private fun findMemberInClass(phpClass: Any, memberName: String): List<PsiElement> {
-        val cls = phpClass::class.java
-        val results = mutableListOf<PsiElement>()
-
-        // Methods (including the constructor when memberName == "__construct").
-        tryInvokeCollection(cls, phpClass, "getMethods")?.let { methods ->
-            for (method in methods) {
-                if (readStringProperty(method, "getName") == memberName) {
-                    (method as? PsiElement)?.let { results.add(it) }
-                }
-            }
-        }
-
-        // Fields (which in the PHP plugin model also covers constants).
-        tryInvokeCollection(cls, phpClass, "getFields")?.let { fields ->
-            for (field in fields) {
-                if (readStringProperty(field, "getName") == memberName) {
-                    (field as? PsiElement)?.let { results.add(it) }
-                }
-            }
-        }
-
-        return results
-    }
-
-    private fun collectMembers(phpClass: Any): List<PhpMemberInfo> {
-        val cls = phpClass::class.java
-        val out = mutableListOf<PhpMemberInfo>()
-
-        tryInvokeCollection(cls, phpClass, "getMethods")?.forEach { method ->
-            val name = readStringProperty(method, "getName") ?: return@forEach
-            if (name == CONSTRUCTOR_NAME) return@forEach // surfaced via `Class.` shorthand, not `Class/`
-            if (!isAccessible(method)) return@forEach
-            val element = method as? PsiElement ?: return@forEach
-            val isStatic = readBoolProperty(method, "isStatic") ?: false
-            val signature = methodSignature(method, name)
-            out.add(PhpMemberInfo(name, MemberKind.METHOD, isStatic, signature, element))
-        }
-
-        tryInvokeCollection(cls, phpClass, "getFields")?.forEach { field ->
-            val name = readStringProperty(field, "getName") ?: return@forEach
-            if (!isAccessible(field)) return@forEach
-            val element = field as? PsiElement ?: return@forEach
-            val isConstant = readBoolProperty(field, "isConstant") ?: false
-            val isStatic = readBoolProperty(field, "isStatic") ?: isConstant
-            val kind = if (isConstant) MemberKind.CONSTANT else MemberKind.FIELD
-            out.add(PhpMemberInfo(name, kind, isStatic, name, element))
-        }
-
-        return out
-    }
-
-    private fun methodSignature(method: Any?, name: String): String {
-        if (method == null) return "$name(...)"
-        return try {
-            val getParameters = method.javaClass.getMethod("getParameters")
-            val params = getParameters.invoke(method) as? Array<*> ?: return "$name(...)"
-            val rendered = params.joinToString(", ") { p ->
-                readStringProperty(p, "getName")?.let { "$$it" } ?: "?"
-            }
-            "$name($rendered)"
-        } catch (t: Throwable) {
-            rethrowIfPlatformControlFlow(t)
-            LOG.warn("Could not read parameters of PHP method '$name'", t)
-            "$name(...)"
-        }
-    }
-
-    private fun isAccessible(member: Any?): Boolean {
-        if (member == null) return false
-        // Access object lives on Method/Field via `getModifier().getAccess()`.
-        // Anything that isn't explicitly private/protected is considered callable
-        // from Phel.
-        return try {
-            val getModifier = member.javaClass.getMethod("getModifier")
-            val modifier = getModifier.invoke(member) ?: return true
-            val getAccess = modifier.javaClass.getMethod("getAccess")
-            val access = getAccess.invoke(modifier) ?: return true
-            val name = (access.javaClass.getMethod("name").invoke(access) as? String)?.uppercase()
-            name == null || name == "PUBLIC"
-        } catch (t: Throwable) {
-            rethrowIfPlatformControlFlow(t)
-            // Fail open: if the PHP plugin's modifier API ever changes shape, offering a
-            // member we can't classify beats hiding every member of the class.
-            LOG.warn("Could not read PHP member accessibility; treating it as public", t)
-            true
-        }
-    }
-
-    private fun tryInvokeCollection(cls: Class<*>, target: Any, name: String): Collection<*>? {
-        return try {
-            val m = cls.methods.firstOrNull { it.name == name && it.parameterCount == 0 } ?: return null
-            m.invoke(target) as? Collection<*>
-        } catch (t: Throwable) {
-            rethrowIfPlatformControlFlow(t)
-            LOG.warn("Reflective call to PHP '$name()' failed", t)
-            null
-        }
-    }
-
-    private fun readStringProperty(target: Any?, methodName: String): String? {
-        if (target == null) return null
-        return try {
-            target.javaClass.getMethod(methodName).invoke(target) as? String
-        } catch (t: Throwable) {
-            rethrowIfPlatformControlFlow(t)
-            LOG.warn("Reflective read of PHP '$methodName()' failed", t)
-            null
-        }
-    }
-
-    private fun readBoolProperty(target: Any?, methodName: String): Boolean? {
-        if (target == null) return null
-        return try {
-            target.javaClass.getMethod(methodName).invoke(target) as? Boolean
-        } catch (t: Throwable) {
-            rethrowIfPlatformControlFlow(t)
-            LOG.warn("Reflective read of PHP '$methodName()' failed", t)
-            null
-        }
-    }
-
-    private fun loadPhpIndexClass() {
-        synchronized(this) {
-            if (checkedForPhpPlugin) return
-            checkedForPhpPlugin = true
-            phpIndexClass = try {
-                Class.forName("com.jetbrains.php.PhpIndex", false, javaClass.classLoader)
-            } catch (_: ClassNotFoundException) {
-                null
-            } catch (t: Throwable) {
-                LOG.debug("Unexpected error loading PhpIndex", t)
-                null
-            }
-        }
-    }
-
-    private const val CONSTRUCTOR_NAME = "__construct"
 }

--- a/src/main/kotlin/org/phellang/language/psi/references/PhpIndexBridge.kt
+++ b/src/main/kotlin/org/phellang/language/psi/references/PhpIndexBridge.kt
@@ -1,0 +1,190 @@
+package org.phellang.language.psi.references
+
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.progress.ProcessCanceledException
+import com.intellij.openapi.project.IndexNotReadyException
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import org.phellang.language.psi.references.PhpClassResolver.MemberKind
+import org.phellang.language.psi.references.PhpClassResolver.PhpMemberInfo
+import java.lang.reflect.InvocationTargetException
+
+/**
+ * The reflective bridge to the JetBrains PHP plugin. Everything that touches `com.jetbrains.php.*`
+ * lives here, so the resolver above can be read as plain Phel→PHP mapping.
+ *
+ * The PHP plugin is not a compile-time dependency — Phel support must not break in IDEA Community
+ * just because PHP isn't on the classpath — so `PhpIndex` and every method on the objects it returns
+ * are reached reflectively. When the plugin is absent, or its API isn't the shape we expect, every
+ * call degrades to "nothing found" and lets the Phel-only resolution stay authoritative.
+ */
+internal object PhpIndexBridge {
+
+    private val LOG = Logger.getInstance(PhpIndexBridge::class.java)
+
+    const val CONSTRUCTOR_NAME = "__construct"
+
+    @Volatile
+    private var phpIndexClass: Class<*>? = null
+
+    @Volatile
+    private var checkedForPhpPlugin: Boolean = false
+
+    /** False when the PHP plugin isn't installed — callers should then return no PHP targets. */
+    fun isAvailable(): Boolean {
+        if (!checkedForPhpPlugin) loadPhpIndexClass()
+        return phpIndexClass != null
+    }
+
+    /** The PHP declarations for [fqn] — classes, interfaces, traits and enums alike. */
+    fun findClassesByFqn(project: Project, fqn: String): List<Any> {
+        val phpIndex = phpIndexClass ?: return emptyList()
+        return try {
+            val instance = phpIndex.getMethod("getInstance", Project::class.java).invoke(null, project)
+            // `getAnyByFQN` covers interfaces such as `PersistentMapInterface`, which
+            // `getClassesByFQN` would miss.
+            val getByFqn = phpIndex.getMethod("getAnyByFQN", String::class.java)
+            @Suppress("UNCHECKED_CAST")
+            val phpTypes = getByFqn.invoke(instance, fqn) as? Collection<Any> ?: return emptyList()
+            phpTypes.toList()
+        } catch (t: Throwable) {
+            rethrowIfPlatformControlFlow(t)
+            LOG.warn("PHP type lookup failed for '$fqn'", t)
+            emptyList()
+        }
+    }
+
+    /** The declaration(s) of [memberName] on [phpClass] — a method or a field/constant. */
+    fun findMemberInClass(phpClass: Any, memberName: String): List<PsiElement> {
+        val results = mutableListOf<PsiElement>()
+
+        // Methods (including the constructor when memberName == "__construct").
+        membersOf(phpClass, "getMethods")
+            .filter { readStringProperty(it, "getName") == memberName }
+            .forEach { (it as? PsiElement)?.let(results::add) }
+
+        // Fields (which in the PHP plugin model also cover constants).
+        membersOf(phpClass, "getFields")
+            .filter { readStringProperty(it, "getName") == memberName }
+            .forEach { (it as? PsiElement)?.let(results::add) }
+
+        return results
+    }
+
+    /** The public members of [phpClass] surfaced for completion — private/protected are excluded. */
+    fun collectMembers(phpClass: Any): List<PhpMemberInfo> {
+        val out = mutableListOf<PhpMemberInfo>()
+
+        membersOf(phpClass, "getMethods").forEach { method ->
+            val name = readStringProperty(method, "getName") ?: return@forEach
+            if (name == CONSTRUCTOR_NAME) return@forEach // surfaced via `Class.`, not `Class/`
+            if (!isAccessible(method)) return@forEach
+            val element = method as? PsiElement ?: return@forEach
+            val isStatic = readBoolProperty(method, "isStatic") ?: false
+            out += PhpMemberInfo(name, MemberKind.METHOD, isStatic, methodSignature(method, name), element)
+        }
+
+        membersOf(phpClass, "getFields").forEach { field ->
+            val name = readStringProperty(field, "getName") ?: return@forEach
+            if (!isAccessible(field)) return@forEach
+            val element = field as? PsiElement ?: return@forEach
+            val isConstant = readBoolProperty(field, "isConstant") ?: false
+            val isStatic = readBoolProperty(field, "isStatic") ?: isConstant
+            val kind = if (isConstant) MemberKind.CONSTANT else MemberKind.FIELD
+            out += PhpMemberInfo(name, kind, isStatic, name, element)
+        }
+
+        return out
+    }
+
+    /**
+     * Reflection wraps whatever the callee threw in an [InvocationTargetException], so a
+     * [ProcessCanceledException] out of a PHP stub-index query does *not* arrive as a PCE and is
+     * invisible to every PCE-aware catch upstream. Swallowing it would break read-action
+     * cancellation (this runs under `PhelReference.multiResolve`). Rethrow anything the platform
+     * owns; everything else is a genuine "the PHP plugin's API is not the shape we expect".
+     */
+    fun rethrowIfPlatformControlFlow(t: Throwable) {
+        val cause = (t as? InvocationTargetException)?.targetException ?: t
+        if (cause is ProcessCanceledException || cause is IndexNotReadyException || cause is Error) {
+            throw cause
+        }
+    }
+
+    private fun membersOf(phpClass: Any, accessor: String): Collection<*> =
+        tryInvokeCollection(phpClass::class.java, phpClass, accessor) ?: emptyList<Any>()
+
+    private fun methodSignature(method: Any?, name: String): String {
+        if (method == null) return "$name(...)"
+        return try {
+            val params = method.javaClass.getMethod("getParameters").invoke(method) as? Array<*>
+                ?: return "$name(...)"
+            val rendered = params.joinToString(", ") { p -> readStringProperty(p, "getName")?.let { "$$it" } ?: "?" }
+            "$name($rendered)"
+        } catch (t: Throwable) {
+            rethrowIfPlatformControlFlow(t)
+            LOG.warn("Could not read parameters of PHP method '$name'", t)
+            "$name(...)"
+        }
+    }
+
+    /** Anything not explicitly private/protected is callable from Phel. */
+    private fun isAccessible(member: Any?): Boolean {
+        if (member == null) return false
+        return try {
+            val modifier = member.javaClass.getMethod("getModifier").invoke(member) ?: return true
+            val access = modifier.javaClass.getMethod("getAccess").invoke(modifier) ?: return true
+            val name = (access.javaClass.getMethod("name").invoke(access) as? String)?.uppercase()
+            name == null || name == "PUBLIC"
+        } catch (t: Throwable) {
+            rethrowIfPlatformControlFlow(t)
+            // Fail open: if the modifier API ever changes shape, offering a member we can't classify
+            // beats hiding every member of the class.
+            LOG.warn("Could not read PHP member accessibility; treating it as public", t)
+            true
+        }
+    }
+
+    private fun tryInvokeCollection(cls: Class<*>, target: Any, name: String): Collection<*>? {
+        return try {
+            val m = cls.methods.firstOrNull { it.name == name && it.parameterCount == 0 } ?: return null
+            m.invoke(target) as? Collection<*>
+        } catch (t: Throwable) {
+            rethrowIfPlatformControlFlow(t)
+            LOG.warn("Reflective call to PHP '$name()' failed", t)
+            null
+        }
+    }
+
+    private fun readStringProperty(target: Any?, methodName: String): String? =
+        readProperty(target, methodName) as? String
+
+    private fun readBoolProperty(target: Any?, methodName: String): Boolean? =
+        readProperty(target, methodName) as? Boolean
+
+    private fun readProperty(target: Any?, methodName: String): Any? {
+        if (target == null) return null
+        return try {
+            target.javaClass.getMethod(methodName).invoke(target)
+        } catch (t: Throwable) {
+            rethrowIfPlatformControlFlow(t)
+            LOG.warn("Reflective read of PHP '$methodName()' failed", t)
+            null
+        }
+    }
+
+    private fun loadPhpIndexClass() {
+        synchronized(this) {
+            if (checkedForPhpPlugin) return
+            checkedForPhpPlugin = true
+            phpIndexClass = try {
+                Class.forName("com.jetbrains.php.PhpIndex", false, javaClass.classLoader)
+            } catch (_: ClassNotFoundException) {
+                null
+            } catch (t: Throwable) {
+                LOG.debug("Unexpected error loading PhpIndex", t)
+                null
+            }
+        }
+    }
+}

--- a/src/test/kotlin/org/phellang/unit/language/psi/references/PhpClassResolverControlFlowTest.kt
+++ b/src/test/kotlin/org/phellang/unit/language/psi/references/PhpClassResolverControlFlowTest.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
-import org.phellang.language.psi.references.PhpClassResolver
+import org.phellang.language.psi.references.PhpIndexBridge
 import java.io.IOException
 import java.lang.reflect.InvocationTargetException
 
@@ -28,7 +28,7 @@ class PhpClassResolverControlFlowTest {
         val pce = ProcessCanceledException()
 
         val thrown = assertThrows(ProcessCanceledException::class.java) {
-            PhpClassResolver.rethrowIfPlatformControlFlow(InvocationTargetException(pce))
+            PhpIndexBridge.rethrowIfPlatformControlFlow(InvocationTargetException(pce))
         }
 
         // The original PCE must escape, not a wrapper: the platform matches on identity/type.
@@ -46,14 +46,14 @@ class PhpClassResolverControlFlowTest {
         val indexNotReady = mock(IndexNotReadyException::class.java)
 
         assertThrows(IndexNotReadyException::class.java) {
-            PhpClassResolver.rethrowIfPlatformControlFlow(InvocationTargetException(indexNotReady))
+            PhpIndexBridge.rethrowIfPlatformControlFlow(InvocationTargetException(indexNotReady))
         }
     }
 
     @Test
     fun `rethrows a bare ProcessCanceledException that was not wrapped`() {
         assertThrows(ProcessCanceledException::class.java) {
-            PhpClassResolver.rethrowIfPlatformControlFlow(ProcessCanceledException())
+            PhpIndexBridge.rethrowIfPlatformControlFlow(ProcessCanceledException())
         }
     }
 
@@ -61,7 +61,7 @@ class PhpClassResolverControlFlowTest {
     fun `rethrows an Error rather than absorbing it`() {
         // catch (Throwable) previously swallowed StackOverflowError / OutOfMemoryError too.
         assertThrows(StackOverflowError::class.java) {
-            PhpClassResolver.rethrowIfPlatformControlFlow(InvocationTargetException(StackOverflowError()))
+            PhpIndexBridge.rethrowIfPlatformControlFlow(InvocationTargetException(StackOverflowError()))
         }
     }
 
@@ -70,10 +70,10 @@ class PhpClassResolverControlFlowTest {
         // "The PHP plugin's API is not the shape we expect" is the case the broad catch exists for:
         // it must NOT be rethrown, so the resolver can degrade to "no PHP target found".
         assertDoesNotThrow {
-            PhpClassResolver.rethrowIfPlatformControlFlow(NoSuchMethodException("getAnyByFQN"))
+            PhpIndexBridge.rethrowIfPlatformControlFlow(NoSuchMethodException("getAnyByFQN"))
         }
         assertDoesNotThrow {
-            PhpClassResolver.rethrowIfPlatformControlFlow(InvocationTargetException(IOException("boom")))
+            PhpIndexBridge.rethrowIfPlatformControlFlow(InvocationTargetException(IOException("boom")))
         }
     }
 }


### PR DESCRIPTION
Breaks up the codebase's biggest classes so each holds one responsibility, per the soft targets of ~100 lines/class and short methods. Every split is behaviour-preserving — **1143 tests, 0 failures** on a clean rebuild, verified after each commit.

## What moved

| Class | Before | After | Extracted into |
|---|---:|---:|---|
| `PhelReference` | 871 | 172 | 6 resolvers (require-ns, qualified-symbol, local-scope, usages, definition search + matching) |
| `PhelSymbolAnalyzer` | 504 | 116 | parameter / let-binding / local-function analyzers + a form walker |
| `PhelNamespaceUtils` | 412 | 218 | `:require` and `:use` clause analyzers |
| `PhpClassResolver` | 356 | 140 | `PhpIndexBridge` (all the reflection) |
| `PhelArityMismatchInspection` | 227 | 47 | `PhelArityCallSite` (the false-positive guards) |

Every over-300-line **logic** class is gone. The one file still above 250 is `PriorityRules` (328) — but 221 of those lines are a classification data table, cohesive as-is; splitting it would add indirection, not clarity, so it's left whole.

## The pattern in each case

The big classes were big because they did several jobs at once. `PhelReference` mixed the `PsiReference` contract with six different ways of finding a target; it now owns only the contract and the *order* the resolvers are consulted in — which is where the precedence rules live and are finally readable. `PhpClassResolver` mixed Phel→PHP mapping with the delicate reflection (where a `ProcessCanceledException` arrives wrapped in an `InvocationTargetException`); all the reflection is now in one place.

## Duplication removed along the way

- "Walk a file's lists, match a definition" was written out **four times** in `PhelReference` → one `PhelDefinitionFinder.collectDefinitionsIn`.
- "Walk up enclosing lists, skip non-lists, read the head symbol" was duplicated across `PhelSymbolAnalyzer`'s methods → `PhelFormWalker`.
- The `:as`/`:refer` require-spec walk appeared three times in `PhelNamespaceUtils` → one shared traversal.
- Symbol/vector unwrapping (a head may be a bare symbol or a `PhelAccess` around one) was re-derived in a dozen spots → the existing `PhelPsiUtils.asSymbol`.

## Deliberately *not* unified

`PhelSymbolAnalyzer.isLetBinding` walks `PhelForm` children via `asSymbol`, while `isReferenceToLetBinding` walks raw `.children`. They look alike but traverse differently, so each kept its own traversal rather than being merged into a subtly different one.

## Verification

- [x] `./gradlew build --rerun-tasks` from clean — **1143 tests, 0 failures**, after every commit
- [x] No new package cycles (the 3 present are all pre-existing / from #178)
- [x] `PhpClassResolverControlFlowTest` still pins the exception-unwrap logic (now targeting `PhpIndexBridge`)
- [ ] `./gradlew runIde` — smoke-test go-to-definition, find-usages, rename and the arity inspection, since `PhelReference` is the most-restructured piece and reference resolution has subtle precedence


## Follow-up: further dedup and splits

Beyond the five headline splits, a second pass removed cross-file duplication and split two more:

- **`PhelLocalBindingScope`** — `PhelArityCallSite` and `PhelParameterHintsProvider` carried byte-identical `resolvesToLocalBinding` / `bindingVecContains` / `paramVecContains`. Now one shared helper.
- **`PhelRequireClauseAnalyzer.imports()`** — `PhelProjectCompletionHelper.extractImportedNamespaces` was a *third* copy of the `(:require ...)` spec walk. Promoted to a shared `imports()` returning `RequireImport`; `computeAliasMap` now derives from it.
- **`PhelDocHtml`** — split hover-popup HTML rendering out of `PhelSymbolDocumentationResolver`.

| File | Before | After |
|---|---:|---:|
| `PhelProjectCompletionHelper` | 175 | 106 |
| `PhelParameterHintsProvider` | 170 | 124 |
| `PhelSymbolDocumentationResolver` | 196 | 166 |
| `PhelArityCallSite` | 128 | 97 |

## Note: a global-gitignore footgun (commit 4d4ef10)

The first push failed CI with `Unresolved reference 'PhelParameterAnalyzer'` — the four new `core/psi/` analyzers built locally but weren't committed. Cause: a bare `core` pattern in the **global** `~/.gitignore` matches any path component named `core`, so `git add -A` silently skipped them. Force-added, and every commit since is verified against a fresh `git worktree` (what CI actually checks out), not just the working directory.