### PR TITLE
fix: make the project symbol index build cancellable and deadlock-safe

### DIFF
--- a/src/main/kotlin/org/phellang/registry/indexing/PhelProjectSymbolIndex.kt
+++ b/src/main/kotlin/org/phellang/registry/indexing/PhelProjectSymbolIndex.kt
@@ -3,6 +3,7 @@ package org.phellang.registry.indexing
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
+import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
@@ -12,6 +13,7 @@ import com.intellij.psi.search.GlobalSearchScope
 import org.phellang.registry.PhelProjectSymbol
 import org.phellang.language.psi.files.PhelFile
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
 
 @Service(Service.Level.PROJECT)
 class PhelProjectSymbolIndex(private val project: Project) : Disposable {
@@ -24,9 +26,12 @@ class PhelProjectSymbolIndex(private val project: Project) : Disposable {
     /** Cache: file path -> List of symbols */
     private val symbolsByFile = ConcurrentHashMap<String, List<PhelProjectSymbol>>()
 
-    /** Whether the index has been built */
+    /** Whether a full-project scan has completed. Only ever set true by a scan that finished. */
     @Volatile
     private var indexBuilt = false
+
+    /** Single-flight guard so at most one thread runs the full scan at a time. */
+    private val buildInProgress = AtomicBoolean(false)
 
     init {
         // Register file change listener to keep index in sync (for file saves)
@@ -123,17 +128,29 @@ class PhelProjectSymbolIndex(private val project: Project) : Disposable {
     }
 
     private fun ensureIndexBuilt() {
-        if (!indexBuilt) {
-            synchronized(this) {
-                if (!indexBuilt) {
-                    buildIndex()
-                    indexBuilt = true
-                }
+        if (indexBuilt) return
+
+        // Single-flight without holding a monitor across the read action. The old
+        // `synchronized(this) { runReadAction { … } }` acquired the read lock while holding the
+        // monitor — a lock-ordering deadlock shape against the EDT taking the monitor inside a
+        // write action. A concurrent caller that finds a build already running returns whatever is
+        // indexed so far rather than blocking on the monitor.
+        if (!buildInProgress.compareAndSet(false, true)) return
+        try {
+            // `indexBuilt` flips only when a scan actually completed. A build cut short by
+            // cancellation (ProcessCanceledException) or a disposed project leaves it false, so the
+            // next call rebuilds instead of trusting a partial/empty index.
+            if (buildIndex()) {
+                indexBuilt = true
             }
+        } finally {
+            buildInProgress.set(false)
         }
     }
 
-    private fun buildIndex() {
+    /** @return true only if the scan ran to completion (not disposed, not cancelled). */
+    private fun buildIndex(): Boolean {
+        var completed = false
         ApplicationManager.getApplication().runReadAction {
             if (project.isDisposed) return@runReadAction
             val phelFiles = FilenameIndex.getAllFilesByExt(
@@ -141,21 +158,26 @@ class PhelProjectSymbolIndex(private val project: Project) : Disposable {
             )
 
             val psiManager = PsiManager.getInstance(project)
-
-            for (virtualFile in phelFiles) {
-                if (!virtualFile.isValid) continue
-                val psiFile = psiManager.findFile(virtualFile) as? PhelFile ?: continue
-
-                val symbols = PhelProjectSymbolScanner.scanFile(psiFile)
-
-                if (symbols.isNotEmpty()) {
-                    symbolsByFile[virtualFile.path] = symbols
-                    for (symbol in symbols) {
-                        addToMap(symbolsByNamespace, symbol.shortNamespace, symbol)
-                        addToMap(symbolsByName, symbol.name, symbol)
-                    }
-                }
+            val psiFiles = phelFiles.mapNotNull { vf ->
+                if (vf.isValid) psiManager.findFile(vf) as? PhelFile else null
             }
+
+            indexFiles(psiFiles)
+            completed = true
+        }
+        return completed
+    }
+
+    /**
+     * Scans [files] into the index, checking for cancellation before each one so a large project's
+     * scan can be abandoned (e.g. the user keeps typing during completion). Re-scanning replaces a
+     * file's prior entries via [refreshFileFromPsi], so re-running after a cancelled build is safe
+     * and never duplicates. Caller must hold read access.
+     */
+    internal fun indexFiles(files: List<PhelFile>) {
+        for (file in files) {
+            ProgressManager.checkCanceled()
+            refreshFileFromPsi(file)
         }
     }
 

--- a/src/test/kotlin/org/phellang/integration/registry/PhelProjectSymbolIndexBuildTest.kt
+++ b/src/test/kotlin/org/phellang/integration/registry/PhelProjectSymbolIndexBuildTest.kt
@@ -1,0 +1,68 @@
+package org.phellang.integration.registry
+
+import com.intellij.openapi.progress.ProcessCanceledException
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.progress.util.ProgressIndicatorBase
+import org.phellang.integration.PhelIntegrationTestCase
+import org.phellang.language.psi.files.PhelFile
+import org.phellang.registry.indexing.PhelProjectSymbolIndex
+
+/**
+ * The lazy full-project scan must be cancellable and idempotent: a scan abandoned mid-way (the user
+ * keeps typing) has to leave the index in a state a later call rebuilds cleanly, never duplicating
+ * the files it already visited.
+ *
+ * The scan loop is exercised directly via [PhelProjectSymbolIndex.indexFiles] because the
+ * FilenameIndex-driven discovery in `buildIndex` finds nothing under the light test fixture — which
+ * is exactly why the rest of the suite primes the index with `refreshFileFromPsi`.
+ */
+class PhelProjectSymbolIndexBuildTest : PhelIntegrationTestCase() {
+
+    private fun index() = PhelProjectSymbolIndex.getInstance(project)
+
+    fun testScanIndexesSymbolsFromEveryFile() {
+        val a = myFixture.addFileToProject("src/a.phel", "(ns app\\a)\n(defn foo [] 1)\n") as PhelFile
+        val b = myFixture.addFileToProject("src/b.phel", "(ns app\\b)\n(defn bar [] 2)\n") as PhelFile
+
+        index().indexFiles(listOf(a, b))
+
+        assertEquals(listOf("bar", "foo"), index().getAllSymbols().map { it.name }.sorted())
+    }
+
+    fun testReScanningTheSameFilesDoesNotDuplicate() {
+        val a = myFixture.addFileToProject("src/a.phel", "(ns app\\a)\n(defn foo [] 1)\n") as PhelFile
+
+        index().indexFiles(listOf(a))
+        index().indexFiles(listOf(a))
+
+        assertEquals("re-scanning must replace, not append", 1, index().findByName("foo").size)
+    }
+
+    /** Underpins safe rebuild-after-cancel: a single file's re-scan is idempotent. */
+    fun testRefreshingTheSameFileIsIdempotent() {
+        val file = myFixture.addFileToProject("src/a.phel", "(ns app\\a)\n(defn foo [] 1)\n") as PhelFile
+
+        index().refreshFileFromPsi(file)
+        index().refreshFileFromPsi(file)
+
+        assertEquals(1, index().findByName("foo").size)
+    }
+
+    fun testScanHonorsCancellationAndLeavesFilesRescannable() {
+        val a = myFixture.addFileToProject("src/a.phel", "(ns app\\a)\n(defn foo [] 1)\n") as PhelFile
+        val b = myFixture.addFileToProject("src/b.phel", "(ns app\\b)\n(defn bar [] 2)\n") as PhelFile
+
+        val cancelled = ProgressIndicatorBase().apply { start(); cancel() }
+        try {
+            ProgressManager.getInstance().runProcess({ index().indexFiles(listOf(a, b)) }, cancelled)
+            fail("the scan must honor cancellation")
+        } catch (expected: ProcessCanceledException) {
+            // expected: checkCanceled aborted before touching any file
+        }
+
+        // A later, uncancelled scan rebuilds the whole set without duplication.
+        index().indexFiles(listOf(a, b))
+        assertEquals(listOf("bar", "foo"), index().getAllSymbols().map { it.name }.sorted())
+        assertEquals(1, index().findByName("foo").size)
+    }
+}


### PR DESCRIPTION
`PhelProjectSymbolIndex.ensureIndexBuilt()` parsed every `.phel` file in the project under `synchronized(this) { runReadAction { … } }`, with no cancellation and with `indexBuilt` set unconditionally afterward. All three defects the issue names are real (verified against the file):

1. **Uncancellable** — the per-file loop (`buildIndex`) had no `ProgressManager.checkCanceled()`, so a completion-triggered scan on a large project couldn't be abandoned when the user kept typing.
2. **Monitor held across the read action** — acquiring the read lock while holding the monitor is a lock-ordering deadlock shape against the EDT taking the monitor inside a write action.
3. **`indexBuilt` set even when the scan did nothing** — if the read action short-circuited on `project.isDisposed`, the flag still flipped and the index stayed permanently empty.

## Fix

- **Drop the monitor.** `ensureIndexBuilt` single-flights via an `AtomicBoolean` and never holds a lock across the read action. A concurrent caller that finds a build already running returns what's indexed so far rather than blocking on the monitor.
- **`buildIndex` returns whether the scan completed;** `indexBuilt` flips only then. A cancelled or disposed build leaves the index rebuildable.
- **Extract the per-file loop into `indexFiles`,** which calls `checkCanceled()` before each file and reuses the existing `refreshFileFromPsi`. Re-scanning replaces a file's entries, so a rebuild after a cancelled scan never duplicates.

## A deliberate scoping note

The issue proposed moving the build to a "cancellable background task" with fully non-blocking accessors. I fixed the three concrete defects but kept the build running on the first caller's thread rather than a detached `ReadAction.nonBlocking` task, because:

- Every accessor caller is **off the EDT** — completion, the annotator's highlight pass, hover, and arity resolution all run in background read actions. So the UI never blocks, and a superseded scan aborts via `checkCanceled`. Concurrent callers already return available data without blocking (the single-flight). The user-facing goal (no UI freeze, cancellable) is met.
- A detached `ReadAction.nonBlocking` build's async-callback threading **isn't verifiable in the light test fixture**, and introducing async build threads into the test lifecycle risks the index-priming determinism that #209 is about. Given "verify, don't trust," I preferred the fix I could test end to end.

If a fully detached background build is wanted, it's a clean follow-up on top of this.

## Testing

New `PhelProjectSymbolIndexBuildTest` (4 cases). The FilenameIndex-driven discovery finds nothing under the light fixture — which is exactly why the rest of the suite primes via `refreshFileFromPsi` — so the tests drive the extracted `indexFiles` scan loop directly:

- indexes symbols from every file;
- re-scanning the same files doesn't duplicate;
- single-file refresh is idempotent (underpins safe rebuild-after-cancel);
- **a scan under a cancelled progress indicator throws `ProcessCanceledException` and leaves the files rescannable** — this is the regression guard, and it fails on the pre-fix code (no `checkCanceled`).

(One wrinkle worth noting: `EmptyProgressIndicator.cancel()` is a no-op in this harness — `isCanceled` stays false — so the cancellation test uses a started-then-cancelled `ProgressIndicatorBase`, which I verified actually makes `checkCanceled()` throw.)

- `./gradlew build` green.
- `./gradlew test` — 1161 green on a clean run (1157 + 4 new); the resolution/inspection integration tests that read the index still pass.

The refactor pass over the changed file surfaced nothing to change.

Closes #205
