### PR TITLE
test: enforce module boundaries with an architecture test

### DIFF
--- a/.agnostic-ai/rules/plugin-architecture.md
+++ b/.agnostic-ai/rules/plugin-architecture.md
@@ -50,6 +50,17 @@ Key classes: `PhelCompletionContributor` (completion), `PhelAnnotator` (highligh
 `PhelFunctionRegistry`, `PhelDocumentationProvider` (hover), `PhelReference` (resolve/nav),
 `PhelFoldingBuilder`, `PhelTypedHandler`, `PhelBraceMatcher`, `PhelCommenter`.
 
+## Enforced boundaries
+
+`ArchitectureBoundaryTest` (a plain source scan, no library) fails the build if a cross-package
+import breaks one of these — Kotlin's `internal` is whole-module and can't. To relax a rule, change
+the test deliberately, not by working around it.
+
+- `registry/data/**` (generated) is imported only from within `registry`; everyone else goes through
+  `PhelFunctionRegistry` / `PhelArityResolver`.
+- `registry` imports no feature package (it stays a leaf — a feature import re-creates the removed cycle).
+- `tools` (build-time generator) is imported by nothing at runtime, and imports no feature package.
+
 ## Rules
 
 - Every feature must be registered in `META-INF/plugin.xml`.

--- a/src/test/kotlin/org/phellang/unit/architecture/ArchitectureBoundaryTest.kt
+++ b/src/test/kotlin/org/phellang/unit/architecture/ArchitectureBoundaryTest.kt
@@ -1,0 +1,121 @@
+package org.phellang.unit.architecture
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * Compiler-adjacent enforcement of the module boundaries this codebase relies on.
+ *
+ * Kotlin's `internal` is whole-Gradle-module (the entire plugin), so it cannot stop one package from
+ * importing another's internals — these rules can. Each locks in an invariant that holds today and
+ * fails the build the moment a new import crosses a line, with the offending `file:line` named.
+ *
+ * A plain source scan rather than a library (Konsist/ArchUnit): it needs no dependency on the
+ * plugin's test classpath, and it mirrors how the repo's cycle-detector already reasons about imports.
+ */
+class ArchitectureBoundaryTest {
+
+    /** The generated function data under `registry/data` is reached only through the registry's API. */
+    @Test
+    fun `registry data is not imported outside the registry package`() {
+        val offenders = mainSources()
+            .filterNot { it.packageName.startsWith("$ROOT.registry") }
+            .flatMap { src -> src.importsMatching("$ROOT.registry.data").map { src to it } }
+
+        assertNoOffenders(
+            offenders,
+            "The generated registry data is private to `registry`. Reach it through PhelFunctionRegistry " +
+                    "/ PhelArityResolver, not by importing `registry.data.*`.",
+        )
+    }
+
+    /** `registry` is a leaf: it may use `language`/`core` and the platform, never a feature package. */
+    @Test
+    fun `registry does not import any feature package`() {
+        val offenders = mainSources()
+            .filter { it.packageName.startsWith("$ROOT.registry") }
+            .flatMap { src -> src.importsMatchingAny(FEATURE_PACKAGES).map { src to it } }
+
+        assertNoOffenders(
+            offenders,
+            "`registry` must stay a leaf — importing a feature package re-creates the cycle its " +
+                    "extraction removed. Move the shared type down into `registry` or `language` instead.",
+        )
+    }
+
+    /** `tools` is the build-time generator; runtime plugin code must not depend on it. */
+    @Test
+    fun `runtime code does not import the build-time tools package`() {
+        val offenders = mainSources()
+            .filterNot { it.packageName.startsWith("$ROOT.tools") }
+            .flatMap { src -> src.importsMatching("$ROOT.tools").map { src to it } }
+
+        assertNoOffenders(
+            offenders,
+            "`tools` runs at build time (updatePhelRegistry). Runtime code importing it would drag the " +
+                    "generator into the shipped plugin.",
+        )
+    }
+
+    /** The generator must not reach into runtime feature packages. */
+    @Test
+    fun `the tools generator does not import feature packages`() {
+        val offenders = mainSources()
+            .filter { it.packageName.startsWith("$ROOT.tools") }
+            .flatMap { src -> src.importsMatchingAny(FEATURE_PACKAGES).map { src to it } }
+
+        assertNoOffenders(offenders, "The build-time generator must not depend on runtime feature code.")
+    }
+
+    private fun assertNoOffenders(offenders: List<Pair<KtSource, Import>>, rule: String) {
+        if (offenders.isEmpty()) return
+        val detail = offenders.joinToString("\n") { (src, imp) -> "  ${src.relativePath}:${imp.line}  ${imp.fqName}" }
+        assertTrue(false, "$rule\n\nOffending imports:\n$detail")
+    }
+
+    private data class Import(val fqName: String, val line: Int)
+
+    private class KtSource(val relativePath: String, val packageName: String, private val imports: List<Import>) {
+        fun importsMatching(prefix: String): List<Import> =
+            imports.filter { it.fqName == prefix || it.fqName.startsWith("$prefix.") }
+
+        fun importsMatchingAny(prefixes: List<String>): List<Import> =
+            imports.filter { imp -> prefixes.any { imp.fqName == it || imp.fqName.startsWith("$it.") } }
+    }
+
+    companion object {
+        private const val ROOT = "org.phellang"
+
+        private val FEATURE_PACKAGES = listOf(
+            "annotator", "completion", "editor", "inspection",
+            "documentation", "actions", "inlay", "refactoring", "syntax",
+        ).map { "$ROOT.$it" }
+
+        private val MAIN_ROOT = File("src/main/kotlin")
+
+        private fun mainSources(): List<KtSource> {
+            assertTrue(MAIN_ROOT.isDirectory, "expected to run from the project root; ${MAIN_ROOT.absolutePath} not found")
+            return MAIN_ROOT.walkTopDown()
+                .filter { it.isFile && it.extension == "kt" }
+                .map { parse(it) }
+                .toList()
+        }
+
+        private fun parse(file: File): KtSource {
+            var packageName = ""
+            val imports = mutableListOf<Import>()
+            file.readLines().forEachIndexed { i, raw ->
+                val line = raw.trim()
+                when {
+                    line.startsWith("package ") -> packageName = line.removePrefix("package ").trim()
+                    line.startsWith("import ") -> {
+                        val fq = line.removePrefix("import ").substringBefore(" as ").trim()
+                        imports += Import(fq, i + 1)
+                    }
+                }
+            }
+            return KtSource(file.path, packageName, imports)
+        }
+    }
+}


### PR DESCRIPTION
## What you asked for

You wanted cross-module access to go through defined surfaces, *enforced* rather than convention. I pushed back on a single `Client` god-object (it concentrates coupling and would re-create the cycles the registry extraction removed) and we landed on this: an **architecture test** that fails the build when a boundary is crossed.

## Why a test, not `internal`

Kotlin's `internal` means "this whole Gradle module" — the entire plugin — so it can't stop one package from importing another's internals. Real sub-package walls would need splitting into Gradle subprojects (a much bigger move). This test gives you the enforcement without the restructure.

## The invariants locked in

All hold today; the test fails the build the moment a new import breaks one:

1. **`registry/data` (generated) is private to `registry`** — everyone else uses `PhelFunctionRegistry` / `PhelArityResolver`.
2. **`registry` is a leaf** — imports no feature package, so the cycle its extraction removed can't come back.
3. **`tools` is build-time-only** — nothing at runtime imports it, and it imports no feature code.

## It actually bites

I planted a feature import in `registry/PhelArity.kt` and confirmed the test fails with:

```
registry must stay a leaf — importing a feature package re-creates the cycle its extraction removed.
Offending imports:
  src/main/kotlin/org/phellang/registry/PhelArity.kt:3  org.phellang.completion.infrastructure.PhelCompletionUtils
```

— then passes once removed. An enforcement test that can't fail would be worthless, so this was the part that mattered.

## Not a library

A plain source scan, no Konsist/ArchUnit dependency — keeps the plugin's test classpath untouched and mirrors how the repo's `cycle-detector` already reasons about imports. Easy to add rules to as boundaries firm up.

- [x] `./gradlew build --rerun-tasks` — **1147 tests, 0 failures**
- [x] Verified the test fails on a real violation and passes when clean