### PR TITLE
ci: retry the intellij-platform-gradle-plugin bundled-plugin race

### DIFF
--- a/.github/scripts/gradle-retry.sh
+++ b/.github/scripts/gradle-retry.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Runs Gradle, retrying only the known IntelliJ Platform Gradle Plugin race.
+#
+# IdeLayoutIndexService parses plugin.xml out of the transformed IDE jars to build its
+# bundled-plugin index. The zip filesystem backing those jars is sometimes closed while it is
+# still reading, which surfaces as:
+#
+#   Unable to read descriptor [plugin.xml] from [.../ideaIC-<version>/plugins/java/lib/java-impl.jar]
+#   java.nio.file.ClosedFileSystemException
+#   Following 1 plugins could not be created: plugins/java
+#
+# The index then comes back incomplete and the build fails with the misleading
+#
+#   Could not find bundled plugin with ID: 'com.intellij.java'
+#
+# Upstream: https://github.com/JetBrains/intellij-platform-gradle-plugin/issues/2192
+# (open; JetBrains confirmed it on their own pipeline and their guidance is to re-run).
+# It is a race, so it hits whichever configuration resolves first, which is why it has shown up
+# as ':intellijPlatformRuntimeClasspath' in one job and ':intellijPlatformTestRuntimeClasspath'
+# in another. Delete this script and call ./gradlew directly once the upstream fix ships.
+#
+# Only this signature is retried. Any other failure, a real test or compile error, fails
+# immediately so genuine breakage is never masked.
+
+set -uo pipefail
+
+MAX_ATTEMPTS="${GRADLE_RETRY_ATTEMPTS:-3}"
+RACE_SIGNATURE='ClosedFileSystemException|Could not find bundled plugin with ID'
+
+log="$(mktemp)"
+trap 'rm -f "$log"' EXIT
+
+for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+    if [ "$attempt" -gt 1 ]; then
+        echo "::group::Gradle attempt ${attempt}/${MAX_ATTEMPTS}"
+    fi
+
+    ./gradlew "$@" 2>&1 | tee "$log"
+    status="${PIPESTATUS[0]}"
+
+    if [ "$attempt" -gt 1 ]; then
+        echo "::endgroup::"
+    fi
+
+    if [ "$status" -eq 0 ]; then
+        exit 0
+    fi
+
+    if ! grep -qE "$RACE_SIGNATURE" "$log"; then
+        echo "::error::Gradle failed for a reason unrelated to intellij-platform-gradle-plugin#2192. Not retrying."
+        exit "$status"
+    fi
+
+    echo "::warning::Attempt ${attempt}/${MAX_ATTEMPTS} hit the bundled-plugin race (intellij-platform-gradle-plugin#2192)."
+done
+
+echo "::error::Still hitting the bundled-plugin race after ${MAX_ATTEMPTS} attempts."
+exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
-
+  
 jobs:
 
   # Prepare the environment and build the plugin
@@ -38,32 +38,9 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
 
