### PR TITLE
docs: add Codecov coverage badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build](https://github.com/phel-lang/phel-intellij-plugin/actions/workflows/build.yml/badge.svg)](https://github.com/phel-lang/phel-intellij-plugin/actions/workflows/build.yml)
 [![Version](https://img.shields.io/jetbrains/plugin/v/28459.svg)](https://plugins.jetbrains.com/plugin/28459)
 [![Downloads](https://img.shields.io/jetbrains/plugin/d/28459.svg)](https://plugins.jetbrains.com/plugin/28459)
+[![Coverage](https://codecov.io/gh/phel-lang/phel-intellij-plugin/graph/badge.svg)](https://app.codecov.io/gh/phel-lang/phel-intellij-plugin)
 
 [![Plugin Icon](src/main/resources/META-INF/pluginIcon.svg)](https://plugins.jetbrains.com/plugin/28459-phel-lang)
 


### PR DESCRIPTION
## Summary

Adds a **Codecov** coverage badge to the README, next to the existing Build, Version and Downloads badges.

Coverage is already produced and uploaded by CI: `build.yml` runs `koverXmlReport` and uploads `build/reports/kover/report.xml` via `codecov/codecov-action@v7`. This just surfaces the result in the README and links to the hosted report.

```markdown
[![Coverage](https://codecov.io/gh/phel-lang/phel-intellij-plugin/graph/badge.svg)](https://app.codecov.io/gh/phel-lang/phel-intellij-plugin)
```

## Notes

- The badge shows `unknown` until Codecov has processed a report on the default branch. Once a `main` build finishes with the upload succeeding, it renders the real percentage.
- No token is needed for the badge itself (public repo); the upload continues to use the `CODECOV_TOKEN` secret.
