### PR TITLE
test: add end-to-end coverage for the nine paredit actions

### DIFF
--- a/src/test/kotlin/org/phellang/integration/editor/PhelPareditActionsTest.kt
+++ b/src/test/kotlin/org/phellang/integration/editor/PhelPareditActionsTest.kt
@@ -1,0 +1,142 @@
+package org.phellang.integration.editor
+
+import org.phellang.integration.PhelIntegrationTestCase
+
+/**
+ * End-to-end coverage of the nine registered paredit actions, driven through the real action system
+ * (`performEditorAction`) so registration, the handler and the operation are all exercised. Each
+ * case pins the observed before -> after so a regression that silently rewrites the user's source
+ * fails loudly. Behaviour was captured from the shipped actions, not assumed.
+ */
+class PhelPareditActionsTest : PhelIntegrationTestCase() {
+
+    private fun run(actionId: String, before: String, after: String) {
+        myFixture.configureByText("a.phel", before)
+        myFixture.performEditorAction(actionId)
+        myFixture.checkResult(after)
+    }
+
+    /** The action finds nothing to do and leaves the source untouched. */
+    private fun noOp(actionId: String, source: String) {
+        run(actionId, source, source.replace("<caret>", ""))
+    }
+
+    // --- Slurp forward ---
+
+    fun testSlurpForwardPullsFollowingFormIntoTheOuterList() {
+        run("Phel.Paredit.SlurpForward", "(a (b<caret>)) c", "(a (b) c)")
+    }
+
+    /**
+     * KNOWN DEFECT (characterization test): slurping across mismatched delimiters moves the inner
+     * close delimiter and produces unbalanced output. Pinned so the corruption is visible and a
+     * later fix updates this deliberately. Worth its own issue.
+     */
+    fun testSlurpForwardAcrossMismatchedDelimitersIsUnbalanced() {
+        run("Phel.Paredit.SlurpForward", "(a [b<caret>]) c", "(a [b) c]")
+    }
+
+    fun testSlurpForwardIsANoOpWithoutAnEnclosingWrapper() {
+        noOp("Phel.Paredit.SlurpForward", "(a<caret>) b")
+    }
+
+    fun testSlurpForwardIsANoOpWithNothingToSlurp() {
+        noOp("Phel.Paredit.SlurpForward", "(a<caret>)")
+    }
+
+    // --- Barf forward ---
+
+    fun testBarfForwardEjectsTheLastFormToTheRight() {
+        run("Phel.Paredit.BarfForward", "(a<caret> b)", "(a) b")
+    }
+
+    fun testBarfForwardOnANestedForm() {
+        run("Phel.Paredit.BarfForward", "(a (b c<caret>))", "(a (b) c)")
+    }
+
+    fun testBarfForwardIsANoOpOnASingleElementForm() {
+        noOp("Phel.Paredit.BarfForward", "(a<caret>)")
+    }
+
+    fun testBarfForwardIsANoOpOnAnEmptyForm() {
+        noOp("Phel.Paredit.BarfForward", "(<caret>)")
+    }
+
+    // --- Slurp backward ---
+
+    fun testSlurpBackwardPullsThePrecedingFormIntoTheOuterList() {
+        run("Phel.Paredit.SlurpBackward", "a ((b<caret>))", "(a (b))")
+    }
+
+    fun testSlurpBackwardIsANoOpWithNothingBefore() {
+        noOp("Phel.Paredit.SlurpBackward", "(a (b<caret>))")
+    }
+
+    // --- Barf backward ---
+
+    fun testBarfBackwardEjectsTheFirstFormToTheLeft() {
+        run("Phel.Paredit.BarfBackward", "(a<caret> b)", "a (b)")
+    }
+
+    fun testBarfBackwardOnANestedForm() {
+        run("Phel.Paredit.BarfBackward", "(a (b<caret> c))", "(a b (c))")
+    }
+
+    // --- Splice ---
+
+    fun testSpliceRemovesTheEnclosingListDelimiters() {
+        run("Phel.Paredit.Splice", "(a (b<caret> c) d)", "(a b c d)")
+    }
+
+    fun testSpliceRemovesVectorDelimiters() {
+        run("Phel.Paredit.Splice", "(a [b<caret> c] d)", "(a b c d)")
+    }
+
+    fun testSpliceRemovesMapDelimiters() {
+        run("Phel.Paredit.Splice", "(a {b<caret> c} d)", "(a b c d)")
+    }
+
+    fun testSpliceAtTopLevel() {
+        run("Phel.Paredit.Splice", "(a<caret> b)", "a b")
+    }
+
+    fun testSpliceOnAnEmptyFormRemovesIt() {
+        run("Phel.Paredit.Splice", "(<caret>)", "")
+    }
+
+    fun testSpliceIsANoOpOutsideAnyForm() {
+        noOp("Phel.Paredit.Splice", "a<caret>")
+    }
+
+    // --- Raise ---
+
+    fun testRaiseReplacesTheContainerWithTheFormAtCaret() {
+        run("Phel.Paredit.Raise", "(a (b<caret>) c)", "(b)")
+    }
+
+    fun testRaiseFromInsideAVector() {
+        run("Phel.Paredit.Raise", "[a (b<caret>) c]", "(b)")
+    }
+
+    fun testRaiseIsANoOpOnATopLevelForm() {
+        noOp("Phel.Paredit.Raise", "(a<caret>)")
+    }
+
+    // --- Wrap ---
+
+    fun testWrapParenWrapsTheFormAtCaret() {
+        run("Phel.Paredit.WrapParen", "foo<caret>", "(foo)")
+    }
+
+    fun testWrapParenWrapsAWholeList() {
+        run("Phel.Paredit.WrapParen", "(a b<caret>)", "((a b))")
+    }
+
+    fun testWrapBracketWrapsInSquareBrackets() {
+        run("Phel.Paredit.WrapBracket", "foo<caret>", "[foo]")
+    }
+
+    fun testWrapBraceWrapsInBraces() {
+        run("Phel.Paredit.WrapBrace", "foo<caret>", "{foo}")
+    }
+}


