### PR TITLE
ref: reach feature packages only through their roots

### DIFF
--- a/.agnostic-ai/rules/plugin-architecture.md
+++ b/.agnostic-ai/rules/plugin-architecture.md
@@ -62,6 +62,10 @@ the test deliberately, not by working around it.
   `PhelFunctionRegistry` / `PhelArityResolver`.
 - `registry` imports no feature package (it stays a leaf — a feature import re-creates the removed cycle).
 - `tools` (build-time generator) is imported by nothing at runtime, and imports no feature package.
+- A feature package reaches another only through a class at its **root**, never past it
+  (`editor` → `syntax.PhelSyntaxHighlighter` is fine; `editor` → `syntax.attributes.*` is not).
+  Shared vocabulary goes down into a leaf (`core`/`registry`/`language`) instead — this is why the
+  highlighting attribute keys live in `core/highlighting` and not under `syntax`/`annotator`.
 
 ## Rules
 

--- a/.agnostic-ai/rules/plugin-architecture.md
+++ b/.agnostic-ai/rules/plugin-architecture.md
@@ -38,7 +38,9 @@ helpers in that module's subfolders. If the concern is new, create a new module 
 ## Layout
 
 `actions/` menu actions · `annotator/` highlighting + form-comment detection · `completion/` ·
