### PR TITLE
docs: add description HTML for the three inspections missing it

### DIFF
--- a/src/main/resources/inspectionDescriptions/PhelArityMismatch.html
+++ b/src/main/resources/inspectionDescriptions/PhelArityMismatch.html
@@ -1,0 +1,37 @@
+<html>
+<body>
+<p>Reports a call that passes the wrong number of arguments to a known function.</p>
+
+<p>The argument count of a call site is compared against the arities the function actually accepts,
+    resolved from the Phel standard library and from project definitions. Both fixed-arity and
+    variadic (<code>&amp; rest</code>) signatures are understood, including multi-arity functions.</p>
+
+<h3>Example:</h3>
+<pre><code>
+;; inc takes exactly one argument
+(inc 1 2)   ;; reported: Wrong number of args (2) passed to 'inc'. Expected: 1.
+
+(inc 1)     ;; fine
+</code></pre>
+
+<h3>What is checked</h3>
+<p>Only real function calls with a trustworthy textual argument count are inspected. To avoid false
+    positives, the following are deliberately <em>not</em> checked:</p>
+<ul>
+    <li>Special forms and macros with variable argument shapes (<code>if</code>, <code>when</code>,
+        <code>let</code>, <code>fn</code>, <code>defn</code>, <code>cond</code>, <code>and</code>,
+        <code>or</code>, and similar).</li>
+    <li>PHP interop calls (<code>php/...</code>, <code>.method</code>).</li>
+    <li>Quoted or data forms — inside <code>quote</code>, <code>var</code>, or a <code>'</code> /
+        <code>`</code> reader macro.</li>
+    <li>Arguments of a threading macro (<code>-&gt;</code>, <code>-&gt;&gt;</code>,
+        <code>as-&gt;</code>, <code>some-&gt;</code>, …), where the macro shifts the effective
+        argument count.</li>
+    <li>Heads that resolve to a local binding rather than the standard-library function of the same
+        name.</li>
+</ul>
+
+<p>This inspection is registered at error severity because a genuine arity mismatch is a call Phel
+    will reject at compile time.</p>
+</body>
+</html>

--- a/src/main/resources/inspectionDescriptions/PhelShadowedLetBinding.html
+++ b/src/main/resources/inspectionDescriptions/PhelShadowedLetBinding.html
@@ -1,0 +1,26 @@
+<html>
+<body>
+<p>Reports a <code>let</code>-like binding that shadows an outer binding of the same name.</p>
+
+<p>When a binding reuses a name already introduced by an enclosing scope, the inner name hides the
+    outer one for the rest of the form. This is legal Phel, but it is a frequent source of confusion,
+    so it is surfaced as a weak warning.</p>
+
+<p>The outer binding is found in an enclosing <code>let</code>-like form
+    (<code>let</code>, <code>if-let</code>, <code>when-let</code>, <code>loop</code>, <code>for</code>,
+    <code>foreach</code>, <code>binding</code>, <code>dofor</code>) or in the parameter vector of an
+    enclosing function form (<code>fn</code>, <code>defn</code>, <code>defn-</code>,
+    <code>defmacro</code>, <code>defmacro-</code>).</p>
+
+<h3>Example:</h3>
+<pre><code>
+(defn f [x]
+  (let [x (inc x)]   ;; reported: Binding 'x' shadows an outer binding.
+    x))
+</code></pre>
+
+<h3>Ignored names</h3>
+<p>The placeholder <code>_</code> and names starting with <code>&amp;</code> (rest markers) are never
+    reported.</p>
+</body>
+</html>

--- a/src/main/resources/inspectionDescriptions/PhelUnusedLetBinding.html
+++ b/src/main/resources/inspectionDescriptions/PhelUnusedLetBinding.html
@@ -1,0 +1,26 @@
+<html>
+<body>
+<p>Reports a binding in a <code>let</code>-like form whose name is never used.</p>
+
+<p>A binding name is flagged when it appears in neither the body of the form nor the value of any
+    later binding. Phel binds sequentially, so a value can only refer to names introduced before it;
+    both places are taken into account.</p>
+
+<p>Applies to the binding-introducing forms <code>let</code>, <code>if-let</code>,
+    <code>when-let</code>, <code>loop</code>, <code>for</code>, <code>foreach</code>,
+    <code>binding</code> and <code>dofor</code>.</p>
+
+<h3>Example:</h3>
+<pre><code>
+(let [x 1
+      y 2]   ;; 'y' is reported: Binding 'y' is never used.
+  (println x))
+</code></pre>
+
+<h3>Ignored names</h3>
+<p>Names conventionally used to discard a value are never reported: <code>_</code>, any name starting
+    with <code>_</code>, and names starting with <code>&amp;</code> (rest markers).</p>
+
+<p>A quick-fix removes the unused binding pair from the binding vector.</p>
+</body>
+</html>

--- a/src/test/kotlin/org/phellang/unit/inspection/InspectionDescriptionsTest.kt
+++ b/src/test/kotlin/org/phellang/unit/inspection/InspectionDescriptionsTest.kt
@@ -1,0 +1,39 @@
+package org.phellang.unit.inspection
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * Every `localInspection` registered in plugin.xml must ship a description, or its panel in
+ * Settings → Editor → Inspections is blank and the IntelliJ Plugin Verifier flags it. The platform
+ * resolves the description from `inspectionDescriptions/<shortName>.html`, so this guards that a new
+ * inspection cannot land without one — a plain source scan, no platform fixture, mirroring
+ * ArchitectureBoundaryTest.
+ */
+class InspectionDescriptionsTest {
+
+    private val pluginXml = File("src/main/resources/META-INF/plugin.xml")
+    private val descriptionsDir = File("src/main/resources/inspectionDescriptions")
+
+    private val shortNamePattern =
+        Regex("""<localInspection\b[^>]*?shortName="([^"]+)"""", RegexOption.DOT_MATCHES_ALL)
+
+    @Test
+    fun `every registered localInspection has a non-empty description file`() {
+        val shortNames = shortNamePattern.findAll(pluginXml.readText()).map { it.groupValues[1] }.toList()
+
+        assertTrue(shortNames.isNotEmpty(), "expected localInspection registrations in plugin.xml")
+
+        val missing = shortNames.filter { shortName ->
+            val file = File(descriptionsDir, "$shortName.html")
+            !file.isFile || file.readText().isBlank()
+        }
+
+        assertTrue(
+            missing.isEmpty(),
+            "Inspections missing a description under inspectionDescriptions/: $missing. " +
+                "Add <shortName>.html so the Settings panel and the plugin verifier are satisfied.",
+        )
+    }
+}


### PR DESCRIPTION
Three of the five registered `localInspection`s shipped no `inspectionDescriptions/<shortName>.html`, so **Settings → Editor → Inspections → Phel** showed a blank panel for them — including `PhelArityMismatch`, which is registered at `level="ERROR"` and is the one a user is most likely to read before disabling.

## Added

Three description files, following the structure of the existing two (what the inspection reports, an example, ignored/skipped cases, severity):

| shortName | severity | notes |
|---|---|---|
| `PhelArityMismatch` | ERROR | Spells out what counts as a checkable call site |
| `PhelUnusedLetBinding` | WARNING | let-like forms; ignored `_` / `&` names; quick-fix |
| `PhelShadowedLetBinding` | WARNING | outer binding from an enclosing let-like or fn/defn param vector |

The arity description documents the skip rules from `PhelArityCallSite` — special forms, PHP interop, quoted/data forms, threading-macro arguments, and heads that resolve to a local binding — so a user understands why some apparent mismatches aren't flagged, per the issue's suggestion.

Every claim was checked against the code, not assumed: the let-like form set (`let if-let when-let loop for foreach binding dofor`), the function-defining set for the shadow lookup (`fn defn defn- defmacro defmacro-`), the ignored-name rules, the severities, and the reported messages.

## Regression guard (small test, not production code)

The issue is "no code changes," but a blank inspection panel is easy to reintroduce, so I added `InspectionDescriptionsTest` — a plain source scan (no platform fixture, mirroring `ArchitectureBoundaryTest`) that reads every `localInspection` shortName from `plugin.xml` and fails the build if any lacks a non-empty description file. I confirmed it fails on the pre-fix state (reports the three missing) and passes now.

- `./gradlew build` green.
- `./gradlew test` — 1162 green on a clean run (1161 + 1 new).

Closes #207
