### PR TITLE
test: guard the architecture test against vacuous passing

### DIFF
--- a/src/test/kotlin/org/phellang/unit/architecture/ArchitectureBoundaryTest.kt
+++ b/src/test/kotlin/org/phellang/unit/architecture/ArchitectureBoundaryTest.kt
@@ -68,6 +68,36 @@ class ArchitectureBoundaryTest {
         assertNoOffenders(offenders, "The build-time generator must not depend on runtime feature code.")
     }
 
+    /**
+     * The rules above all read "no file in package X imports Y" — which passes vacuously if package
+     * X no longer exists (renamed, moved, emptied). This guards the guards: it fails loudly if the
+     * scan stops covering a package a rule polices, so a boundary can never silently stop enforcing.
+     */
+    @Test
+    fun `the scan actually covers the packages these rules police`() {
+        val sources = mainSources()
+
+        // A plausible floor: the plugin is well over a hundred hand-written files. Catches a scan
+        // that finds the directory but somehow walks almost nothing.
+        assertTrue(sources.size >= 100, "expected the scan to find the plugin sources, found only ${sources.size}")
+
+        assertPackagePopulated(sources, "$ROOT.registry", "the registry-leaf and registry-data rules")
+        assertPackagePopulated(sources, "$ROOT.registry.data", "the registry-data encapsulation rule")
+        assertPackagePopulated(sources, "$ROOT.tools", "the build-time-tools rules")
+        for (feature in FEATURE_PACKAGES) {
+            assertPackagePopulated(sources, feature, "the feature-import rules")
+        }
+    }
+
+    private fun assertPackagePopulated(sources: List<KtSource>, pkg: String, guardedRules: String) {
+        val count = sources.count { it.packageName == pkg || it.packageName.startsWith("$pkg.") }
+        assertTrue(
+            count > 0,
+            "No sources found in `$pkg`. If it was renamed or moved, $guardedRules now enforce " +
+                    "nothing — update this test to point at the new location.",
+        )
+    }
+
     private fun assertNoOffenders(offenders: List<Pair<KtSource, Import>>, rule: String) {
         if (offenders.isEmpty()) return
         val detail = offenders.joinToString("\n") { (src, imp) -> "  ${src.relativePath}:${imp.line}  ${imp.fqName}" }


### PR DESCRIPTION
Follow-up to #183. You asked if something was missing — there was.

## The gap

Every boundary rule reads *"no file in package X imports Y"*. That passes **vacuously** if package X stops existing. Rename or move `registry` and the three registry rules (`registry` is a leaf, `registry.data` is encapsulated) all go green while enforcing **nothing** — the exact "test that can't fail" failure the rules are meant to prevent, one level up. The only existing guard was `MAIN_ROOT.isDirectory`, which catches a wrong working directory but not a vanished package.

## The fix

A self-check test that asserts the scan actually covers every package a rule polices — `registry`, `registry.data`, `tools`, and each feature package — plus a floor on total sources found. If any of them moves, the build fails with a pointed message rather than the boundary silently going unenforced:

```
No sources found in `org.phellang.registry`. If it was renamed or moved, the
registry-leaf and registry-data rules now enforce nothing — update this test
to point at the new location.
```

## Verified it bites

Simulated a renamed feature package → the self-check fails naming the missing package → restored → passes. An enforcement test whose *own coverage* can silently evaporate is worse than none, so this was the part worth getting right.

- [x] `./gradlew build --rerun-tasks` — 0 failures
- [x] Verified the self-check fails when a policed package is absent, passes when present