### PR TITLE
feat: generate Marketplace change-notes from a CHANGELOG, and fix multi-arity doc rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,270 @@
+# Changelog
+
+All notable changes to the Phel IntelliJ plugin are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Entries are reconstructed from the git history. Each release notes the bundled Phel API registry version where it was
+refreshed, since completion, hover and arity checking are all driven by it.
+
+## [Unreleased]
+
+### Added
+
+- `trace` namespace support; registry refreshed to **Phel 0.49.0**.
+
+### Fixed
+
+- Multi-arity standard-library signatures now render one arity per line in the documentation popup, matching the
+  project-symbol popup (#231).
+- `#_` form comments are resolved over the PSI instead of a text regex, so discarded forms no longer shift argument
+  positions.
+- Project symbol index build is now cancellable and deadlock-safe, and VFS-triggered parsing is moved off the EDT and
+  scoped to the project.
+- Private definitions are detected from metadata rather than body text.
+
+### Changed
+
+- The build keeps the Kotlin stdlib, gson and the registry generator out of the distribution jar.
+- CI enforces the plugin project-configuration check and uploads real Kover coverage to Codecov.
+
+## [0.5.3] - 2026-07-16
+
+- Registry refreshed to **Phel 0.48.0**.
+- Broad internal cleanup: stronger types, broken import cycles, consolidated PSI-walking logic.
+
+## [0.5.2] - 2026-07-15
+
+### Fixed
+
+- Local completions are no longer dropped in large files.
+- Explicit completion invocation respects the namespace prefix.
+
+### Changed
+
+- Large architectural refactor: every module now exposes its entry point at its root; oversized classes (
+  `PhelReference`, `PhelSymbolAnalyzer`, the PHP reflection layer, ns-clause analysis) were split into focused
+  collaborators, enforced by a new module-boundary architecture test.
+
+## [0.5.1] - 2026-06-25
+
+### Added
+
+- Lexer support for namespaced tagged literals.
+- Registry refreshed.
+
+## [0.5.0] - 2026-06-13
+
+### Performance
+
+- Wide performance pass across highlighting and analysis: per-file caching of the `(ns …)`declaration, `(:require …)`/
+  `(:use …)` clauses, alias maps, referred symbols, used classes and local function names; map-based token
+  classification; lazy API-doc rendering; and fast paths that skip anon-function and form-comment work when the file
+  contains no `#(` or `#_`.
+
+### Fixed
+
+- Eliminated arity-mismatch false positives for variadic, multi-arity and short-function calls.
+- Arity mismatch, inlay parameter hints and let-binding inspections now fire for `PhelAccess`-wrapped heads; `when-let`
+  bindings resolve in reference resolution.
+- Symbol-index map updates are now atomic.
+- Registry refreshed to **Phel 0.42.0**.
+
+## [0.4.5] - 2026-06-05
+
+- Go-to-definition from `(:use …)` PHP classes.
+
+## [0.4.4] - 2026-06-05
+
+### Added
+
+- Navigate from `load` / `require` forms to their target files.
+
+### Fixed
+
+- PHP interop operators `php/^`, `php/~`, `php/@` are lexed as single symbols.
+- Cleared the deprecated- and experimental-API Marketplace warnings.
+
+## [0.4.3] - 2026-05-25
+
+### Added
+
+- Recognise PHP interop shorthands and resolve classes brought in via `(:use …)`.
+
+### Fixed
+
+- Function parameters are no longer mis-marked as functions when they share a name with a Phel standard-library
+  function.
+
+## [0.4.2] - 2026-05-21
+
+### Added
+
+- Rename refactoring.
+- Inlay parameter hints.
+- Arity-mismatch and unused/shadowed let-binding inspections.
+
+### Fixed
+
+- Resolved `:refer` import warnings.
+
+## [0.4.1] - 2026-05-20
+
+- Updated for Phel 0.35.0–0.39.0, plus platform and dependency updates.
+
+## [0.4.0] - 2026-05-11
+
+### Added
+
+- Recognise multi-arity `defn`/`fn` parameter vectors.
+- Surface the `defn` docstring on hover instead of only the category label; resolve hover docs for symbols imported via
+  `:refer`.
+- Paredit structural-editing actions.
+- Structure view for top-level Phel forms.
+- Reformat Code integration with `./bin/phel fmt`.
+- Registry updated to **Phel 0.36.0**.
+
+## [0.3.6] - 2026-04-21
+
+- Syntax and registry updated to **Phel 0.34.1**.
+
+## [0.3.5] - 2026-04-18
+
+- Syntax support updated for Phel 0.3.3; added `CONTRIBUTING.md` and `RELEASE.md`.
+
+## [0.3.4] - 2026-04-13
+
+- Syntax support updated for Phel 0.3.2.
+
+## [0.3.3] - 2026-04-13
+
+- Registry refreshed.
+
+## [0.3.2] - 2026-04-08
+
+### Added
+
+- Suggest `require`, `require-file`, `use` and `refer` inside the `ns` form (#84).
+- Registry updated to **Phel 0.31.0**.
+
+## [0.3.0] - 2026-02-01
+
+### Added
+
+- Symbol completion, namespace validation and Go to Definition.
+- Automatic namespace import when a function belongs to another namespace.
+- Documentation on hover for aliased and `:refer`-imported functions.
+- Visual deprecation warning on deprecated functions.
+- Completion results sorted by priority.
+
+### Fixed
+
+- Grey out unused namespaces; correct the color for `:refer` keys.
+
+## [0.2.4] - 2026-01-25
+
+### Added
+
+- `updatePhelRegistry` command to regenerate the function registry from the official Phel API.
+
+## [0.2.3] - 2025-12-12
+
+### Fixed
+
+- Slash-symbol handling, including `::` for `php/::`.
+
+### Changed
+
+- Renamed the `DataFunction` model to `PhelFunction`.
+
+## [0.2.2] - 2025-12-09
+
+- Reformatted the documentation popup.
+
+## [0.2.1] - 2025-12-08
+
+- Compatibility with IntelliJ 2025.3.
+
+## [0.2.0] - 2025-11-15
+
+### Added
+
+- Documentation module: quick-documentation popups for standard-library functions.
+
+### Fixed
+
+- Parenthesis-position and short-set `#{}` highlighting.
+
+## [0.1.10] - 2025-11-04
+
+### Added
+
+- GitHub Actions CI (build, test and plugin-verification jobs) and a "Build Distribution" run configuration.
+
+### Fixed
+
+- Invalid-namespace handling.
+
+### Changed
+
+- Large internal modularization of the editor, language and syntax packages; renamed the file type to "Phel File".
+
+## [0.1.9] - 2025-09-27
+
+- Show completion suggestions only where they make sense; refactored the actions module.
+
+## [0.1.8] - 2025-09-24
+
+### Added
+
+- "Phel File" entry in the New-file context menu.
+
+### Fixed
+
+- Stop rendering raw HTML in completion suggestions.
+
+## [0.1.6] - 2025-09-21
+
+- Refined syntax colors and plugin description; silenced warning logs.
+
+## [0.1.5] - 2025-09-20
+
+### Added
+
+- Completion of user-defined function names.
+
+## [0.1.4] - 2025-09-20
+
+### Added
+
+- Code folding.
+- Multi-line comment support.
+- Richer semantic coloring, including set literals `#{}` and namespaced constructions (`QUALIFIED_SYMBOL` token).
+
+## [0.1.3] - 2025-09-14
+
+### Added
+
+- Auto-completion of the `{` character.
+
+### Changed
+
+- Migrated the plugin sources from Java to Kotlin.
+
+## [0.1.2] - 2025-09-12
+
+- Compatibility bump: build target moved from 242 to 252.
+
+## [0.1.0] - 2025-09-12
+
+The first public release. Core language support for `.phel` files:
+
+### Added
+
+- File type, JFlex lexer and Grammar-Kit parser/PSI for the Phel language.
+- Syntax highlighting.
+- Code completion, with `namespace/function` matching.
+- Reference resolution and symbol navigation.
+- `;` line comments and `#_` form-comment tokens.
+- Auto-closing brackets and a comment shortcut.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -23,13 +23,18 @@ In IntelliJ, run the **Update Registry Repository** task (or from terminal):
 
 Run the **Run Plugin** task in IntelliJ (or `./gradlew runIde`). This opens a sandboxed IDE instance with the plugin loaded. Verify everything works as expected.
 
-### 3. Bump the version
+### 3. Bump the version and update the changelog
 
-Update `version` on line 5 of `build.gradle.kts`:
+Update `version` in `build.gradle.kts`:
 
 ```kotlin
 version = "X.Y.Z"
 ```
+
+Then promote the `## [Unreleased]` entries in `CHANGELOG.md` into a new `## [X.Y.Z] - YYYY-MM-DD`
+section (or run `./gradlew patchChangelog`, which does this for you). The Marketplace "What's new"
+notes are generated from this section: `patchPluginXml` renders the entry matching `version` into
+`<change-notes>`, so releasing with an empty changelog ships empty release notes.
 
 ### 4. Update IDE compatibility (if needed)
 
@@ -66,7 +71,7 @@ Alternatively, with the `PUBLISH_TOKEN` (and `CERTIFICATE_CHAIN`, `PRIVATE_KEY`,
 ### 7. Commit and push
 
 ```bash
-git add build.gradle.kts src/main/kotlin/org/phellang/registry/data
+git add build.gradle.kts CHANGELOG.md src/main/kotlin/org/phellang/registry/data
 git commit -m "chore: bump plugin to X.Y.Z and update registry"
 git push origin main
 ```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.changelog.Changelog
 import org.jetbrains.grammarkit.tasks.GenerateLexerTask
 import org.jetbrains.grammarkit.tasks.GenerateParserTask
 import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginProjectConfigurationTask
@@ -11,6 +12,7 @@ plugins {
     id("org.jetbrains.intellij.platform") version "2.18.1"
     id("org.jetbrains.grammarkit") version "2023.3.0.3"
     id("org.jetbrains.kotlinx.kover") version "0.9.8"
+    id("org.jetbrains.changelog") version "2.5.0"
 }
 
 tasks.withType<Wrapper> {
@@ -111,6 +113,14 @@ java {
 
 kotlin {
     jvmToolchain(21)
+}
+
+// CHANGELOG.md is the single source of the Marketplace "What's new" section: patchPluginXml
+// (below) renders the entry matching the current version into <change-notes>. `groups` lists
+// the Keep a Changelog sections this project uses, so `patchChangelog` scaffolds them at release.
+changelog {
+    repositoryUrl.set("https://github.com/phel-lang/phel-intellij-plugin")
+    groups.set(listOf("Added", "Changed", "Deprecated", "Removed", "Fixed", "Security", "Performance"))
 }
 
 kover {
@@ -273,6 +283,20 @@ tasks {
         patchPluginXml {
             sinceBuild.set("243")
             untilBuild.set("262.*")
+
+            // Render the CHANGELOG entry for the current version (falling back to Unreleased when
+            // this version has no section yet) as the Marketplace <change-notes>. Lazy so the file
+            // is read at task time, not configuration time.
+            changeNotes.set(project.provider {
+                with(changelog) {
+                    renderItem(
+                        (getOrNull(project.version.toString()) ?: getUnreleased())
+                            .withHeader(false)
+                            .withEmptySections(false),
+                        Changelog.OutputType.HTML,
+                    )
+                }
+            })
         }
 
         signPlugin {

--- a/src/main/kotlin/org/phellang/registry/PhelFunction.kt
+++ b/src/main/kotlin/org/phellang/registry/PhelFunction.kt
@@ -23,7 +23,10 @@ data class DocumentationInfo(
 ) {
     fun toHtml(signature: String): String = buildString {
         append("<br />")
-        signature.takeIf(String::isNotBlank)?.let { append("<code>$it</code><br /><br />") }
+        // Multi-arity signatures are newline-separated (see KotlinCodeGenerator); render each
+        // arity on its own line, mirroring the project-symbol popup (PhelDocHtml.projectSymbol).
+        signature.takeIf(String::isNotBlank)
+            ?.let { append("<code>${it.replace("\n", "<br />")}</code><br /><br />") }
         append(summary)
         append("<br />")
 

--- a/src/test/kotlin/org/phellang/unit/registry/DocumentationInfoRenderingTest.kt
+++ b/src/test/kotlin/org/phellang/unit/registry/DocumentationInfoRenderingTest.kt
@@ -1,0 +1,51 @@
+package org.phellang.unit.registry
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.phellang.registry.CompletionInfo
+import org.phellang.registry.DocumentationInfo
+import org.phellang.registry.PhelCompletionPriority
+import org.phellang.registry.PhelFunction
+
+/**
+ * Rendering of the standard-library documentation popup ([DocumentationInfo.toHtml]).
+ *
+ * Multi-arity stdlib functions carry every arity in a single newline-separated signature
+ * string (see KotlinCodeGenerator); the popup must render each arity on its own line, the
+ * same way the project-symbol popup does (PhelDocHtml.projectSymbol).
+ */
+class DocumentationInfoRenderingTest {
+
+    private fun functionWithSignature(signature: String) = PhelFunction(
+        namespace = "trace",
+        name = "trace/trace",
+        signature = signature,
+        completion = CompletionInfo(tailText = "", priority = PhelCompletionPriority.DEBUG_FUNCTIONS),
+        documentation = DocumentationInfo(summary = "Prints value and returns it unchanged"),
+    )
+
+    @Test
+    fun `multi-arity signatures render each arity on its own line`() {
+        val html = functionWithSignature("(trace value)\n(trace tag value)").toHtmlDocumentation()
+
+        assertTrue(
+            html.contains("<code>(trace value)<br />(trace tag value)</code>"),
+            "Expected each arity on its own line, got: $html",
+        )
+        assertFalse(
+            html.contains("\n"),
+            "Rendered signature must not leak the raw newline separator, got: $html",
+        )
+    }
+
+    @Test
+    fun `single-arity signature renders unchanged`() {
+        val html = functionWithSignature("(inc x)").toHtmlDocumentation()
+
+        assertTrue(
+            html.contains("<code>(inc x)</code>"),
+            "Single-arity signature should render as-is, got: $html",
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Two related improvements to how the plugin surfaces information, plus the release-notes plumbing they feed into.

### `fix(documentation)` — multi-arity signatures in the doc popup (Closes #231)

The standard-library documentation popup rendered multi-arity signatures on a single line. Stdlib signatures store every arity newline-separated (see `KotlinCodeGenerator`), and `DocumentationInfo.toHtml` wrapped the raw string in `<code>` without converting the newlines, so HTML collapsed them to a space. The project-symbol popup (`PhelDocHtml.projectSymbol`) already did the right thing. Now the stdlib path does too — each arity renders on its own line.

Affects the 19 multi-arity stdlib functions (e.g. `trace`, `read-string`, `php/->`).

### `feat(build)` — generate Marketplace change-notes from a CHANGELOG (Closes #213)

- Adds `CHANGELOG.md` in [Keep a Changelog](https://keepachangelog.com/) format, reconstructed from the git history. Each release notes the bundled Phel registry version where it was refreshed (0.31.0 → 0.48.0, and 0.49.0 in Unreleased), which answers the "no record of when the registry was regenerated" concern in #213.
- Applies the `org.jetbrains.changelog` Gradle plugin and wires `patchPluginXml { changeNotes }` to render the entry matching the current `version` (falling back to `[Unreleased]`) as HTML. The Marketplace "What's new" section is now generated from the changelog instead of being empty.
- Documents the changelog step in `RELEASE.md`.

## Test plan

- [x] `./gradlew test --tests 'org.phellang.unit.registry.DocumentationInfoRenderingTest'` — new test covers multi-arity rendering (one arity per line, no leaked newline) and single-arity unchanged. **Green.**
- [x] `./gradlew getChangelog` — parses `CHANGELOG.md` and returns the `[0.5.3]` section, confirming the format is valid.
- [x] `./gradlew patchPluginXml` — generated `<change-notes>` contains the `[0.5.3]` entry rendered as HTML (`<ul><li>…<strong>Phel 0.48.0</strong>…</li></ul>`).
- [ ] CI (`build.yml`) runs the full build, tests and plugin verification.

## Notes

- Only `v0.1.5` is tagged in this repo, so the Keep a Changelog `compare/…` footer links were omitted; they can be added once releases are tagged.
- On the next version bump, promote `[Unreleased]` into a new `## [x.y.z]` section (or run `./gradlew patchChangelog`) so the change-notes track the new version. `RELEASE.md` documents this.
