### PR TITLE
ci: stop the Gradle daemon between bundled-plugin race retries

### DIFF
--- a/.github/scripts/gradle-retry.sh
+++ b/.github/scripts/gradle-retry.sh
@@ -53,6 +53,11 @@ for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
     fi
 
     echo "::warning::Attempt ${attempt}/${MAX_ATTEMPTS} hit the bundled-plugin race (intellij-platform-gradle-plugin#2192)."
+
+    # IdeLayoutIndexService is a shared build service, so the daemon keeps the incomplete index
+    # and replays it: without this the retries fail in ~1s instead of re-reading the jars. Stop
+    # the daemon so the next attempt rebuilds the index from scratch.
+    ./gradlew --stop >/dev/null 2>&1 || true
 done
 
 echo "::error::Still hitting the bundled-plugin race after ${MAX_ATTEMPTS} attempts."


### PR DESCRIPTION
## 📚 Description

The retry added in #198 **never actually recovered**. On the first `main` build after it merged, the Test job burned all three attempts:

| Attempt | Duration | Error |
|---|---|---|
| 1 | 42s | `ClosedFileSystemException` → `Could not find bundled plugin` |
| 2 | **1s** | `Could not find bundled plugin` |
| 3 | **1s** | `Could not find bundled plugin` |

The sub-second retries give it away. `IdeLayoutIndexService` is a **shared build service**, so the Gradle daemon holds on to the incomplete bundled-plugin index and replays it on every subsequent invocation. The retry never re-read the jars — it just re-reported the cached result. Only the first attempt ever had a chance.

### Fix

Stop the daemon after a racing attempt, so the next one rebuilds the index from scratch.

## ✅ Test plan

Verified against a stub `gradlew` that records its call sequence:

| Scenario | Call sequence | Exit |
|---|---|---|
| passes first try | `build` | 0 |
| race, then passes | `build → stop → build → stop → build` | 0 |
| race every time | gives up after 3 | 1 |
| **real test failure** | `build` (no retry, no `--stop`) | 1 |

- [ ] All three jobs green

> The race is intermittent, so a green run does not by itself prove the retry works — it most likely will not trigger at all. The evidence is the call sequence above: the daemon is now stopped between attempts, which is exactly what attempts 2 and 3 were missing.

Refs [JetBrains/intellij-platform-gradle-plugin#2192](https://github.com/JetBrains/intellij-platform-gradle-plugin/issues/2192)
