### PR TITLE
fix: read active forms in the scanner and let inspections so #_ doesn't shift positions

### DIFF
--- a/src/main/kotlin/org/phellang/inspection/PhelShadowedLetBindingInspection.kt
+++ b/src/main/kotlin/org/phellang/inspection/PhelShadowedLetBindingInspection.kt
@@ -17,14 +17,16 @@ class PhelShadowedLetBindingInspection : LocalInspectionTool() {
     override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
         return object : PhelVisitor() {
             override fun visitList(o: PhelList) {
-                val forms = o.forms
+                // activeForms, not forms: a `#_`-discarded form must not shift the head/binding-vec
+                // reads or the name/value pairing in the binding vector.
+                val forms = PhelPsiUtils.activeForms(o)
                 if (forms.size < 2) return
                 val head = PhelPsiUtils.asSymbol(forms[0]) ?: return
                 val headText = head.text ?: return
                 if (headText !in BINDING_INTRO_FORMS) return
 
                 val bindingVec = forms[1] as? PhelVec ?: return
-                val bindings = bindingVec.forms
+                val bindings = PhelPsiUtils.activeForms(bindingVec)
 
                 var i = 0
                 while (i < bindings.size) {
@@ -52,7 +54,7 @@ class PhelShadowedLetBindingInspection : LocalInspectionTool() {
         var current: PsiElement? = innerForm.parent
         while (current != null) {
             if (current is PhelList) {
-                val parentForms = current.forms
+                val parentForms = PhelPsiUtils.activeForms(current)
                 val head = PhelPsiUtils.asSymbol(parentForms.firstOrNull())
                 val headText = head?.text
                 if (headText != null) {
@@ -71,7 +73,7 @@ class PhelShadowedLetBindingInspection : LocalInspectionTool() {
 
     private fun findInBindingVec(forms: List<PhelForm>, name: String): PsiElement? {
         val vec = forms.getOrNull(1) as? PhelVec ?: return null
-        val bindings = vec.forms
+        val bindings = PhelPsiUtils.activeForms(vec)
         var i = 0
         while (i < bindings.size) {
             val s = PhelPsiUtils.asSymbol(bindings[i])
@@ -87,7 +89,7 @@ class PhelShadowedLetBindingInspection : LocalInspectionTool() {
         // (defn name "doc" [params] ...) — scan first vec.
         for (form in forms.drop(1)) {
             if (form is PhelVec) {
-                for (p in form.forms) {
+                for (p in PhelPsiUtils.activeForms(form)) {
                     val text = PhelPsiUtils.asSymbol(p)?.text
                     if (text == name) return p
                 }

--- a/src/main/kotlin/org/phellang/inspection/PhelUnusedLetBindingInspection.kt
+++ b/src/main/kotlin/org/phellang/inspection/PhelUnusedLetBindingInspection.kt
@@ -14,13 +14,15 @@ class PhelUnusedLetBindingInspection : LocalInspectionTool() {
     override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
         return object : PhelVisitor() {
             override fun visitList(o: PhelList) {
-                val forms = o.forms
+                // activeForms, not forms: a `#_`-discarded form must not shift the head/binding-vec
+                // reads or the name/value pairing in the binding vector.
+                val forms = PhelPsiUtils.activeForms(o)
                 if (forms.size < 2) return
                 val head = PhelPsiUtils.asSymbol(forms[0]) ?: return
                 if (head.text !in LET_LIKE_FORMS) return
 
                 val bindingVec = forms[1] as? PhelVec ?: return
-                val bindings = bindingVec.forms
+                val bindings = PhelPsiUtils.activeForms(bindingVec)
 
                 val body = forms.drop(2)
                 if (body.isEmpty()) return

--- a/src/main/kotlin/org/phellang/registry/indexing/PhelProjectSymbolScanner.kt
+++ b/src/main/kotlin/org/phellang/registry/indexing/PhelProjectSymbolScanner.kt
@@ -47,7 +47,9 @@ object PhelProjectSymbolScanner {
         shortNamespace: String,
         virtualFile: com.intellij.openapi.vfs.VirtualFile
     ): PhelProjectSymbol? {
-        val forms = list.forms
+        // activeForms, not list.forms: a `#_`-discarded form must not shift the positional reads
+        // below. `(defn #_old new [x] …)` has to index `new`, not `old`.
+        val forms = PhelPsiUtils.activeForms(list)
         if (forms.size < 2) return null
 
         val keywordSymbol = PhelPsiUtils.asSymbol(forms[0])
@@ -128,7 +130,7 @@ object PhelProjectSymbolScanner {
 
     /** The form bound to [key] in [map], or null when the key is absent. */
     private fun mapValueFor(map: PhelMap, key: String): PhelForm? {
-        val children = map.forms
+        val children = PhelPsiUtils.activeForms(map)
         for (i in 0 until children.size - 1) {
             val child = children[i]
             if (child is PhelKeyword && child.text == key) return children[i + 1]
@@ -179,7 +181,7 @@ object PhelProjectSymbolScanner {
 
             // Multi-arity: each arity is a list whose first form is a vector.
             if (form is PhelList) {
-                val paramVec = form.forms.firstOrNull() as? PhelVec ?: continue
+                val paramVec = PhelPsiUtils.activeForms(form).firstOrNull() as? PhelVec ?: continue
                 val params = extractParameterNames(paramVec)
                 val sig = if (params.isEmpty()) "($name)" else "($name ${params.joinToString(" ")})"
                 signatures.add(sig)
@@ -199,7 +201,7 @@ object PhelProjectSymbolScanner {
 
     private fun extractParameterNames(paramVec: PhelVec): List<String> {
         val params = mutableListOf<String>()
-        for (form in paramVec.forms) {
+        for (form in PhelPsiUtils.activeForms(paramVec)) {
             val text = form.text
             if (!text.isNullOrBlank()) params.add(text)
         }

--- a/src/test/kotlin/org/phellang/integration/inspection/PhelShadowedLetBindingInspectionIntegrationTest.kt
+++ b/src/test/kotlin/org/phellang/integration/inspection/PhelShadowedLetBindingInspectionIntegrationTest.kt
@@ -30,6 +30,18 @@ class PhelShadowedLetBindingInspectionIntegrationTest : PhelIntegrationTestCase(
         assertTrue("distinct names should not be flagged: $warnings", warnings.isEmpty())
     }
 
+    /** A `#_` before the real binding must not shift the pairing that finds the shadow. */
+    fun testDiscardInBindingVectorStillDetectsShadow() {
+        val warnings = inspect("(ns app\\m)\n(defn f []\n  (let [x 1]\n    (let [#_gap x 2]\n      x)))\n")
+        assertEquals(listOf("Binding 'x' shadows an outer binding."), warnings)
+    }
+
+    /** The outer scope is still recognized as a binding form when a `#_` precedes its vector. */
+    fun testDiscardBeforeOuterBindingVectorStillShadows() {
+        val warnings = inspect("(ns app\\m)\n(defn f []\n  (let #_junk [x 1]\n    (let [x 2]\n      x)))\n")
+        assertEquals(listOf("Binding 'x' shadows an outer binding."), warnings)
+    }
+
     private fun inspect(text: String): List<String> {
         val file = myFixture.configureByText("a.phel", text) as PhelFile
         val holder = ProblemsHolder(InspectionManager.getInstance(project), file, true)

--- a/src/test/kotlin/org/phellang/integration/inspection/PhelUnusedLetBindingInspectionIntegrationTest.kt
+++ b/src/test/kotlin/org/phellang/integration/inspection/PhelUnusedLetBindingInspectionIntegrationTest.kt
@@ -35,6 +35,19 @@ class PhelUnusedLetBindingInspectionIntegrationTest : PhelIntegrationTestCase() 
         assertTrue("intentionally-unused _-prefixed binding should be ignored: $warnings", warnings.isEmpty())
     }
 
+    /** A `#_` before the binding vector must not hide the let form from the inspection. */
+    fun testDiscardBeforeBindingVectorStillInspects() {
+        val warnings = inspect("(ns app\\m)\n(defn f []\n  (let #_junk [unused 1]\n    42))\n")
+        assertEquals(listOf("Binding 'unused' is never used."), warnings)
+    }
+
+    /** A `#_`-discarded binding must not shift the name/value pairing in the binding vector. */
+    fun testDiscardInsideBindingVectorKeepsPairingAligned() {
+        // Active bindings are `[used 1]`: `used` is the name, `1` the value, and it is used.
+        val warnings = inspect("(ns app\\m)\n(defn f []\n  (let [#_gap used 1]\n    (println used)))\n")
+        assertTrue("pairing must stay aligned past the discard: $warnings", warnings.isEmpty())
+    }
+
     /** Runs the inspection's visitor over every element and returns the reported messages. */
     private fun inspect(text: String): List<String> {
         val file = myFixture.configureByText("a.phel", text) as PhelFile

--- a/src/test/kotlin/org/phellang/integration/registry/PhelProjectSymbolScannerFormCommentTest.kt
+++ b/src/test/kotlin/org/phellang/integration/registry/PhelProjectSymbolScannerFormCommentTest.kt
@@ -1,0 +1,52 @@
+package org.phellang.integration.registry
+
+import org.phellang.integration.PhelIntegrationTestCase
+import org.phellang.language.psi.files.PhelFile
+import org.phellang.registry.indexing.PhelProjectSymbolScanner
+
+/**
+ * The scanner must read a definition's forms with `#_`-discarded forms stripped. Reading the raw
+ * list shifts every positional slot, so a discarded form before the name indexes the wrong symbol
+ * and misreads the signature — a silent wrong answer.
+ */
+class PhelProjectSymbolScannerFormCommentTest : PhelIntegrationTestCase() {
+
+    private fun scan(def: String): List<PhelProjectSymbolLite> {
+        val file = myFixture.configureByText("a.phel", "(ns my\\app)\n$def") as PhelFile
+        return PhelProjectSymbolScanner.scanFile(file).map { PhelProjectSymbolLite(it.name, it.signature) }
+    }
+
+    private data class PhelProjectSymbolLite(val name: String, val signature: String)
+
+    fun testDiscardedFormBeforeNameIndexesTheRealName() {
+        val symbols = scan("(defn #_old-name new-name [x] x)")
+
+        assertEquals(listOf("new-name"), symbols.map { it.name })
+    }
+
+    fun testStackedDiscardsBeforeNameAreSkipped() {
+        val symbols = scan("(defn #_#_a b real [x] x)")
+
+        assertEquals(listOf("real"), symbols.map { it.name })
+    }
+
+    fun testSignatureReadsCorrectSlotsPastADiscard() {
+        val symbols = scan("(defn #_junk foo [a b] \"doc\" body)")
+
+        assertEquals("foo", symbols.single().name)
+        assertEquals("(foo a b)", symbols.single().signature)
+    }
+
+    fun testDiscardedParameterIsNotCountedInTheSignature() {
+        val symbols = scan("(defn f [a #_b c] body)")
+
+        assertEquals("(f a c)", symbols.single().signature)
+    }
+
+    fun testPlainDefinitionIsUnaffected() {
+        val symbols = scan("(defn plain [x] x)")
+
+        assertEquals("plain", symbols.single().name)
+        assertEquals("(plain x)", symbols.single().signature)
+    }
+}


### PR DESCRIPTION
`PhelProjectSymbolScanner.extractDefinition` read the definition with `list.forms`, which includes `#_`-discarded forms. `PhelPsiUtils.activeForms` exists precisely to strip them — and the scanner is exactly the caller its doc warns about:

```phel
(defn #_old-name new-name [x] …)
```

was indexed under `old-name`, so `new-name` got no completion, go-to-definition or arity checking (and a nonexistent symbol appeared in its place), while every downstream slot — signature, docstring, parameters — read one position off.

## Scanner (the fix)

Switched all four positional `.forms` reads in the scanner to `activeForms`:

- the definition's forms (`extractDefinition`) — the main one;
- the metadata-map key/value pairs (`mapValueFor`);
- the multi-arity clause head (`extractMultiAritySignatures`);
- the parameter vector (`extractParameterNames`).

## The two let inspections (the issue's note)

The issue flagged `PhelUnusedLetBindingInspection` and `PhelShadowedLetBindingInspection` as "worth confirming." They have the **same** bug — both read `o.forms` and `bindingVec.forms` (and the shadowed one its outer-scope lookups) positionally, so a `#_` either hides the binding vector entirely or misaligns the name/value pairing. Since it's the identical one-line pattern and the issue points right at them, I fixed those too rather than leave the codebase half-corrected. Each change is behaviour-preserving without a `#_`, so the existing inspection tests stay green.

## Testing

Per the issue's test plan, plus coverage for the inspection fixes:

- **`PhelProjectSymbolScannerFormCommentTest`** — `(defn #_old new …)` indexes `new`; `(defn #_#_a b real …)` indexes `real`; the signature reads the right slots past a discard; a discarded parameter isn't counted; a plain definition is unaffected.
- **Unused-let** — a `#_` before the binding vector still inspects; a `#_` inside it keeps the name/value pairing aligned.
- **Shadowed-let** — a `#_` inside the inner binding vector, and before the outer one, still detects the shadow.

I confirmed the scanner tests **fail on the pre-fix code** (`old-name` instead of `new-name`, `junk` instead of `foo`) and pass after — genuine regression guards, not tautologies.

- `./gradlew build` green (incl. `ArchitectureBoundaryTest`).
- `./gradlew test` — 1164 green; all pre-existing scanner and inspection tests stay green.

Closes #212
