### PR TITLE
ci: drop restored Gradle artifact transforms before building

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
-  
+
 jobs:
 
   # Prepare the environment and build the plugin
@@ -37,6 +37,29 @@ jobs:
       # Setup Gradle
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
+
+      # Gradle extracts the IntelliJ IDEA distribution through an artifact transform into an
+      # "immutable workspace" under caches/<version>/transforms, and verifies it by hashing the
+      # directory. setup-gradle restores that directory from a deduplicated gradle-transforms-v1-*
+      # cache entry, and a perturbed or partially written entry makes Gradle report
+      #   The contents of the immutable workspace ... have been modified
+      # discard the extracted IDE, and fail every lookup against it with
+      #   Could not find bundled plugin with ID: 'com.intellij.java'
+      # gradle-home-cache-excludes does NOT cover these entries (the enhanced cache provider
+      # restores them by its own hardcoded paths), so drop them before Gradle starts and let it
+      # re-extract. The IDE archive still comes from the cached modules-2 dependencies, so the
+      # cost is extraction, not a download.
+      - name: Drop restored artifact transforms
+        shell: bash
+        run: |
+          shopt -s nullglob
+          dirs=(~/.gradle/caches/*/transforms ~/.gradle/caches/transforms-*)
+          if [ ${#dirs[@]} -eq 0 ]; then
+            echo "No restored transform caches to drop"
+          else
+            printf 'Dropping %s\n' "${dirs[@]}"
+            rm -rf "${dirs[@]}"
+          fi
 
       # Build plugin
       - name: Build plugin
@@ -91,6 +114,29 @@ jobs:
         with:
           cache-read-only: true
 
+      # Gradle extracts the IntelliJ IDEA distribution through an artifact transform into an
+      # "immutable workspace" under caches/<version>/transforms, and verifies it by hashing the
+      # directory. setup-gradle restores that directory from a deduplicated gradle-transforms-v1-*
+      # cache entry, and a perturbed or partially written entry makes Gradle report
+      #   The contents of the immutable workspace ... have been modified
+      # discard the extracted IDE, and fail every lookup against it with
+      #   Could not find bundled plugin with ID: 'com.intellij.java'
+      # gradle-home-cache-excludes does NOT cover these entries (the enhanced cache provider
+      # restores them by its own hardcoded paths), so drop them before Gradle starts and let it
+      # re-extract. The IDE archive still comes from the cached modules-2 dependencies, so the
+      # cost is extraction, not a download.
+      - name: Drop restored artifact transforms
+        shell: bash
+        run: |
+          shopt -s nullglob
+          dirs=(~/.gradle/caches/*/transforms ~/.gradle/caches/transforms-*)
+          if [ ${#dirs[@]} -eq 0 ]; then
+            echo "No restored transform caches to drop"
+          else
+            printf 'Dropping %s\n' "${dirs[@]}"
+            rm -rf "${dirs[@]}"
+          fi
+
       # Run tests
       - name: Run Tests
         run: ./gradlew check
@@ -140,6 +186,29 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
         with:
           cache-read-only: true
+
+      # Gradle extracts the IntelliJ IDEA distribution through an artifact transform into an
+      # "immutable workspace" under caches/<version>/transforms, and verifies it by hashing the
+      # directory. setup-gradle restores that directory from a deduplicated gradle-transforms-v1-*
+      # cache entry, and a perturbed or partially written entry makes Gradle report
+      #   The contents of the immutable workspace ... have been modified
+      # discard the extracted IDE, and fail every lookup against it with
+      #   Could not find bundled plugin with ID: 'com.intellij.java'
+      # gradle-home-cache-excludes does NOT cover these entries (the enhanced cache provider
+      # restores them by its own hardcoded paths), so drop them before Gradle starts and let it
+      # re-extract. The IDE archive still comes from the cached modules-2 dependencies, so the
+      # cost is extraction, not a download.
+      - name: Drop restored artifact transforms
+        shell: bash
+        run: |
+          shopt -s nullglob
+          dirs=(~/.gradle/caches/*/transforms ~/.gradle/caches/transforms-*)
+          if [ ${#dirs[@]} -eq 0 ]; then
+            echo "No restored transform caches to drop"
+          else
+            printf 'Dropping %s\n' "${dirs[@]}"
+            rm -rf "${dirs[@]}"
+          fi
 
       # Run Verify Plugin task and IntelliJ Plugin Verifier tool
       - name: Run Plugin Verification tasks


### PR DESCRIPTION
## 📚 Description

Fixes the intermittent pipeline failure:

```
Could not find bundled plugin with ID: 'com.intellij.java'
Following 1 plugins could not be created: plugins/java
```

### Root cause

The real error appears earlier in the same log, before the resolution failure:

```
The contents of the immutable workspace
'/home/runner/.gradle/caches/9.6.1/transforms/f1fcbde712761c69a2f45326870a5de4'
have been modified. These workspace directories are not supposed to be modified
once they are created.
```

That workspace is `transformed/ideaIC-2025.2.6/` — the IntelliJ IDEA distribution, which Gradle extracts via an artifact transform. Gradle verifies these immutable workspaces by hashing the directory, and `setup-gradle` restores this one from a deduplicated `gradle-transforms-v1-*` cache entry. A perturbed or partially written entry makes Gradle reject the extracted IDE, so every bundled-plugin lookup against it fails.

### Why it looked flaky

It depends on which cache entry a given job restores, so it hit whichever configuration resolved first:

| Run | Job | Configuration |
|---|---|---|
| PR #196 | Build | `:intellijPlatformRuntimeClasspath` |
| main `ebfd5ad` | Test | `:intellijPlatformTestRuntimeClasspath` |

Not branch-specific or new — the identical failure is in the `docs/comment-syntax-deprecations` run from 2026-07-16, which then merged green.

### Fix

`gradle-home-cache-excludes` does **not** cover these entries. I tried that first and verified it fails: the exclude was accepted as an input, and the entry was still restored to `caches/transforms-4/*/` and `caches/*/transforms/*/` — the enhanced cache provider restores them by its own hardcoded paths.

So the directories are removed after the cache is restored and before Gradle starts, letting Gradle re-extract. The IDE archive still comes from the cached `modules-2` dependencies, so the cost is extraction, not a download.

## ✅ Test plan

Verified against the logs of run `30012284458` (green), for all three jobs:

- [x] Purge step fires and removes the exact path that was corrupt: `Dropping /home/runner/.gradle/caches/9.6.1/transforms` — so it is doing real work, not a no-op
- [x] Zero `immutable workspace ... have been modified` occurrences
- [x] Zero `Could not find bundled plugin` / `could not be created: plugins` occurrences

Runtime impact is in the noise (Build 162s → 176s, Verify 366s → 394s, Test 218s → 231s), well within run-to-run variance.

> Note: the failure is intermittent, so a green run alone is not proof. The evidence here is mechanical — the corrupt input is provably absent before Gradle starts.