### PR TITLE
fix: keep kotlin-stdlib, gson and the generator out of the distribution

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,11 @@ sourceSets {
         }
         kotlin {
             srcDirs("src/main/kotlin", "src/main/gen")
+            // The build-time registry generator lives under src/main/kotlin for the tools tests to
+            // reach, but it is compiled by the isolated `generator` source set below and must not be
+            // part of the plugin's main output — otherwise it ships in the distribution jar and drags
+            // gson in with it. Tests get it via the generator output (see `dependencies`).
+            exclude("org/phellang/tools/**")
         }
     }
     test {
@@ -77,8 +82,19 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.mockito:mockito-core:5.23.0")
     testImplementation("org.mockito:mockito-junit-jupiter:5.23.0")
-    implementation("com.google.code.gson:gson:2.14.0")
+    // gson is used only by the build-time generator under org/phellang/tools/**, never by runtime
+    // plugin code (ArchitectureBoundaryTest enforces this), so it is not a plugin `implementation`
+    // dependency and never ships in the distribution. The generator source set and the tools tests
+    // each get their own copy; the tests also read the generator's compiled output for the tools
+    // classes, which the main source set deliberately excludes.
     "generatorImplementation"("com.google.code.gson:gson:2.14.0")
+    // The main source set receives the Kotlin stdlib transitively from the IntelliJ Platform, but
+    // the isolated generator source set does not depend on the platform. With the auto-added stdlib
+    // now disabled (kotlin.stdlib.default.dependency=false, see gradle.properties) it must declare
+    // its own — it is a plain JVM program, not plugin code that ships.
+    "generatorImplementation"(kotlin("stdlib"))
+    testImplementation("com.google.code.gson:gson:2.14.0")
+    testImplementation(sourceSets["generator"].output)
 }
 
 configurations.all {

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,6 +11,11 @@ org.gradle.parallel=true
 kotlin.code.style=official
 kotlin.incremental=true
 
+# The IntelliJ Platform bundles its own Kotlin standard library. Let the Gradle Kotlin plugin
+# add ours too and a newer stdlib (2.4.10) than the platform's ships in the distribution and can
+# cause ClassNotFoundException / version-mismatch at runtime. See: https://jb.gg/intellij-platform-kotlin-stdlib
+kotlin.stdlib.default.dependency=false
+
 # Suppress Gradle 10.0 deprecation warnings from third-party plugins
 org.gradle.warning.mode=none
 


### PR DESCRIPTION
`phelplugin-0.5.3.zip` was 3.0 MB, ~2.2 MB of it never used at runtime: `kotlin-stdlib-2.4.10.jar`, `gson`, gson's two transitive annotation jars, and 25 `org/phellang/tools/**` classes compiled into the plugin jar.

## Before / after

| | Before | After |
|---|---|---|
| distribution `lib/` | 5 jars, 3.0 MB | **1 jar, 809 KB** |
| `kotlin-stdlib-2.4.10.jar` | bundled | gone |
| `gson` + `error_prone` + `annotations` | bundled | gone |
| `org/phellang/tools/**` in plugin jar | 25 classes | **0** |
| `verifyPluginProjectConfiguration` stdlib conflict | reported | **gone** |

## Changes

**1. `kotlin.stdlib.default.dependency=false`** (`gradle.properties`). The IntelliJ Platform provides the stdlib; bundling our own *newer* copy (2.4.10) risks classloader conflicts, which `verifyPluginProjectConfiguration` flagged directly. Disabling the auto-added stdlib also removed it from the isolated `generator` source set — which, unlike `main`, does not receive it transitively from the platform — so the generator now declares its own `kotlin("stdlib")`. It is a plain JVM program run by `updatePhelRegistry`, not shipped code.

**2. gson moves off the plugin `implementation` configuration** to `generatorImplementation` + `testImplementation`. gson is used only by the build-time generator under `org/phellang/tools/**`; `ArchitectureBoundaryTest` already forbids runtime code from importing `tools`, so gson has no runtime role and should never have been an `implementation` dependency.

**3. `org/phellang/tools/**` excluded from the main source set.** This is the part that needed care. My first attempt — excluding `tools/**` from the `jar` task — did not work: the platform's `composedJar` is merged from a separately-built `instrumentedJar` that reads the compiled main output directly, and `InstrumentedJarTask` is not a `Jar` subclass, so a copy-filter exclude cannot touch it. The issue's own suggestion is the correct lever — move `tools` out of the main source set (the `generator` source set already compiles it). The generator is then never in the main output that feeds `instrumentedJar`/`composedJar`. The 6 tools test files still compile and run because the test source set now reads `sourceSets["generator"].output`.

## On testing

This is a build-configuration change with no runtime code, so there is no unit test — a `./gradlew test` assertion cannot inspect the packaged jar without building the distribution, and coupling the fast test task to `buildPlugin` (the `verifyPlugin` job alone is ~14 min) would be the wrong trade. It is verified by artifact inspection and the existing CI `build` / `Verify plugin` gates. The source-level invariant that makes excluding `tools` safe — runtime code never imports it — is already locked by `ArchitectureBoundaryTest`.

The mandatory post-implementation refactor pass over the two touched config files surfaced nothing to change.

## Verification performed

```
$ unzip -l build/distributions/*.zip | grep '\.jar'
   809189  phelplugin/lib/phelplugin-0.5.3.jar          # single jar

$ unzip -l <plugin jar> | grep -c org/phellang/tools/   # 0
$ verifyPluginProjectConfiguration | grep -c 'stdlib.*conflict'  # 0
$ ./gradlew updatePhelRegistry                          # 966 functions, registry unchanged
$ ./gradlew test                                        # 1157 tests green
```

Closes #203
