### PR TITLE
ci: generate real Kover coverage for the Codecov upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,9 +113,11 @@ jobs:
         with:
           cache-read-only: true
 
-      # Run tests
+      # Run tests and generate the Kover coverage report. Both depend on `test`, so it runs once
+      # under Kover instrumentation and koverXmlReport writes build/reports/kover/report.xml for the
+      # upload step below.
       - name: Run Tests
-        run: .github/scripts/gradle-retry.sh check
+        run: .github/scripts/gradle-retry.sh check koverXmlReport
 
       # Collect Tests Result of failed tests
       - name: Collect Tests Result

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
     id("org.jetbrains.kotlin.jvm") version "2.4.10"
     id("org.jetbrains.intellij.platform") version "2.18.1"
     id("org.jetbrains.grammarkit") version "2023.3.0.3"
+    id("org.jetbrains.kotlinx.kover") version "0.9.8"
 }
 
 tasks.withType<Wrapper> {
@@ -110,6 +111,32 @@ java {
 
 kotlin {
     jvmToolchain(21)
+}
+
+kover {
+    currentProject {
+        // The isolated build-time generator source set is not shipped code (its output is kept out
+        // of the distribution) and its plain-JVM Kotlin compilation trips Kover's instrumentation.
+        // Leave it out of coverage entirely.
+        sources {
+            excludedSourceSets.add("generator")
+        }
+    }
+    reports {
+        filters {
+            excludes {
+                // Grammar-Kit / JFlex output under src/main/gen: never hand-written and not
+                // unit-tested directly, so counting it would only dilute the coverage signal. The
+                // generated PSI interfaces in language.psi are left in (they share the package with
+                // hand-written code and carry almost no executable lines).
+                classes(
+                    "org.phellang.language.PhelLexer",
+                    "org.phellang.language.parser.*",
+                    "org.phellang.language.psi.impl.*",
+                )
+            }
+        }
+    }
 }
 
 val generatePhelLexer = tasks.register<GenerateLexerTask>("generatePhelLexer") {


### PR DESCRIPTION
The `test` job uploaded `build/reports/kover/report.xml` to Codecov, but nothing produced that file — no Kover plugin, no config. Coverage reporting was silently a no-op (and with `fail_ci_if_error` unset, never failed either).

Per the decision on the issue, this makes coverage **real** (option a).

## Changes

- **Apply `org.jetbrains.kotlinx.kover` 0.9.8** and run `koverXmlReport` in the test job. `check` and `koverXmlReport` both depend on `test`, so it runs once under instrumentation and the report is written for the existing upload step (its path is unchanged).
- **Exclude the `generator` source set** from coverage. It's the build-time registry generator — not shipped (kept out of the distribution in #203) and its plain-JVM compilation otherwise trips Kover's artifact task with *"unknown property `compileKotlinTask` for compilation 'generator'"*. This needed Kover **0.9.8** specifically: source-set exclusion only stopped depending on the excluded compilation's task in a later 0.9.x, so 0.9.1 still failed.
- **Exclude the Grammar-Kit / JFlex output** under `src/main/gen` (the lexer, `language.parser.*`, and `language.psi.impl.*`) from the report, so generated code doesn't dilute the signal. The generated PSI interfaces in `language.psi` are left in — they share the package with hand-written code and carry almost no executable lines.

## Verification

Build-config change, verified by generating the artifact locally (consistent with #203/#204 — there's no unit test for a CI wiring change):

```
$ ./gradlew koverXmlReport
$ ls build/reports/kover/report.xml      # exists, valid XML, the path the upload expects
$ grep -c 'PhelParser\|PhelLexer' report.xml   # 0 — generated parser/lexer excluded
$ ./gradlew koverLog
  application line coverage: 91.6546%
```

- `./gradlew build` green with the plugin applied.
- The Codecov upload step is unchanged; it now has a real file to upload.

I left `fail_ci_if_error` unset, as it was — a Codecov outage shouldn't fail the build. And the ~92% figure is a starting point: as the issue and #209 note, the areas with the most tests aren't the areas with the most risk, and this now makes that visible.

Closes #208
