### PR TITLE
fix: detect private definitions from metadata, not body text

### DIFF
--- a/src/main/kotlin/org/phellang/registry/indexing/PhelProjectSymbolScanner.kt
+++ b/src/main/kotlin/org/phellang/registry/indexing/PhelProjectSymbolScanner.kt
@@ -8,6 +8,7 @@ import org.phellang.language.psi.PhelKeyword
 import org.phellang.language.psi.PhelList
 import org.phellang.language.psi.PhelLiteral
 import org.phellang.language.psi.PhelMap
+import org.phellang.language.psi.PhelMetadata
 import org.phellang.language.psi.PhelNamespaceUtils
 import org.phellang.language.psi.PhelProjectNamespaceFinder
 import org.phellang.language.psi.PhelVec
@@ -16,6 +17,8 @@ import org.phellang.language.psi.utils.PhelPsiUtils
 
 object PhelProjectSymbolScanner {
     private val PRIVATE_KEYWORDS = setOf("defn-", "def-", "defmacro-")
+
+    private const val PRIVATE_KEY = ":private"
 
     fun scanFile(psiFile: PhelFile): List<PhelProjectSymbol> {
         val namespace = PhelNamespaceUtils.extractNamespaceFromFile(psiFile) ?: return emptyList()
@@ -76,10 +79,54 @@ object PhelProjectSymbolScanner {
         )
     }
 
+    /**
+     * Phel marks a definition private with the `defn-` family (handled by [PRIVATE_KEYWORDS]), a
+     * `^` flag on the name symbol, or a keyword/map in the metadata slot between the name and the
+     * value — `(def x :private 1)` and `(def x {:private true} 1)`.
+     *
+     * The body is never consulted: a definition that merely mentions `:private` in its docstring
+     * or references a `:private-mode` keyword stays public.
+     */
     private fun isPrivateDefinition(forms: List<PhelForm>): Boolean {
-        for (form in forms) {
-            val text = form.text ?: continue
-            if (text.contains(":private")) return true
+        return hasPrivateNameFlag(forms[1]) || hasPrivateMetadataSlot(forms)
+    }
+
+    /** `^:private` / `^{:private true}` attached to the name symbol. */
+    private fun hasPrivateNameFlag(nameForm: PhelForm): Boolean {
+        val metadata = PsiTreeUtil.getChildrenOfType(nameForm, PhelMetadata::class.java) ?: return false
+
+        return metadata.any { meta ->
+            PsiTreeUtil.getChildOfType(meta, PhelKeyword::class.java)?.text == PRIVATE_KEY ||
+                PsiTreeUtil.getChildOfType(meta, PhelMap::class.java)?.let { declaresPrivate(it) } == true
+        }
+    }
+
+    /**
+     * The metadata slot sits between the name and the value, so the last form is always the value
+     * (or body) and never metadata — that is what keeps `(def defaults {:visibility :private-ish})`
+     * public while `(def x {:private true} 1)` is private.
+     */
+    private fun hasPrivateMetadataSlot(forms: List<PhelForm>): Boolean {
+        for (i in 2 until forms.size - 1) {
+            when (val form = forms[i]) {
+                is PhelKeyword -> if (form.text == PRIVATE_KEY) return true
+                is PhelMap -> if (declaresPrivate(form)) return true
+                // A docstring may precede the flag; anything else ends the metadata slot.
+                is PhelLiteral -> if (extractStringLiteral(form) == null) return false
+                else -> return false
+            }
+        }
+        return false
+    }
+
+    /** True when [map] binds `:private` to `true`; `{:private false}` is explicitly public. */
+    private fun declaresPrivate(map: PhelMap): Boolean {
+        val children = map.forms
+        for (i in 0 until children.size - 1) {
+            val child = children[i]
+            if (child is PhelKeyword && child.text == PRIVATE_KEY) {
+                return children[i + 1].text == "true"
+            }
         }
         return false
     }

--- a/src/main/kotlin/org/phellang/registry/indexing/PhelProjectSymbolScanner.kt
+++ b/src/main/kotlin/org/phellang/registry/indexing/PhelProjectSymbolScanner.kt
@@ -20,6 +20,8 @@ object PhelProjectSymbolScanner {
 
     private const val PRIVATE_KEY = ":private"
 
+    private const val DOC_KEY = ":doc"
+
     fun scanFile(psiFile: PhelFile): List<PhelProjectSymbol> {
         val namespace = PhelNamespaceUtils.extractNamespaceFromFile(psiFile) ?: return emptyList()
         val shortNamespace = PhelProjectNamespaceFinder.extractShortNamespace(namespace)
@@ -121,14 +123,17 @@ object PhelProjectSymbolScanner {
 
     /** True when [map] binds `:private` to `true`; `{:private false}` is explicitly public. */
     private fun declaresPrivate(map: PhelMap): Boolean {
+        return mapValueFor(map, PRIVATE_KEY)?.text == "true"
+    }
+
+    /** The form bound to [key] in [map], or null when the key is absent. */
+    private fun mapValueFor(map: PhelMap, key: String): PhelForm? {
         val children = map.forms
         for (i in 0 until children.size - 1) {
             val child = children[i]
-            if (child is PhelKeyword && child.text == PRIVATE_KEY) {
-                return children[i + 1].text == "true"
-            }
+            if (child is PhelKeyword && child.text == key) return children[i + 1]
         }
-        return false
+        return null
     }
 
     private fun extractSignature(keyword: String, name: String, forms: List<PhelForm>): String {
@@ -220,16 +225,8 @@ object PhelProjectSymbolScanner {
 
     private fun extractDocFromMap(form: PhelForm): String? {
         val map = form as? PhelMap ?: return null
-
-        val children = map.forms
-        for (i in 0 until children.size - 1) {
-            val child = children[i]
-            if (child is PhelKeyword && child.text == ":doc") {
-                return extractStringLiteral(children[i + 1])
-            }
-        }
-
-        return null
+        val doc = mapValueFor(map, DOC_KEY) ?: return null
+        return extractStringLiteral(doc)
     }
 
     private fun extractStringLiteral(form: PhelForm): String? {

--- a/src/test/kotlin/org/phellang/integration/registry/PhelProjectSymbolScannerPrivacyTest.kt
+++ b/src/test/kotlin/org/phellang/integration/registry/PhelProjectSymbolScannerPrivacyTest.kt
@@ -1,0 +1,75 @@
+package org.phellang.integration.registry
+
+import org.phellang.integration.PhelIntegrationTestCase
+import org.phellang.language.psi.files.PhelFile
+import org.phellang.registry.indexing.PhelProjectSymbolScanner
+
+/**
+ * Privacy detection must read the definition's metadata, never its body. Scanning body text for
+ * `:private` silently dropped public symbols from the index, taking completion, navigation, arity
+ * checking and hover docs with them.
+ *
+ * Phel marks a definition private four ways — the `defn-` family, a `^` flag on the name, and a
+ * keyword or map in the metadata slot between the name and the value (`DefSymbol.php`: "metadata
+ * form (string `:doc`, keyword flag, or map), then folds in flags attached to the name symbol").
+ */
+class PhelProjectSymbolScannerPrivacyTest : PhelIntegrationTestCase() {
+
+    // --- stays indexed: the body merely mentions the word ---
+
+    fun testBodyReferencingPrivateKeywordStaysIndexed() =
+        assertIndexed("(defn parse-flags [] (get opts :private-mode))", "parse-flags")
+
+    fun testDocstringMentioningPrivateStaysIndexed() =
+        assertIndexed("""(defn visibility-of [x] "Returns :public or :private for x." x)""", "visibility-of")
+
+    /** The map is the value here, not a metadata slot — there is no form after it. */
+    fun testMapValueMentioningPrivateStaysIndexed() =
+        assertIndexed("(def defaults {:visibility :private-ish})", "defaults")
+
+    fun testExplicitlyNonPrivateMetadataStaysIndexed() =
+        assertIndexed("(def ^{:private false} z 1)", "z")
+
+    fun testPlainDefinitionIsIndexed() = assertIndexed("(defn plain [x] x)", "plain")
+
+    // --- excluded: genuinely private ---
+
+    fun testCaretKeywordFlagIsPrivate() = assertIndexed("(def ^:private a 1)")
+
+    fun testCaretMapFlagIsPrivate() = assertIndexed("(def ^{:private true} b 1)")
+
+    fun testCaretFlagOnDefmacroIsPrivate() = assertIndexed("(defmacro ^:private m [] 1)")
+
+    fun testDefnDashIsPrivate() = assertIndexed("(defn- c [] 1)")
+
+    fun testDefDashIsPrivate() = assertIndexed("(def- d 1)")
+
+    fun testDefmacroDashIsPrivate() = assertIndexed("(defmacro- e [] 1)")
+
+    /** `(def x :private 1)` — bare keyword in the metadata slot, per Phel's own def fixtures. */
+    fun testPositionalKeywordFlagIsPrivate() = assertIndexed("(def f :private 1)")
+
+    /** `(def name {:private true :doc "..."} value)` — the form phel core itself uses. */
+    fun testPositionalMapFlagIsPrivate() = assertIndexed("""(def g {:private true :doc "d"} 1)""")
+
+    fun testPositionalMapFlagOnDefnIsPrivate() = assertIndexed("(defn h {:private true} [x] x)")
+
+    // --- the index still sees everything else in the file ---
+
+    fun testPrivateDefinitionDoesNotHideItsNeighbours() = assertIndexed(
+        """
+        (def ^:private secret 1)
+        (defn public-one [] secret)
+        (defn- hidden [] 1)
+        (defn public-two [] 2)
+        """.trimIndent(),
+        "public-one", "public-two"
+    )
+
+    /** Asserts scanning [source] yields exactly [expected] symbol names. */
+    private fun assertIndexed(source: String, vararg expected: String) {
+        val file = myFixture.configureByText("a.phel", "(ns my\\app)\n$source") as PhelFile
+        val actual = PhelProjectSymbolScanner.scanFile(file).map { it.name }
+        assertEquals("indexed symbols for `$source`", expected.toList(), actual)
+    }
+}

--- a/src/test/kotlin/org/phellang/unit/completion/indexing/PhelProjectSymbolScannerTest.kt
+++ b/src/test/kotlin/org/phellang/unit/completion/indexing/PhelProjectSymbolScannerTest.kt
@@ -13,56 +13,10 @@ class PhelProjectSymbolScannerTest {
         assertNotNull(PhelProjectSymbolScanner)
     }
 
-    @Nested
-    inner class PrivateDefinitionDetection {
-
-        @Test
-        fun `all private keywords are recognized`() {
-            // All shorthand forms for private definitions
-            val privateKeywords = setOf("defn-", "def-", "defmacro-")
-
-            assertTrue("defn-" in privateKeywords)
-            assertTrue("def-" in privateKeywords)
-            assertTrue("defmacro-" in privateKeywords)
-            assertFalse("defn" in privateKeywords)
-            assertFalse("def" in privateKeywords)
-            assertFalse("defmacro" in privateKeywords)
-        }
-
-        @Test
-        fun `names ending with dash are NOT private by themselves`() {
-            // A name ending with - is still public
-            // Only defn- keyword makes a function private
-            val namesWithDash = listOf("helper-", "process-data-", "validate-")
-
-            for (name in namesWithDash) {
-                // These should be public functions (the dash is just part of the name)
-                assertTrue(name.endsWith("-"), "$name ends with dash but is still public")
-            }
-        }
-
-        @Test
-        fun `text containing private attribute is private`() {
-            val privateTexts = listOf(
-                "^:private", "(def ^:private name value)", "{:private true}"
-            )
-
-            for (text in privateTexts) {
-                assertTrue(text.contains(":private"), "$text should be detected as private")
-            }
-        }
-
-        @Test
-        fun `regular defn with dash in name is public`() {
-            // Functions like "process-data" or even "my-fn-" are public
-            val publicFunctions = listOf("defn process-data", "defn my-fn-", "defn validate-input")
-
-            for (fn in publicFunctions) {
-                assertTrue(fn.startsWith("defn "), "$fn uses public defn keyword")
-                assertFalse(fn.startsWith("defn-"), "$fn is not private defn-")
-            }
-        }
-    }
+    // Privacy detection is covered by PhelProjectSymbolScannerPrivacyTest, which parses real
+    // definitions and calls scanFile. The cases that used to live here asserted String.contains
+    // over local literals without involving the scanner, so they passed while the scanner was
+    // dropping every public definition that merely mentioned `:private`.
 
     @Nested
     inner class QualifiedNameConstruction {


### PR DESCRIPTION
`PhelProjectSymbolScanner.isPrivateDefinition` scanned **every form of a top-level definition, body included**, for the substring `:private`. Any occurrence anywhere inside the definition suppressed indexing of the whole symbol, so a public function that merely mentioned the word silently lost completion, go-to-definition, find-usages, arity checking and hover docs:

```phel
(defn parse-flags [] (get opts :private-mode))
(defn visibility-of [x] "Returns :public or :private for x." x)
(def defaults {:visibility :private-ish})
```

Privacy is now read from the definition's metadata. The body is never consulted.

## Scope note: four private forms, not two

The issue proposed reading the `^:private` / `^{:private true}` flag on `forms[1]`. Implementing only that would have **regressed** a form phel core uses heavily — a metadata map in the slot after the name:

```phel
src/phel/core.phel        (def next-vector-or-nil {:private true :doc "..."} ...)
src/phel/core/meta.phel   (def copy-meta {:private true :doc "..."} ...)
src/phel/core/ns.phel     (def ^:private munge-instance ...)
tests/.../private-def.test       (def x :private 1)
tests/.../private-def-meta.test  (def x {:private true :export true} 1)
```

`DefSymbol.php` confirms the shape: *"metadata form (string `:doc`, keyword flag, or map), then folds in flags attached to the name symbol (e.g. `^:dynamic`, `^:private`)"*. Those definitions are private today (the substring scan catches them by accident), and the narrow fix would have made them public. So the scanner now honours all four:

1. the `defn-` / `def-` / `defmacro-` family (unchanged)
2. `^:private` / `^{:private true}` on the name symbol
3. a bare `:private` keyword in the metadata slot — `(def x :private 1)`
4. a map declaring `:private true` in the metadata slot — `(def x {:private true} 1)`

## The metadata slot never includes the last form

That single rule is what separates the two map cases:

| Source | `forms[2]` | Verdict |
|---|---|---|
| `(def defaults {:visibility :private-ish})` | last form → the **value** | public |
| `(def x {:private true} 1)` | followed by `1` → **metadata** | private |

`{:private false}` is treated as explicitly public.

## Test plan

New `PhelProjectSymbolScannerPrivacyTest` (15 cases) parses real definitions and calls `scanFile`, covering all four private forms, the three public false-positives above, `{:private false}`, and a mixed file asserting a private definition does not hide its neighbours.

I also removed the `PrivateDefinitionDetection` block from the old unit test. It asserted `String.contains(":private")` over local string literals without ever invoking the scanner, which is why it stayed green while the scanner dropped every public definition mentioning the word. The remaining stale test shapes in that file belong to #209.

- `./gradlew build` green
- `./gradlew test` green — 1157 tests, 0 failures (1146 before, +15 new, −4 vacuous)

Closes #202
