### PR TITLE
ci: re-extract the IDE between bundled-plugin race retries

### DIFF
--- a/.github/scripts/gradle-retry.sh
+++ b/.github/scripts/gradle-retry.sh
@@ -54,10 +54,23 @@ for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
 
     echo "::warning::Attempt ${attempt}/${MAX_ATTEMPTS} hit the bundled-plugin race (intellij-platform-gradle-plugin#2192)."
 
-    # IdeLayoutIndexService is a shared build service, so the daemon keeps the incomplete index
-    # and replays it: without this the retries fail in ~1s instead of re-reading the jars. Stop
-    # the daemon so the next attempt rebuilds the index from scratch.
+    # The incomplete index survives in two places, and a retry has to clear both.
+    #
+    # IdeLayoutIndexService is a shared build service, so the daemon replays it in-process:
+    # without the stop, retries failed in ~1s having never re-read the jars.
     ./gradlew --stop >/dev/null 2>&1 || true
+    #
+    # It also survives on disk. With only the daemon stopped, retries still failed in ~10s on a
+    # provably fresh daemon ("1 stopped Daemon could not be reused") and without the originating
+    # ClosedFileSystemException, while re-running the whole job on a clean runner has always
+    # worked. So the interrupted read leaves the extracted IDE unusable, and it has to be
+    # re-extracted. The archive stays in modules-2, so this costs extraction, not a download.
+    shopt -s nullglob
+    stale=(~/.gradle/caches/*/transforms ~/.gradle/caches/transforms-*)
+    if [ ${#stale[@]} -gt 0 ]; then
+        echo "Re-extracting the IDE: dropping ${stale[*]}"
+        rm -rf "${stale[@]}"
+    fi
 done
 
 echo "::error::Still hitting the bundled-plugin race after ${MAX_ATTEMPTS} attempts."


### PR DESCRIPTION
## 📚 Description

Stopping the daemon in #199 was necessary but not sufficient. The next `main` build still burned all three attempts in the Verify job:

| Attempt | Duration | Error |
|---|---|---|
| 1 | 2m50s | `ClosedFileSystemException` → `Could not find bundled plugin` |
| 2 | 10s | `Could not find bundled plugin` |
| 3 | 9s | `Could not find bundled plugin` |

### Where the bad state actually lives

Attempts 2 and 3 ran on a **provably fresh daemon** — `Starting a Gradle Daemon, 1 stopped Daemon could not be reused` — took 10s rather than the 1s seen before the daemon stop, and never re-raised the originating `ClosedFileSystemException`.

So the incomplete index outlives the daemon; it is on disk. Combined with the fact that re-running the whole job on a clean runner has always worked, that puts the bad state in the Gradle user home — and the only IDE-derived state there is the extracted distribution, which the interrupted read leaves unusable.

| Fresh… | Result |
|---|---|
| runner (job re-run) | ✅ works |
| daemon, same disk (#199) | ❌ fails |
| daemon **and** extracted IDE (this PR) | expected fix |

### Fix

Drop the extracted IDE alongside stopping the daemon, so the next attempt re-extracts it. The archive stays in `modules-2`, so this costs extraction rather than a download — and only on an attempt that has already failed.

## ✅ Test plan

Verified against a stub `gradlew` that records its call sequence and whether the transforms directory is present:

| Scenario | Call sequence | Transforms after | Exit |
|---|---|---|---|
| passes first try | `build(tf=yes)` | kept | 0 |
| race, then passes | `build(tf=yes) → stop → build(tf=no)` | dropped | 0 |
| **real test failure** | `build(tf=yes)` — no retry, no stop | untouched | 1 |

- [ ] All three jobs green

> ⚠️ The race is intermittent and cannot be triggered on demand, so a green run does **not** prove this works — it most likely will not race at all. What is verified is the mechanism: the retry now runs with both the daemon and the extracted IDE gone, which is precisely what attempts 2 and 3 were missing. Real confirmation only comes the next time a race occurs and the build recovers.

Refs [JetBrains/intellij-platform-gradle-plugin#2192](https://github.com/JetBrains/intellij-platform-gradle-plugin/issues/2192)
