### PR TITLE
fix: enforce plugin configuration check and resolve apiVersion mismatch

### DIFF
--- a/.agnostic-ai/AGNOSTIC_AI.md
+++ b/.agnostic-ai/AGNOSTIC_AI.md
@@ -32,7 +32,7 @@ Plugin sources live under `src/main/kotlin/org/phellang/`:
 ## Build & Tooling
 
 - Gradle (Kotlin DSL), IntelliJ Platform Gradle Plugin, Grammar-Kit (JFlex + BNF), Java 21 toolchain, Kotlin 2.1.
-- Target IntelliJ IDEA 2025.2 (compat 2024.2 — 2026.2.x). `buildSearchableOptions` disabled.
+- Target IntelliJ IDEA 2025.2 (compat 2024.3 — 2026.2.x). `buildSearchableOptions` disabled.
 - Kotlin/Java compile tasks depend on lexer/parser generation automatically.
 - After editing `.flex`/`.bnf`, run `./gradlew generatePhelLexer generatePhelParser` (a PostToolUse hook does this for Claude).
 

--- a/.agnostic-ai/rules/build.md
+++ b/.agnostic-ai/rules/build.md
@@ -6,7 +6,7 @@ description: Build system and Gradle tasks
 # Build
 
 Gradle (Kotlin DSL) · IntelliJ Platform Gradle Plugin · Grammar-Kit (JFlex+BNF) · Java 21 · Kotlin 2.1.