-`core/` utils · `registry/` the shared Phel function/symbol model — API at the root, generated
+`core/` utils + `highlighting/` (the `TextAttributesKey` vocabulary shared by `syntax`, `annotator`
+and the colorsettings page — a leaf; the keys' external IDs persist in user color schemes, so they
+are contract, not internals) · `registry/` the shared Phel function/symbol model — API at the root, generated
 `register*Functions.kt` under `data/`, project symbol index under `indexing/` (a **leaf**: it may
 import `language/psi` and the platform, never a feature package) · `documentation/` hover ·
 `editor/` a namespace of editor modules (folding, typing, quote, matching, commenting,

--- a/src/main/kotlin/org/phellang/annotator/PhelAnnotator.kt
+++ b/src/main/kotlin/org/phellang/annotator/PhelAnnotator.kt
@@ -3,7 +3,7 @@ package org.phellang.annotator
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.Annotator
 import com.intellij.psi.PsiElement
-import org.phellang.annotator.infrastructure.PhelAnnotationConstants.COMMENTED_OUT_FORM
+import org.phellang.core.highlighting.PhelAnnotationConstants.COMMENTED_OUT_FORM
 import org.phellang.annotator.analyzers.PhelCommentAnalyzer
 import org.phellang.annotator.highlighters.PhelElementHighlighter
 import org.phellang.annotator.highlighters.PhelRequireHighlighter

--- a/src/main/kotlin/org/phellang/annotator/highlighters/PhelElementHighlighter.kt
+++ b/src/main/kotlin/org/phellang/annotator/highlighters/PhelElementHighlighter.kt
@@ -1,8 +1,8 @@
 package org.phellang.annotator.highlighters
 
 import com.intellij.lang.annotation.AnnotationHolder
-import org.phellang.annotator.infrastructure.PhelAnnotationConstants.ANONYMOUS_FUNCTION
-import org.phellang.annotator.infrastructure.PhelAnnotationConstants.KEYWORD
+import org.phellang.core.highlighting.PhelAnnotationConstants.ANONYMOUS_FUNCTION
+import org.phellang.core.highlighting.PhelAnnotationConstants.KEYWORD
 import org.phellang.annotator.infrastructure.PhelAnnotationUtils
 import org.phellang.language.psi.*
 

--- a/src/main/kotlin/org/phellang/annotator/highlighters/PhelSymbolHighlighter.kt
+++ b/src/main/kotlin/org/phellang/annotator/highlighters/PhelSymbolHighlighter.kt
@@ -1,14 +1,14 @@
 package org.phellang.annotator.highlighters
 
 import com.intellij.lang.annotation.AnnotationHolder
-import org.phellang.annotator.infrastructure.PhelAnnotationConstants.DEPRECATED_SYMBOL
-import org.phellang.annotator.infrastructure.PhelAnnotationConstants.FUNCTION_PARAMETER
-import org.phellang.annotator.infrastructure.PhelAnnotationConstants.FUNCTION_CALL
-import org.phellang.annotator.infrastructure.PhelAnnotationConstants.FUNCTION_NAME
-import org.phellang.annotator.infrastructure.PhelAnnotationConstants.NAMESPACE_SYMBOL
-import org.phellang.annotator.infrastructure.PhelAnnotationConstants.PHP_INTEROP
-import org.phellang.annotator.infrastructure.PhelAnnotationConstants.REGULAR_SYMBOL
-import org.phellang.annotator.infrastructure.PhelAnnotationConstants.VARIADIC_PARAMETER
+import org.phellang.core.highlighting.PhelAnnotationConstants.DEPRECATED_SYMBOL
+import org.phellang.core.highlighting.PhelAnnotationConstants.FUNCTION_PARAMETER
+import org.phellang.core.highlighting.PhelAnnotationConstants.FUNCTION_CALL
+import org.phellang.core.highlighting.PhelAnnotationConstants.FUNCTION_NAME
+import org.phellang.core.highlighting.PhelAnnotationConstants.NAMESPACE_SYMBOL
+import org.phellang.core.highlighting.PhelAnnotationConstants.PHP_INTEROP
+import org.phellang.core.highlighting.PhelAnnotationConstants.REGULAR_SYMBOL
+import org.phellang.core.highlighting.PhelAnnotationConstants.VARIADIC_PARAMETER
 import org.phellang.annotator.validators.PhelFunctionReferenceValidator
 import org.phellang.annotator.validators.PhelNamespaceValidator
 import org.phellang.registry.PhelFunctionRegistry

--- a/src/main/kotlin/org/phellang/annotator/validators/PhelFunctionReferenceValidator.kt
+++ b/src/main/kotlin/org/phellang/annotator/validators/PhelFunctionReferenceValidator.kt
@@ -1,6 +1,6 @@
 package org.phellang.annotator.validators
 
-import org.phellang.completion.documentation.PhelApiDocumentation
+import org.phellang.registry.PhelFunctionRegistry
 import org.phellang.registry.indexing.PhelProjectSymbolIndex
 import org.phellang.language.psi.utils.PhelPsiUtils
 import org.phellang.language.psi.PhelInteropShorthands
@@ -58,14 +58,14 @@ object PhelFunctionReferenceValidator {
 
     private fun existsInStandardLibrary(namespace: String, functionName: String): Boolean {
         val canonicalName = "$namespace/$functionName"
-        if (PhelApiDocumentation.hasDocumentation(canonicalName)) {
+        if (PhelFunctionRegistry.getFunction(canonicalName) != null) {
             return true
         }
 
         val fullNamespace = PhelProjectNamespaceFinder.getStandardLibraryFullNamespace(namespace)
         if (fullNamespace != null) {
             val fullName = "$fullNamespace/$functionName"
-            if (PhelApiDocumentation.hasDocumentation(fullName)) {
+            if (PhelFunctionRegistry.getFunction(fullName) != null) {
                 return true
             }
         }

--- a/src/main/kotlin/org/phellang/core/highlighting/PhelAnnotationConstants.kt
+++ b/src/main/kotlin/org/phellang/core/highlighting/PhelAnnotationConstants.kt
@@ -1,4 +1,4 @@
-package org.phellang.annotator.infrastructure
+package org.phellang.core.highlighting
 
 import com.intellij.openapi.editor.DefaultLanguageHighlighterColors
 import com.intellij.openapi.editor.colors.CodeInsightColors

--- a/src/main/kotlin/org/phellang/core/highlighting/PhelTextAttributesRegistry.kt
+++ b/src/main/kotlin/org/phellang/core/highlighting/PhelTextAttributesRegistry.kt
@@ -1,4 +1,4 @@
-package org.phellang.syntax.attributes
+package org.phellang.core.highlighting
 
 import com.intellij.openapi.editor.DefaultLanguageHighlighterColors
 import com.intellij.openapi.editor.HighlighterColors

--- a/src/main/kotlin/org/phellang/documentation/resolvers/PhelApiDocumentation.kt
+++ b/src/main/kotlin/org/phellang/documentation/resolvers/PhelApiDocumentation.kt
@@ -1,17 +1,13 @@
-package org.phellang.completion.documentation
+package org.phellang.documentation.resolvers
 
 import org.phellang.registry.PhelFunctionRegistry
 import java.util.concurrent.ConcurrentHashMap
 
 object PhelApiDocumentation {
 
-    // Rendered HTML documentation, keyed by fully-qualified function name. Built lazily on
-    // first request instead of eagerly rendering every function up front — highlighting only
-    // needs to know whether a name exists (see [hasDocumentation]), not its rendered HTML.
+    // Rendered HTML documentation, keyed by fully-qualified function name. Built lazily on first
+    // request rather than eagerly rendering all 900+ registry functions: hover asks for one at a time.
     private val rendered = ConcurrentHashMap<String, String>()
-
-    /** True when the standard-library registry has a function with this exact name. */
-    fun hasDocumentation(name: String): Boolean = PhelFunctionRegistry.getFunction(name) != null
 
     /** Rendered HTML documentation for [name], or null when no such standard-library function exists. */
     fun getDocumentation(name: String): String? {

--- a/src/main/kotlin/org/phellang/documentation/resolvers/PhelBasicDocumentation.kt
+++ b/src/main/kotlin/org/phellang/documentation/resolvers/PhelBasicDocumentation.kt
@@ -1,4 +1,4 @@
-package org.phellang.completion.documentation
+package org.phellang.documentation.resolvers
 
 import org.phellang.language.psi.utils.PhelPsiUtils
 import org.phellang.core.psi.PhelSymbolAnalyzer

--- a/src/main/kotlin/org/phellang/documentation/resolvers/PhelSymbolDocumentationResolver.kt
+++ b/src/main/kotlin/org/phellang/documentation/resolvers/PhelSymbolDocumentationResolver.kt
@@ -2,8 +2,6 @@ package org.phellang.documentation.resolvers
 
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
-import org.phellang.completion.documentation.PhelApiDocumentation
-import org.phellang.completion.documentation.PhelBasicDocumentation
 import org.phellang.registry.indexing.PhelProjectSymbolIndex
 import org.phellang.core.psi.PhelSymbolAnalyzer
 import org.phellang.language.psi.PhelForm

--- a/src/main/kotlin/org/phellang/editor/colorsettings/PhelColorSettingsProvider.kt
+++ b/src/main/kotlin/org/phellang/editor/colorsettings/PhelColorSettingsProvider.kt
@@ -1,8 +1,8 @@
 package org.phellang.editor.colorsettings
 
 import com.intellij.openapi.options.colors.AttributesDescriptor
-import org.phellang.annotator.infrastructure.PhelAnnotationConstants
-import org.phellang.syntax.attributes.PhelTextAttributesRegistry
+import org.phellang.core.highlighting.PhelAnnotationConstants
+import org.phellang.core.highlighting.PhelTextAttributesRegistry
 
 class PhelColorSettingsProvider {
 

--- a/src/main/kotlin/org/phellang/syntax/mapping/PhelTokenAttributeMapper.kt
+++ b/src/main/kotlin/org/phellang/syntax/mapping/PhelTokenAttributeMapper.kt
@@ -2,7 +2,7 @@ package org.phellang.syntax.mapping
 
 import com.intellij.openapi.editor.colors.TextAttributesKey
 import org.phellang.syntax.classification.PhelTokenClassifier.TokenCategory
-import org.phellang.syntax.attributes.PhelTextAttributesRegistry
+import org.phellang.core.highlighting.PhelTextAttributesRegistry
 
 object PhelTokenAttributeMapper {
 

--- a/src/test/kotlin/org/phellang/integration/annotator/PhelAnnotatorWorkflowTest.kt
+++ b/src/test/kotlin/org/phellang/integration/annotator/PhelAnnotatorWorkflowTest.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import org.phellang.annotator.analyzers.PhelSymbolPositionAnalyzer
-import org.phellang.annotator.infrastructure.PhelAnnotationConstants
+import org.phellang.core.highlighting.PhelAnnotationConstants
 import org.phellang.annotator.infrastructure.PhelAnnotationUtils
 
 class PhelAnnotatorWorkflowTest {

--- a/src/test/kotlin/org/phellang/integration/annotator/PhelDeprecatedAnnotatorTest.kt
+++ b/src/test/kotlin/org/phellang/integration/annotator/PhelDeprecatedAnnotatorTest.kt
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.phellang.annotator.infrastructure.PhelAnnotationConstants
+import org.phellang.core.highlighting.PhelAnnotationConstants
 import org.phellang.registry.PhelFunctionRegistry
 
 class PhelDeprecatedAnnotatorTest {

--- a/src/test/kotlin/org/phellang/integration/syntax/PhelSyntaxHighlightingWorkflowTest.kt
+++ b/src/test/kotlin/org/phellang/integration/syntax/PhelSyntaxHighlightingWorkflowTest.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.params.provider.CsvSource
 import org.phellang.syntax.PhelSyntaxHighlighter
 import org.phellang.language.psi.PhelTypes
 import org.phellang.language.lexer.PhelLexerAdapter
-import org.phellang.syntax.attributes.PhelTextAttributesRegistry
+import org.phellang.core.highlighting.PhelTextAttributesRegistry
 import org.phellang.syntax.mapping.PhelTokenAttributeMapper
 import org.phellang.syntax.classification.PhelTokenClassifier
 

--- a/src/test/kotlin/org/phellang/unit/architecture/ArchitectureBoundaryTest.kt
+++ b/src/test/kotlin/org/phellang/unit/architecture/ArchitectureBoundaryTest.kt
@@ -44,6 +44,33 @@ class ArchitectureBoundaryTest {
         )
     }
 
+    /**
+     * A feature package reaches another only through its root — the module rule: entry points at a
+     * module's root, internals in subfolders. `editor` importing `syntax.PhelSyntaxHighlighter` is
+     * fine (the ColorSettingsPage API demands it); importing `syntax.attributes.*` would not be.
+     *
+     * Shared vocabulary belongs in a leaf (`core`, `registry`, `language`), not in another feature's
+     * subfolder — that is how the highlighting attribute keys came to live in `core.highlighting`.
+     */
+    @Test
+    fun `no feature package imports another feature's internals`() {
+        val offenders = mainSources()
+            .flatMap { src ->
+                val own = FEATURE_PACKAGES.firstOrNull { src.packageName.startsWith("$it.") || src.packageName == it }
+                    ?: return@flatMap emptyList()
+                src.importsMatchingAny(FEATURE_PACKAGES - own)
+                    .filter { reachesPastRoot(it) }
+                    .map { src to it }
+            }
+
+        assertNoOffenders(
+            offenders,
+            "A feature package may only reach another through a class at its root. Importing past the " +
+                    "root binds you to another module's internals — move the shared type into a leaf " +
+                    "(`core`/`registry`/`language`) instead, or expose it at the owning module's root.",
+        )
+    }
+
     /** `tools` is the build-time generator; runtime plugin code must not depend on it. */
     @Test
     fun `runtime code does not import the build-time tools package`() {
@@ -96,6 +123,17 @@ class ArchitectureBoundaryTest {
             "No sources found in `$pkg`. If it was renamed or moved, $guardedRules now enforce " +
                     "nothing — update this test to point at the new location.",
         )
+    }
+
+    /**
+     * True when [imp] names something below a feature package's root. The segment after the package
+     * tells us which: a lowercase one is a subpackage (`syntax.attributes.Foo`), an uppercase one is
+     * a class at the root (`syntax.PhelSyntaxHighlighter`, or a member/nested import of it).
+     */
+    private fun reachesPastRoot(imp: Import): Boolean {
+        val feature = FEATURE_PACKAGES.firstOrNull { imp.fqName.startsWith("$it.") } ?: return false
+        val next = imp.fqName.removePrefix("$feature.").substringBefore('.')
+        return next.firstOrNull()?.isLowerCase() == true
     }
 
     private fun assertNoOffenders(offenders: List<Pair<KtSource, Import>>, rule: String) {

--- a/src/test/kotlin/org/phellang/unit/core/highlighting/PhelAnnotationConstantsTest.kt
+++ b/src/test/kotlin/org/phellang/unit/core/highlighting/PhelAnnotationConstantsTest.kt
@@ -1,9 +1,9 @@
-package org.phellang.unit.annotator.infrastructure
+package org.phellang.unit.core.highlighting
 
 import com.intellij.openapi.editor.DefaultLanguageHighlighterColors
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
-import org.phellang.annotator.infrastructure.PhelAnnotationConstants
+import org.phellang.core.highlighting.PhelAnnotationConstants
 
 class PhelAnnotationConstantsTest {
     @Test

--- a/src/test/kotlin/org/phellang/unit/core/highlighting/PhelTextAttributesRegistryTest.kt
+++ b/src/test/kotlin/org/phellang/unit/core/highlighting/PhelTextAttributesRegistryTest.kt
@@ -1,8 +1,8 @@
-package org.phellang.unit.syntax.attributes
+package org.phellang.unit.core.highlighting
 
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
-import org.phellang.syntax.attributes.PhelTextAttributesRegistry
+import org.phellang.core.highlighting.PhelTextAttributesRegistry
 
 class PhelTextAttributesRegistryTest {
 

--- a/src/test/kotlin/org/phellang/unit/editor/colorsettings/PhelColorSettingsProviderTest.kt
+++ b/src/test/kotlin/org/phellang/unit/editor/colorsettings/PhelColorSettingsProviderTest.kt
@@ -3,9 +3,9 @@ package org.phellang.unit.editor.colorsettings
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.phellang.annotator.infrastructure.PhelAnnotationConstants
+import org.phellang.core.highlighting.PhelAnnotationConstants
 import org.phellang.editor.colorsettings.PhelColorSettingsProvider
-import org.phellang.syntax.attributes.PhelTextAttributesRegistry
+import org.phellang.core.highlighting.PhelTextAttributesRegistry
 
 class PhelColorSettingsProviderTest {
 

--- a/src/test/kotlin/org/phellang/unit/syntax/PhelSyntaxHighlighterTest.kt
+++ b/src/test/kotlin/org/phellang/unit/syntax/PhelSyntaxHighlighterTest.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test
 import org.phellang.syntax.PhelSyntaxHighlighter
 import org.phellang.language.lexer.PhelLexerAdapter
 import org.phellang.language.psi.PhelTypes
-import org.phellang.syntax.attributes.PhelTextAttributesRegistry
+import org.phellang.core.highlighting.PhelTextAttributesRegistry
 
 class PhelSyntaxHighlighterTest {
     @Test

--- a/src/test/kotlin/org/phellang/unit/syntax/mapping/PhelTokenAttributeMapperTest.kt
+++ b/src/test/kotlin/org/phellang/unit/syntax/mapping/PhelTokenAttributeMapperTest.kt
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
-import org.phellang.syntax.attributes.PhelTextAttributesRegistry
+import org.phellang.core.highlighting.PhelTextAttributesRegistry
 import org.phellang.syntax.mapping.PhelTokenAttributeMapper
 import org.phellang.syntax.classification.PhelTokenClassifier.TokenCategory
 


### PR DESCRIPTION
## Context

The module rule in `.agnostic-ai/rules/plugin-architecture.md` — entry points at a module's root, internals in subfolders — was documented but unenforced. Kotlin's `internal` is whole-module, so nothing stopped one feature package from importing another's subfolder.

Auditing every cross-feature import turned up four edges. Three of them existed because shared code was sitting in the wrong package, not because the modules genuinely needed each other. Moving that code down into a leaf removes the edges rather than formalising them, and the fourth is legal and stays.

## Changes

**1. `ref: move api docs out of completion into the documentation module`**

`PhelApiDocumentation` / `PhelBasicDocumentation` lived under `completion/` but had no consumer inside it — only `annotator/` and `documentation/` used them, and neither file depends on `completion` at all. Same reasoning that keeps the registry out of `completion`. They move beside their real consumer in `documentation/resolvers/`, which empties `completion/documentation/`.

The annotator only ever called `PhelApiDocumentation.hasDocumentation()`, which is `PhelFunctionRegistry.getFunction(name) != null` — a registry question routed through a documentation object. It now asks the registry directly, so that edge disappears instead of following the move. `hasDocumentation()` was then unused and is dropped.

**2. `ref: move shared highlighting keys into a core leaf`**

`PhelAnnotationConstants` and `PhelTextAttributesRegistry` are `TextAttributesKey` holders with no behaviour, and each key's external id is persisted in the user's colour scheme — they are contract, not internals. Living in `annotator`'s and `syntax`'s subfolders forced the colorsettings page, whose job is to enumerate every key in the plugin, to import past two feature roots.

Both move to `core/highlighting`, a leaf every feature may depend on, same shape as `registry`.

The external key strings are literals inside `createTextAttributesKey` and are unaffected by a package move, so **existing user colour schemes are preserved**.

**3. `test: enforce feature-root imports between packages`**

Adds the rule to `ArchitectureBoundaryTest`, which fails the build naming the offending `file:line`. It keys off the package-naming convention rather than import depth: the segment after a feature package tells you what was reached — a lowercase one is a subpackage (`syntax.attributes.Foo`), an uppercase one is a class at the root (`syntax.PhelSyntaxHighlighter`, or a member import of it), which stays legal. Matching on depth alone would flag the latter.

## Result

Cross-feature edges go from four to one. The survivor is `editor` -> `syntax.PhelSyntaxHighlighter`, a root import the `ColorSettingsPage` API requires (`getHighlighter()`), which is compliant and stays.

No behaviour change: every commit is a move plus import updates, or test-only.

## Test plan

- [x] `./gradlew build` green (regenerates lexer/parser, runs unit + integration).
- [x] Both `ref:` commits verified to build **in isolation**, so `git bisect` cannot land on a broken tree.
- [x] New boundary rule verified to **fail** by reintroducing a cross-feature internals import — it reported the exact file, line and import. Reverted; green. A boundary rule that has never been seen failing is not evidence of anything.
- [x] `plugin.xml` swept: no stale package references, every `implementationClass` still resolves. None of the moved classes are registered extension points.
- [x] Raw-text sweep for old package paths: zero hits outside this diff.
- [x] Unit tests follow their sources into `unit/core/highlighting/`.

Colour-scheme preservation is worth a sandbox check on merge (`./gradlew runIde` -> Settings -> Editor -> Color Scheme -> Phel Lang): the reasoning above says the persisted ids cannot change, but that is the one claim this diff cannot prove with a test.
