### PR TITLE
docs: add a Contributor Covenant code of conduct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ refreshed, since completion, hover and arity checking are all driven by it.
 ### Added
 
 - `trace` namespace support; registry refreshed to **Phel 0.49.0**.
+- `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1), linked from the README and `CONTRIBUTING.md` (#229).
 
 ### Fixed
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [phel@chemaclass.es](mailto:phel@chemaclass.es). All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,4 +96,4 @@ Please use [GitHub Issues](https://github.com/phel-lang/phel-intellij-plugin/iss
 
 ## Code of Conduct
 
-Be respectful and constructive. We follow the [Contributor Covenant](https://www.contributor-covenant.org/) code of conduct.
+Be respectful and constructive. This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md); by participating you are expected to uphold it.

--- a/README.md
+++ b/README.md
@@ -59,4 +59,5 @@ automatically during compilation.
 
 ## Contributing
 
-Issues and pull requests are welcome.
+Issues and pull requests are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md), and please follow our
+[Code of Conduct](CODE_OF_CONDUCT.md).


### PR DESCRIPTION
## Summary

Adds `CODE_OF_CONDUCT.md`, resolving #229 — the repo had `CONTRIBUTING.md` but no code of conduct, so GitHub's Community Standards checklist and repo sidebar were missing it.

- **`CODE_OF_CONDUCT.md`**: the [Contributor Covenant 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html), verbatim, with the enforcement contact set to `phel@chemaclass.es` — the vendor email already declared in `plugin.xml`.
- **`CONTRIBUTING.md`**: its existing "Code of Conduct" section now links to the local file instead of the covenant homepage.
- **`README.md`**: the Contributing section now points at `CONTRIBUTING.md` and the new Code of Conduct.
- **`CHANGELOG.md`**: entry under `[Unreleased] → Added`.

## Notes

- The covenant text was fetched from the official source and diffed against the committed file: identical except for the filled-in contact (and one redundant trailing blank line). No wording was reproduced from memory.
- **Final self-review (skill step 10): no changes needed** — a standard covenant plus three link edits, no duplication or drift, so there is no separate `ref` commit.
- Docs-only change (no Kotlin or build files), so no local `./gradlew test` run; CI runs the full pipeline below.

## Test plan

- [x] Committed CoC diffed byte-for-byte against the upstream Contributor Covenant 2.1.
- [x] Contact email matches the `plugin.xml` vendor email (`phel@chemaclass.es`).
- [ ] CI (`build.yml`) green.
- [ ] After merge: GitHub's "Community Standards" page shows Code of Conduct satisfied, and the sidebar links it.

Closes #229