-      # Gradle extracts the IntelliJ IDEA distribution through an artifact transform into an
-      # "immutable workspace" under caches/<version>/transforms, and verifies it by hashing the
-      # directory. setup-gradle restores that directory from a deduplicated gradle-transforms-v1-*
-      # cache entry, and a perturbed or partially written entry makes Gradle report
-      #   The contents of the immutable workspace ... have been modified
-      # discard the extracted IDE, and fail every lookup against it with
-      #   Could not find bundled plugin with ID: 'com.intellij.java'
-      # gradle-home-cache-excludes does NOT cover these entries (the enhanced cache provider
-      # restores them by its own hardcoded paths), so drop them before Gradle starts and let it
-      # re-extract. The IDE archive still comes from the cached modules-2 dependencies, so the
-      # cost is extraction, not a download.
-      - name: Drop restored artifact transforms
-        shell: bash
-        run: |
-          shopt -s nullglob
-          dirs=(~/.gradle/caches/*/transforms ~/.gradle/caches/transforms-*)
-          if [ ${#dirs[@]} -eq 0 ]; then
-            echo "No restored transform caches to drop"
-          else
-            printf 'Dropping %s\n' "${dirs[@]}"
-            rm -rf "${dirs[@]}"
-          fi
-
       # Build plugin
       - name: Build plugin
-        run: ./gradlew buildPlugin
+        run: .github/scripts/gradle-retry.sh buildPlugin
 
       # Prepare plugin archive content for creating artifact
       - name: Prepare Plugin Artifact
@@ -114,32 +91,9 @@ jobs:
         with:
           cache-read-only: true
 
-      # Gradle extracts the IntelliJ IDEA distribution through an artifact transform into an
-      # "immutable workspace" under caches/<version>/transforms, and verifies it by hashing the
-      # directory. setup-gradle restores that directory from a deduplicated gradle-transforms-v1-*
-      # cache entry, and a perturbed or partially written entry makes Gradle report
-      #   The contents of the immutable workspace ... have been modified
-      # discard the extracted IDE, and fail every lookup against it with
-      #   Could not find bundled plugin with ID: 'com.intellij.java'
-      # gradle-home-cache-excludes does NOT cover these entries (the enhanced cache provider
-      # restores them by its own hardcoded paths), so drop them before Gradle starts and let it
-      # re-extract. The IDE archive still comes from the cached modules-2 dependencies, so the
-      # cost is extraction, not a download.
-      - name: Drop restored artifact transforms
-        shell: bash
-        run: |
-          shopt -s nullglob
-          dirs=(~/.gradle/caches/*/transforms ~/.gradle/caches/transforms-*)
-          if [ ${#dirs[@]} -eq 0 ]; then
-            echo "No restored transform caches to drop"
-          else
-            printf 'Dropping %s\n' "${dirs[@]}"
-            rm -rf "${dirs[@]}"
-          fi
-
       # Run tests
       - name: Run Tests
-        run: ./gradlew check
+        run: .github/scripts/gradle-retry.sh check
 
       # Collect Tests Result of failed tests
       - name: Collect Tests Result
@@ -187,32 +141,9 @@ jobs:
         with:
           cache-read-only: true
 
-      # Gradle extracts the IntelliJ IDEA distribution through an artifact transform into an
-      # "immutable workspace" under caches/<version>/transforms, and verifies it by hashing the
-      # directory. setup-gradle restores that directory from a deduplicated gradle-transforms-v1-*
-      # cache entry, and a perturbed or partially written entry makes Gradle report
-      #   The contents of the immutable workspace ... have been modified
-      # discard the extracted IDE, and fail every lookup against it with
-      #   Could not find bundled plugin with ID: 'com.intellij.java'
-      # gradle-home-cache-excludes does NOT cover these entries (the enhanced cache provider
-      # restores them by its own hardcoded paths), so drop them before Gradle starts and let it
-      # re-extract. The IDE archive still comes from the cached modules-2 dependencies, so the
-      # cost is extraction, not a download.
-      - name: Drop restored artifact transforms
-        shell: bash
-        run: |
-          shopt -s nullglob
-          dirs=(~/.gradle/caches/*/transforms ~/.gradle/caches/transforms-*)
-          if [ ${#dirs[@]} -eq 0 ]; then
-            echo "No restored transform caches to drop"
-          else
-            printf 'Dropping %s\n' "${dirs[@]}"
-            rm -rf "${dirs[@]}"
-          fi
-
       # Run Verify Plugin task and IntelliJ Plugin Verifier tool
       - name: Run Plugin Verification tasks
-        run: ./gradlew verifyPlugin
+        run: .github/scripts/gradle-retry.sh verifyPlugin
 
       # Collect Plugin Verifier Result
       - name: Collect Plugin Verifier Result


### PR DESCRIPTION
## 📚 Description

Reverts the transforms purge from #197 and fixes the flake properly. **#197 did not work** — `main` failed the same way immediately after it merged.

### Correcting the earlier diagnosis

#197 blamed a corrupted immutable transform workspace, because this appeared just before the failure:

```
The contents of the immutable workspace '.../transforms/f1fcbde...' have been modified.
```

That was a coincidence. Counting signatures across every failure so far:

| Failing job | `ClosedFileSystemException` | `Unable to read descriptor` | `immutable workspace` |
|---|---|---|---|
| PR #196 Build (attempt 1) | 1 | 1 | 2 |
| main Verify (after #197) | 1 | 1 | **0** |
| main Test (after #197) | 1 | 1 | **0** |

The purge provably ran in those jobs (`Dropping /home/runner/.gradle/caches/9.6.1/transforms`) and they failed anyway, with no immutable-workspace message at all. The constant is the zip filesystem.

### Actual root cause

```
Unable to read descriptor [plugin.xml] from [.../plugins/java/lib/java-impl.jar]
java.nio.file.ClosedFileSystemException
Following 1 plugins could not be created: plugins/java
```

`IdeLayoutIndexService` parses `plugin.xml` out of the transformed IDE jars to build its bundled-plugin index. The zip filesystem backing them is closed while it is still reading, the index comes back incomplete, and the build reports the misleading `Could not find bundled plugin with ID: 'com.intellij.java'`.

This is [JetBrains/intellij-platform-gradle-plugin#2192](https://github.com/JetBrains/intellij-platform-gradle-plugin/issues/2192) — open, and confirmed by JetBrains on their own pipeline, with re-running as the current guidance. We match the reported trigger exactly: IJPG 2.18.1, Gradle 9.6.1, JDK 21, and Kotlin Gradle Plugin 2.4.10 whose `maybeAddTestDependencyCapability` hook forces the configuration-time dependency iteration that realizes the provider early.

Being a race, it hits whichever configuration resolves first — `:intellijPlatformRuntimeClasspath` in one job, `:intellijPlatformTestRuntimeClasspath` in another.

### Fix

There is nothing to fix on our side, so retry the invocation — **and only for this signature**. Any other failure exits on the first attempt, so a genuine test or compile error is never masked or slowed by retries.

Drop `.github/scripts/gradle-retry.sh` and call `./gradlew` directly once upstream ships the fix.

## ✅ Test plan

Script logic verified against a stub `gradlew`:

| Scenario | Attempts | Exit |
|---|---|---|
| passes first try | 1 | 0 |
| race, then passes | 3 | 0 |
| race every time | 3 (gives up) | 1 |
| **real test failure** | **1 (no retry)** | 1 |

- [ ] All three jobs green
