### PR TITLE
docs: correct Phel comment syntax and list deprecated forms

### DIFF
--- a/.agnostic-ai/rules/phel-language.md
+++ b/.agnostic-ai/rules/phel-language.md
@@ -7,8 +7,14 @@ description: Phel syntax reference
 
 Lisp transpiling to PHP; Clojure/Janet dialect. Source of truth: https://phel-lang.org/.
 
-**Comments**: `#` or `;` line. `#_` comments next form (stackable `#_#_` = two). No block comments.
+**Comments**: `;` line. `#_` comments next form (stackable `#_#_` = two).
 `[#_:one :two :three]` → `[:two :three]`.
+
+**Deprecated — never emit, never lex** (Phel still accepts these with an `E_USER_DEPRECATED`;
+the plugin lexer deliberately does not support any of them, so don't "fix" that as a gap):
+bare `#` line comments (use `;`) · `#| ... |#` nesting block comments (use `;` or `#_`) ·
+`|()` short fn (use `#()`) · `,` / `,@` unquote+splice (use `~` / `~@`; the plugin lexes `,`
+as whitespace).
 
 **Keywords**: `:kw` · `:ns/kw` · `::foo` (current-ns) · `::alias/foo`.
 

--- a/src/main/kotlin/org/phellang/editor/commenting/PhelCommenter.kt
+++ b/src/main/kotlin/org/phellang/editor/commenting/PhelCommenter.kt
@@ -7,7 +7,7 @@ class PhelCommenter : Commenter {
         return ";"
     }
 
-    // Phel has no block comments.
+    // Phel's `#| ... |#` block comments are deprecated, so none are offered here.
     override fun getBlockCommentPrefix(): String? = null
     override fun getBlockCommentSuffix(): String? = null
     override fun getCommentedBlockCommentPrefix(): String? = null


### PR DESCRIPTION
## Summary

While auditing Phel `v0.46.0`–`v0.48.0` for unimplemented syntax, I found no syntax changes at all in that range (the diff of `Lexer.php`, the parser and the reader between the `v0.46.0` and `v0.48.0` tags is empty — those releases are runtime, CLI and compiler work). The new `0.48` core functions are registry entries, already covered by the `0.48.0` bump in 0c3486f.

What the audit did surface is that our own syntax rule described Phel's comment syntax incorrectly, in both directions:

> **Comments**: `#` or `;` line. … No block comments.

Per [`Lexer.php:66-172`](https://github.com/phel-lang/phel-lang/blob/main/src/php/Compiler/Application/Lexer.php), bare `#` line comments are **deprecated** (use `;`), and `#| ... |#` block comments **do exist** — also deprecated. Both raise `E_USER_DEPRECATED`.

## Changes

- `.agnostic-ai/rules/phel-language.md` — drop the two wrong claims, and list every deprecated form the Phel lexer still accepts: bare `#`, `#| ... |#`, `|()` short fn, and `,` / `,@` unquote. The rule now records that the plugin's non-support of these is **deliberate**, so it isn't mistaken for a gap and "fixed" by adding them back to the lexer.
- `PhelCommenter.kt` — `// Phel has no block comments.` → states that they're deprecated, which is why all four block-comment overrides return `null`.

## No behaviour change

The lexer and `PhelCommenter` were already correct and sit on the non-deprecated side of all four forms (`Phel.flex:22,36,76` — `;` line comments only, `,` lexed as whitespace, `#(` not `|(`). Only the prose describing them was stale. The generated `.claude/rules/` target was refreshed via `agnostic-ai sync`; it's gitignored, so it isn't in the diff.

## Test plan

- [x] `agnostic-ai sync` run; correction verified present in the generated `.claude/rules/phel-language.md`
- [x] Stale `` `#` or `;` `` claim confirmed gone repo-wide (`rg`)
- [x] Deprecated-form inventory verified against `Lexer.php` upstream, not from memory
- [ ] `./gradlew build` — not run locally; comment-only source change, deferring to CI