### PR DESCRIPTION
The nine registered paredit actions had no test exercising them against real PSI — only `PhelTextEditTest` (the low-level primitive). They rewrite the user's source by moving delimiters, so a regression silently corrupts code with nothing to catch it.

## What's added

`PhelPareditActionsTest` — **25 caret-fixture cases** driven through the **real action system** (`performEditorAction("Phel.Paredit.…")`), so registration, the handler, and each operation are all exercised end to end. Every case pins the observed `before → after`.

| Action | Coverage |
|---|---|
| SlurpForward | happy, cross-bracket (see below), 2 no-ops |
| BarfForward | happy, nested, single-element no-op, empty-form no-op |
| SlurpBackward | happy, no-op |
| BarfBackward | happy, nested |
| Splice | list, vector, map, top-level, empty-form, outside-form no-op |
| Raise | list, from a vector, top-level no-op |
| WrapParen / WrapBracket / WrapBrace | happy + whole-list |

Happy / edge (nesting across `()`, `[]`, `{}`; empty forms; top-level forms) / sad (nothing to slurp/barf, caret outside any form) per action, as `git-workflow.md` asks.

**Behaviour was captured, not assumed.** I ran a throwaway probe through the real actions to record the actual `before → after` for every case, then pinned those. This mattered — the slurp/barf semantics operate on the caret form's *parent*, which isn't obvious from the code.

## A bug this surfaced (flagged, not fixed)

Slurp-forward across **mismatched delimiters** corrupts the source:

```
(a [b|]) c   ->   (a [b) c]      # unbalanced
```

The same-delimiter case is fine (`(a (b|)) c → (a (b) c)`), but crossing `(` and `[` moves the inner close delimiter and produces unbalanced output. `#211` is test-only, so I did **not** fix it — instead I pinned it as a clearly-labelled **characterization test** (`testSlurpForwardAcrossMismatchedDelimitersIsUnbalanced`) so the corruption is visible in the suite and a later fix updates the expectation deliberately. **Worth its own issue** — happy to file one if you'd like.

## Testing

- `./gradlew build` green.
- `./gradlew test` — 1156 green (base + 25 new); the whole suite is stable now that #209 removed the flaky timing tests.

Closes #211
