### PR TITLE
fix: offload VFS-triggered parsing off the EDT and scope it to the project

### DIFF
--- a/src/main/kotlin/org/phellang/registry/indexing/PhelFileChangeListener.kt
+++ b/src/main/kotlin/org/phellang/registry/indexing/PhelFileChangeListener.kt
@@ -3,11 +3,15 @@ package org.phellang.registry.indexing
 import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.fileTypes.FileTypeRegistry
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.newvfs.BulkFileListener
 import com.intellij.openapi.vfs.newvfs.events.*
 import com.intellij.psi.PsiManager
+import org.phellang.language.infrastructure.PhelFileType
+import org.phellang.language.psi.files.PhelFile
 
 class PhelFileChangeListener(private val project: Project) : BulkFileListener {
 
@@ -15,50 +19,82 @@ class PhelFileChangeListener(private val project: Project) : BulkFileListener {
         if (project.isDisposed) return
 
         val index = PhelProjectSymbolIndex.getInstance(project)
-        var needsReparse = false
+        // A set: one batch can carry several events for the same file (e.g. content + property
+        // change), and re-scanning it once is enough.
+        val toRefresh = LinkedHashSet<VirtualFile>()
+        var changed = false
 
         for (event in events) {
             val file = event.file ?: continue
 
-            if (!isPhelFile(file)) continue
-
             when (event) {
-                is VFileContentChangeEvent -> {
-                    index.refreshFile(file)
-                    needsReparse = true
-                }
-
-                is VFileCreateEvent -> {
-                    index.refreshFile(file)
-                    needsReparse = true
-                }
-
                 is VFileDeleteEvent -> {
-                    index.removeFile(file)
-                    needsReparse = true
+                    // Removal is cheap (no parse) and idempotent: dropping a path that was never
+                    // indexed — e.g. a foreign file filtered out below — is a harmless no-op, so
+                    // there is no need to scope-check a file that is already gone.
+                    if (isPhelFile(file)) {
+                        index.removeFile(file)
+                        changed = true
+                    }
                 }
 
-                is VFileMoveEvent -> {
-                    index.refreshFile(file)
-                    needsReparse = true
+                is VFileContentChangeEvent, is VFileCreateEvent, is VFileMoveEvent -> {
+                    if (shouldIndex(file)) {
+                        toRefresh += file
+                        changed = true
+                    }
                 }
 
                 is VFilePropertyChangeEvent -> {
-                    if (event.propertyName == VirtualFile.PROP_NAME) {
-                        index.refreshFile(file)
-                        needsReparse = true
+                    if (event.propertyName == VirtualFile.PROP_NAME && shouldIndex(file)) {
+                        toRefresh += file
+                        changed = true
                     }
                 }
             }
         }
 
-        if (needsReparse) {
+        if (toRefresh.isNotEmpty()) {
+            // Refreshing calls PhelProjectSymbolScanner.scanFile, which forces a full PSI parse.
+            // after() runs inside the VFS write action on the EDT, so parsing here would freeze the
+            // UI for the whole changeset — e.g. a git checkout touching many .phel files. Move it
+            // off the write action onto a pooled thread.
+            scheduleBackgroundRefresh(index, toRefresh)
+        } else if (changed) {
             triggerRehighlight()
         }
     }
 
+    /**
+     * A file this project should index: associated with [PhelFileType] and inside project content.
+     *
+     * `VirtualFileManager.VFS_CHANGES` is an application-level topic, so a project-bus subscription
+     * still receives events for `.phel` files anywhere on disk — another open project, a temp or
+     * scratch directory. Without the [ProjectFileIndex] check those symbols would leak into this
+     * project's completion and go-to-definition.
+     */
+    internal fun shouldIndex(file: VirtualFile): Boolean {
+        return isPhelFile(file) && ProjectFileIndex.getInstance(project).isInContent(file)
+    }
+
+    /** File-type association rather than a raw extension string, so custom mappings are honored. */
     private fun isPhelFile(file: VirtualFile): Boolean {
-        return file.extension == "phel"
+        return FileTypeRegistry.getInstance().isFileOfType(file, PhelFileType.INSTANCE)
+    }
+
+    private fun scheduleBackgroundRefresh(index: PhelProjectSymbolIndex, files: Collection<VirtualFile>) {
+        ApplicationManager.getApplication().executeOnPooledThread {
+            for (file in files) {
+                if (project.isDisposed) return@executeOnPooledThread
+                ApplicationManager.getApplication().runReadAction {
+                    if (project.isDisposed || !file.isValid) return@runReadAction
+                    val psiFile = PsiManager.getInstance(project).findFile(file) as? PhelFile
+                        ?: return@runReadAction
+                    index.refreshFileFromPsi(psiFile)
+                }
+            }
+            triggerRehighlight()
+        }
     }
 
     private fun triggerRehighlight() {
@@ -74,7 +110,7 @@ class PhelFileChangeListener(private val project: Project) : BulkFileListener {
                 val daemon = DaemonCodeAnalyzer.getInstance(project)
 
                 fileEditorManager.openFiles
-                    .filter { it.extension == "phel" }
+                    .filter { isPhelFile(it) }
                     .mapNotNull { psiManager.findFile(it) }
                     .forEach { daemon.restart(it) }
             }

--- a/src/main/kotlin/org/phellang/registry/indexing/PhelProjectSymbolIndex.kt
+++ b/src/main/kotlin/org/phellang/registry/indexing/PhelProjectSymbolIndex.kt
@@ -76,26 +76,34 @@ class PhelProjectSymbolIndex(private val project: Project) : Disposable {
         }
     }
 
+    /** Serializes the per-file remove-then-add so concurrent refreshers can't duplicate a file. */
+    private val refreshLock = Any()
+
     /**
-     * Refreshes the index from the current PSI state (used for live updates during editing).
+     * Refreshes the index from the current PSI state (used for live updates during editing and by
+     * the background VFS refresh). The scan runs outside [refreshLock] since it only reads PSI, but
+     * the swap of a file's entries is done under the lock: without it two threads refreshing the
+     * same file — the VFS listener's pooled thread and the PSI listener, say — can both read the
+     * same old set and both append, duplicating every symbol.
      */
     fun refreshFileFromPsi(psiFile: PhelFile) {
         val virtualFile = psiFile.virtualFile ?: return
         val filePath = virtualFile.path
 
-        val oldSymbols = symbolsByFile[filePath] ?: emptyList()
-
-        for (symbol in oldSymbols) {
-            removeFromMap(symbolsByNamespace, symbol.shortNamespace, filePath)
-            removeFromMap(symbolsByName, symbol.name, filePath)
-        }
-
         val newSymbols = PhelProjectSymbolScanner.scanFile(psiFile)
-        symbolsByFile[filePath] = newSymbols
 
-        for (symbol in newSymbols) {
-            addToMap(symbolsByNamespace, symbol.shortNamespace, symbol)
-            addToMap(symbolsByName, symbol.name, symbol)
+        synchronized(refreshLock) {
+            val oldSymbols = symbolsByFile[filePath] ?: emptyList()
+            for (symbol in oldSymbols) {
+                removeFromMap(symbolsByNamespace, symbol.shortNamespace, filePath)
+                removeFromMap(symbolsByName, symbol.name, filePath)
+            }
+
+            symbolsByFile[filePath] = newSymbols
+            for (symbol in newSymbols) {
+                addToMap(symbolsByNamespace, symbol.shortNamespace, symbol)
+                addToMap(symbolsByName, symbol.name, symbol)
+            }
         }
     }
 

--- a/src/test/kotlin/org/phellang/integration/registry/PhelFileChangeListenerTest.kt
+++ b/src/test/kotlin/org/phellang/integration/registry/PhelFileChangeListenerTest.kt
@@ -1,0 +1,41 @@
+package org.phellang.integration.registry
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.testFramework.LightVirtualFile
+import org.phellang.integration.PhelIntegrationTestCase
+import org.phellang.language.psi.files.PhelFile
+import org.phellang.registry.indexing.PhelFileChangeListener
+
+/**
+ * VFS_CHANGES is an application-level topic, so the listener sees `.phel` events for files anywhere
+ * on disk. Only files that belong to this project's content may feed its symbol index; a `.phel`
+ * file elsewhere must not leak into completion or go-to-definition.
+ */
+class PhelFileChangeListenerTest : PhelIntegrationTestCase() {
+
+    private fun listener() = PhelFileChangeListener(project)
+
+    private fun <T> read(block: () -> T): T =
+        ApplicationManager.getApplication().runReadAction<T> { block() }
+
+    fun testInProjectPhelFileIsIndexed() {
+        val file = myFixture.addFileToProject("src/a.phel", "(ns app\\a)\n(defn foo [] 1)\n") as PhelFile
+        val vf = file.virtualFile
+
+        assertTrue(read { listener().shouldIndex(vf) })
+    }
+
+    fun testPhelFileOutsideProjectContentIsExcluded() {
+        // Not attached to any content root — stands in for a .phel file in another project or a
+        // temp/scratch directory that VFS_CHANGES still delivers.
+        val foreign = LightVirtualFile("foreign.phel", "(ns other)\n(defn bar [] 1)\n")
+
+        assertFalse(read { listener().shouldIndex(foreign) })
+    }
+
+    fun testNonPhelFileInProjectIsExcluded() {
+        val vf = myFixture.addFileToProject("src/notes.txt", "not phel").virtualFile
+
+        assertFalse(read { listener().shouldIndex(vf) })
+    }
+}


### PR DESCRIPTION
`PhelFileChangeListener.after()` runs inside the VFS write action on the EDT, and it called `index.refreshFile(file)` inline — which resolves PSI and runs `PhelProjectSymbolScanner.scanFile`, forcing a **full parse**. Both problems the issue names are real (verified against the code):

1. **Parse on the EDT inside the write action.** A `git checkout` touching many `.phel` files parsed all of them synchronously on the EDT, freezing the UI for the whole changeset.
2. **No project-scope filter.** `isPhelFile` checked only `file.extension == "phel"`. `VFS_CHANGES` is an application-level topic, so a `.phel` file *anywhere* on disk (another open project, a temp/scratch dir) was scanned into this project's index and leaked into completion and go-to-definition.

## Fix

- **Offload the parse.** `after()` now collects the affected files, then refreshes them on a **pooled thread under a read action** — off the write action. Deletes stay inline, since `removeFile` is a cheap, parse-free map operation.
- **Scope to the project.** `ProjectFileIndex.isInContent(file)` gates refreshes, so only files in this project's content feed its index.
- **File-type association, not a string.** Matching uses `FileTypeRegistry.isFileOfType(file, PhelFileType.INSTANCE)`, honoring custom mappings, per the issue.

## A concurrency hardening the offload required

Moving the listener's refresh to a background thread means `refreshFileFromPsi` can now run concurrently with the PSI-edit listener and the lazy build — all under shared read access. Its remove-then-add was **not atomic**: two threads refreshing the same file could both read the same old set and both append, duplicating every symbol. I serialized the entry-swap under a dedicated lock (the scan stays outside it, since it only reads PSI).

This is deadlock-safe and doesn't reintroduce the shape #205 removed: the lock is only ever taken by a thread that already holds read access, and is never held while waiting for a platform lock. `removeFile` needs no lock — it runs only inside the VFS write action, mutually exclusive with any read-action refresh.

## Testing

New `PhelFileChangeListenerTest` pins the correctness fix (problem 2) on the deterministic core — the `shouldIndex` filter:

- an in-project `.phel` file **is** indexed;
- a `.phel` file outside project content (a `LightVirtualFile`, standing in for another project / temp dir) **is excluded** — this is the leak the issue reports;
- a non-`.phel` file in the project is excluded (file-type check).

The EDT-offload itself (problem 1) is verified by construction and review: the parse now runs on a pooled thread, so the write action returns immediately. I did not add a timing-based "does not block the EDT" test — asserting EDT-blocking deterministically isn't feasible in the light fixture, and an async-refresh assertion would be the flaky kind #209 targets. The idempotency/no-duplication guarantee that the concurrent refresh relies on is covered by `PhelProjectSymbolIndexBuildTest` (from #205) and the new filter tests.

- `./gradlew build` green (including `ArchitectureBoundaryTest` — `registry` importing `language.infrastructure.PhelFileType` stays within the allowed `language` dependency).
- `./gradlew test` — 1164 green on a clean run (1161 + 3 new).

The refactor pass folded in two hardening tweaks already reflected above: de-duplicating the per-batch refresh set, and the atomic entry-swap.

Closes #206
