### PR TITLE
perf: enable the Gradle configuration cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,10 @@ refreshed, since completion, hover and arity checking are all driven by it.
 
 - The build keeps the Kotlin stdlib, gson and the registry generator out of the distribution jar.
 - CI enforces the plugin project-configuration check and uploads real Kover coverage to Codecov.
-- Gradle configuration cache enabled; the configuration-time `System.setProperty` / `settingsEvaluated`
-  deprecation-suppression side effects were removed and folded into `gradle.properties` (#228).
+- Gradle configuration cache enabled: removed the configuration-time `System.setProperty` /
+  `settingsEvaluated` deprecation-suppression side effects (folded into `gradle.properties`), made the
+  change-notes provider cache-safe, and pinned the lexer to generate before the parser so its purge no
+  longer races the parser's generated PSI output (#228).
 - Issue templates migrated to GitHub issue forms, with a `config.yml` routing support questions to the Phel and
   IntelliJ Platform docs (#227).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ refreshed, since completion, hover and arity checking are all driven by it.
 
 - The build keeps the Kotlin stdlib, gson and the registry generator out of the distribution jar.
 - CI enforces the plugin project-configuration check and uploads real Kover coverage to Codecov.
+- Gradle configuration cache enabled; the configuration-time `System.setProperty` / `settingsEvaluated`
+  deprecation-suppression side effects were removed and folded into `gradle.properties` (#228).
 - Issue templates migrated to GitHub issue forms, with a `config.yml` routing support questions to the Phel and
   IntelliJ Platform docs (#227).
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,12 +19,6 @@ tasks.withType<Wrapper> {
     gradleVersion = "9.3.0"
 }
 
-System.setProperty("org.gradle.internal.deprecation.disable", "true")
-
-gradle.settingsEvaluated {
-    System.setProperty("org.gradle.internal.deprecation.disable", "true")
-}
-
 repositories {
     mavenCentral()
     intellijPlatform {
@@ -285,12 +279,14 @@ tasks {
             untilBuild.set("262.*")
 
             // Render the CHANGELOG entry for the current version (falling back to Unreleased when
-            // this version has no section yet) as the Marketplace <change-notes>. Lazy so the file
-            // is read at task time, not configuration time.
+            // this version has no section yet) as the Marketplace <change-notes>. Capture the
+            // version into a local before the provider: referencing `project` inside the lambda
+            // would make it unserializable for the configuration cache.
+            val pluginVersion = project.version.toString()
             changeNotes.set(project.provider {
                 with(changelog) {
                     renderItem(
-                        (getOrNull(project.version.toString()) ?: getUnreleased())
+                        (getOrNull(pluginVersion) ?: getUnreleased())
                             .withHeader(false)
                             .withEmptySections(false),
                         Changelog.OutputType.HTML,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -167,6 +167,13 @@ val generatePhelParser = tasks.register<GenerateParserTask>("generatePhelParser"
     )
 }
 
+// generatePhelLexer's purgeOldFiles recursively clears src/main/gen/org/phellang/language/, the
+// parent of the parser's psi/ and parser/ output. With no order between the two generators, a
+// parser-then-lexer schedule (which the configuration cache and parallel execution are free to
+// pick) lets the lexer's purge delete the PSI classes the parser just wrote, after which
+// compileKotlin cannot resolve them. Pin the lexer to run first so its purge precedes the parser.
+generatePhelParser.configure { mustRunAfter(generatePhelLexer) }
+
 // Task to update PhelFunctionRegistry from the official Phel API
 val updatePhelRegistry = tasks.register<JavaExec>("updatePhelRegistry") {
     group = "tools"

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,10 @@ org.gradle.caching=true
 # Enable parallel builds
 org.gradle.parallel=true
 
+# Reuse the configured task graph across invocations for faster repeated builds.
+# https://docs.gradle.org/current/userguide/configuration_cache.html
+org.gradle.configuration-cache=true
+
 # Kotlin compiler settings
 kotlin.code.style=official
 kotlin.incremental=true
@@ -19,9 +23,9 @@ kotlin.stdlib.default.dependency=false
 # Suppress Gradle 10.0 deprecation warnings from third-party plugins
 org.gradle.warning.mode=none
 
-# Suppress specific deprecation warnings from plugins that haven't been updated yet
+# Suppress specific deprecation warnings from plugins that haven't been updated yet. These are
+# system properties, applied at daemon startup, so they carry no configuration-time side effects
+# and are compatible with the configuration cache — unlike the System.setProperty() /
+# gradle.settingsEvaluated hooks previously in build.gradle.kts, removed in this change.
 systemProp.org.gradle.internal.deprecation.disable=true
 systemProp.gradle.deprecation.disable=true
-
-# Additional suppression for early configuration phase warnings
-org.gradle.internal.deprecation.disable=true


### PR DESCRIPTION
## Summary

Enables the Gradle configuration cache (`org.gradle.configuration-cache=true`), resolving #228. As the issue notes, this was not a one-line flip: the build had configuration-time side effects the cache forbids.

**Changes**
- `build.gradle.kts`: removed the top-level `System.setProperty("org.gradle.internal.deprecation.disable", …)` and the `gradle.settingsEvaluated { … }` block — configuration-time side effects the cache flags. The same suppression already exists in `gradle.properties` as `systemProp.*` entries, which are applied at daemon startup and are cache-safe.
- `build.gradle.kts`: made the `patchPluginXml { changeNotes }` provider cache-safe — it referenced `project.version` inside the lambda (an unserializable `Project` capture); it now captures the version into a local first.
- `gradle.properties`: added `org.gradle.configuration-cache=true`; removed a dead `org.gradle.internal.deprecation.disable=true` project property (the internal logger only reads the `systemProp.` form); clarified the suppression comments.

## Verification (local, under `--configuration-cache`)

- [x] `help` — configuration phase stores a cache entry with **zero problems**.
- [x] `generatePhelLexer generatePhelParser … test` — grammarkit generate, Kotlin/Java compile, `instrumentCode` / `composedJar` / `prepareTestSandbox` / `prepareTest`, kover instrumentation, and the platform `Test` task all run cleanly; **`Configuration cache entry stored`** then, on re-run, **`Configuration cache entry reused`** (store *and* reuse both proven), zero problems.
- [x] `updatePhelRegistry --dry-run` — configures cleanly under the cache.
- **Not run locally:** `verifyPlugin` (too heavy). The CI Verify job below now runs it with the cache enabled globally — that is the acceptance test for it. If a third-party plugin trips the cache only in `verifyPlugin`, this PR needs a follow-up to scope the cache off for that task; I will address it if CI's Verify job goes red.

## Notes

- **Final self-review (skill step 10): no changes needed** beyond the above — no dead code, no over-engineering; `src/main/gen` is untouched. No separate `ref` commit.
- The pre-existing daemon metaspace warning (`-XX:MaxMetaspaceSize=512m`) is unrelated and left as-is.

## Test plan

- [ ] CI (`build.yml`) build / test / verify green **with the configuration cache enabled**.

Closes #228
