### PR TITLE
fix: pin intellij-platform plugin to 2.17.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ version = "0.5.1"
 plugins {
     id("java")
     id("org.jetbrains.kotlin.jvm") version "2.4.10"
-    id("org.jetbrains.intellij.platform") version "2.18.1"
+    id("org.jetbrains.intellij.platform") version "2.17.0"
     id("org.jetbrains.grammarkit") version "2023.3.0.3"
 }
 


### PR DESCRIPTION
## Summary

Reverts `org.jetbrains.intellij.platform` `2.18.1` -> `2.17.0`.

2.18.1 (introduced by #188) fails the `:test` task: `ClosedFileSystemException` in `IdeLayoutIndexService` while indexing bundled plugins, so `plugins/java` fails to load -> `Could not find bundled plugin with ID: 'com.intellij.java'`. #188 was auto-merged past a red Test check.

## Test plan
- [x] `./gradlew test` green on 2.17.0

Note: dependabot will re-propose the 2.18.x bump; verify the Test job before merging or add an ignore rule.