-Target IDEA 2025.2 (compat 2024.2 — 2026.2.x). Gson powers the API generator.
+Target IDEA 2025.2 (compat 2024.3 — 2026.2.x). Gson powers the API generator.
 
 Tasks:
 - `runIde` — sandbox IDE (don't run `build` concurrently)
@@ -17,5 +17,5 @@ Tasks:
 
 Notes:
 - Compile auto-depends on lexer/parser generation. `buildSearchableOptions` disabled.
-- Verifier runs vs IC 2024.2, 2024.3, 2025.1, 2025.2, 2025.2.6.
+- Verifier runs vs IC 2024.3, 2025.1, 2025.2, 2025.2.6.
 - Publish env: `CERTIFICATE_CHAIN`, `PRIVATE_KEY`, `PRIVATE_KEY_PASSWORD`, `PUBLISH_TOKEN`.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,28 @@ jobs:
       - name: Build plugin
         run: .github/scripts/gradle-retry.sh buildPlugin
 
+      # Enforce the plugin project configuration check. verifyPluginProjectConfiguration only logs a
+      # warning and exits 0 (it reports to Gradle's Problems API at WARNING severity), so on its own
+      # it can never fail CI — the whole point of this issue. Capture its output and fail when any
+      # unmuted issue is reported. Deliberate policy items (since-build, until-build) are muted in
+      # build.gradle.kts, so this trips only on new or real configuration problems.
+      - name: Enforce plugin project configuration
+        shell: bash
+        run: |
+          set -uo pipefail
+          output="$(.github/scripts/gradle-retry.sh verifyPluginProjectConfiguration 2>&1)"
+          status=$?
+          echo "$output"
+          if [ "$status" -ne 0 ]; then
+            echo "::error::verifyPluginProjectConfiguration task failed."
+            exit "$status"
+          fi
+          if grep -q "plugin configuration issues were found" <<<"$output"; then
+            echo "::error::verifyPluginProjectConfiguration reported configuration issues. Fix them, or if an item reflects deliberate policy, mute its exact message via mutedMessages in build.gradle.kts."
+            exit 1
+          fi
+          echo "Plugin project configuration is clean."
+
       # Prepare plugin archive content for creating artifact
       - name: Prepare Plugin Artifact
         id: artifact

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.jetbrains.grammarkit.tasks.GenerateLexerTask
 import org.jetbrains.grammarkit.tasks.GenerateParserTask
+import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginProjectConfigurationTask
 
 group = "org.phellang"
 version = "0.5.3"
@@ -154,6 +155,24 @@ val generatorCompileTasks = sourceSets["generator"].let {
     setOf(it.compileJavaTaskName, it.getCompileTaskName("kotlin"))
 }
 
+// Mute only the two informational items that reflect this plugin's deliberate, documented
+// compatibility policy, so every *other* configuration issue still surfaces — the CI gate
+// (.github/workflows/build.yml) fails the build when any unmuted issue is reported. Keep this list
+// as narrow as possible; do not mute real problems.
+//
+//  - since-build (243) is intentionally lower than the platform we build against (252): that is how
+//    the plugin declares support for older IDEs, and the IntelliJ Plugin Verifier exercises the
+//    whole range for real.
+//  - until-build (262.*) is a deliberate upper bound (compat 2024.3 — 2026.2.x). The verifier
+//    suggests dropping it for open-ended forward compatibility on 243+; whether to do so is a
+//    separate forward-compat policy decision, not part of this change.
+tasks.named<VerifyPluginProjectConfigurationTask>("verifyPluginProjectConfiguration") {
+    mutedMessages.addAll(
+        "since-build is lower than target platform version",
+        "until-build property should be removed",
+    )
+}
+
 tasks {
     // Set the JVM compatibility versions
     withType<JavaCompile> {
@@ -167,8 +186,14 @@ tasks {
     withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         compilerOptions {
             jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21
+            // languageVersion must be >= the Kotlin the target platform bundles (252 -> 2.1);
+            // apiVersion must be <= the Kotlin API the minimum supported IDE (since-build 243 =
+            // IDEA 2024.3) guarantees, which is 2.0. The Kotlin 2.4 compiler no longer accepts
+            // apiVersion 1.9, so 2.0 is also the floor — which is why since-build cannot stay at 242
+            // (2024.2 only ships Kotlin API 1.9). languageVersion 2.1 is deprecation-flagged by the
+            // 2.4 compiler; it stays until the minimum platform bundles >= 2.2 (since-build >= 253).
             languageVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_1
-            apiVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_1
+            apiVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_0
         }
         if (name !in generatorCompileTasks) {
             dependsOn(generatePhelLexer, generatePhelParser)
@@ -211,7 +236,6 @@ tasks {
 
         pluginVerification {
             ides {
-                create("IC", "2024.2")
                 create("IC", "2024.3")
                 create("IC", "2025.1")
                 create("IC", "2025.2")
@@ -220,7 +244,7 @@ tasks {
         }
 
         patchPluginXml {
-            sinceBuild.set("242")
+            sinceBuild.set("243")
             untilBuild.set("262.*")
         }
 


### PR DESCRIPTION
`./gradlew verifyPluginProjectConfiguration` reported configuration problems and **exited 0**, so CI's verify step printed them into the log and passed anyway. This makes the check enforcing, and resolves the apiVersion / since-build mismatch.

## The mismatch has a hard toolchain constraint

The issue proposed "lower apiVersion to 1.9." That is impossible with the current toolchain — the **Kotlin 2.4.10 compiler rejects apiVersion 1.9** ("API version 1.9 is no longer supported; use version 2.0 or greater"). The platform→Kotlin map (from the verifier's own `PlatformKotlinVersions`) is:

| since-build | IDE | bundled Kotlin API |
|---|---|---|
| 242 | 2024.2 | 1.9 |
| **243** | **2024.3** | **2.0** |
| 252 | 2025.2 | 2.1 |

So apiVersion's floor (2.0) can't coexist with a 242 floor (which guarantees only 1.9). Per the maintainer's decision (**raise since-build, drop 2024.2**):

- **since-build 242 → 243**, apiVersion pinned to **2.0** → the "apiVersion exceeds since-build" warning clears honestly, no muting.
- Dropped `IC 2024.2` from the plugin verifier IDE list; updated the documented compat range to **2024.3 — 2026.2.x** (`.agnostic-ai` specs → regenerates CLAUDE.md).

## Enforcement

`verifyPluginProjectConfiguration` only calls `log.warn` (it reports to Gradle's Problems API at `Severity.WARNING`) and has no fail hook — confirmed in the plugin source. So enforcement is a CI gate in the `build` job: it runs the task, captures its output, and fails when any **unmuted** issue is reported.

I proved the gate both ways: it stays green on the fixed config, and trips when I temporarily reintroduced an apiVersion mismatch.

Two informational items are muted via the plugin's own `mutedMessages`, because they reflect deliberate, documented policy the verifier can't infer:
- **since-build lower than build target** — unavoidable for any backward-compatible plugin (243 supported, built against 252); the IntelliJ Plugin Verifier covers the real range.
- **until-build should be removed** — this surfaced only after raising to 243. Whether to open up forward-compat by dropping the `262.*` cap is a separate policy decision (CLAUDE.md documents the cap), so I preserved it and muted the item. See "Follow-ups."

Every *other* issue still surfaces and fails the gate — muting is kept as narrow as possible, with a comment forbidding broadening it.

## Part 3 — the deprecated Kotlin 2.1 language version (planned, not changed)

`languageVersion` stays **2.1** because the target platform (252) bundles Kotlin 2.1 and `languageVersion` must be ≥ that. The 2.4 compiler deprecation-flags 2.1, so the plan — documented in the build script — is to raise it once the *minimum* supported platform bundles ≥ 2.2 (since-build ≥ 253 / 2025.3). The `w: Language version 2.1 is deprecated` warning is left visible on purpose as the reminder.

## Testing

Build-config change; verified by artifact inspection and the CI gates, consistent with #203:
- `./gradlew build` green; patched `plugin.xml` shows `since-build="243"`.
- `verifyPluginProjectConfiguration` output is clean (all remaining items muted).
- Gate logic tested locally: green on clean config, red on a reintroduced mismatch.
- `./gradlew test` — 1157 green on a clean run (two `PhelAnnotatorPerformanceTest` timing assertions flake in the full suite and pass in isolation; those are #209's territory, unrelated to this change which touches no runtime code).

The refactor pass over the changed files surfaced nothing to change.

## Follow-ups (out of scope here)

- **until-build**: consider dropping the `262.*` cap for open-ended forward compatibility on 243+, as the verifier now recommends. That's a forward-compat policy call, not part of this fix.
- A few `.agnostic-ai` workflow/skill files still mention `2024.2` in loose "version-compat range" prose (already inconsistent, using `2026.1.x`). Left untouched to keep this diff focused on the maintainer-specified doc updates.

Closes #204
