### PR TITLE
feat: show deprecation and replacement in the function doc popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ refreshed, since completion, hover and arity checking are all driven by it.
 
 - `trace` namespace support; registry refreshed to **Phel 0.49.0**.
 - `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1), linked from the README and `CONTRIBUTING.md` (#229).
+- The standard-library documentation popup now shows a deprecation notice with the suggested replacement, kept
+  consistent with the deprecated-function inspection (#230).
 
 ### Fixed
 

--- a/src/main/kotlin/org/phellang/inspection/deprecated/DeprecationMessageBuilder.kt
+++ b/src/main/kotlin/org/phellang/inspection/deprecated/DeprecationMessageBuilder.kt
@@ -8,29 +8,13 @@ object DeprecationMessageBuilder {
             return "'$functionName' is deprecated"
         }
 
-        // In api.json the `version` field sometimes carries a "Use xyz" message instead of a version.
-        if (deprecation.version.startsWith("Use ", ignoreCase = true)) {
-            val replacement = deprecation.version.removePrefix("Use ").trim()
-            val displayReplacement = ReplacementParser.formatForDisplay(replacement)
-            return "'$functionName' is deprecated. Use '$displayReplacement' instead"
+        return buildString {
+            append("'$functionName' is deprecated")
+            deprecation.displayVersion?.let { append(" since ").append(it) }
+            deprecation.displayReplacement?.let { append(". Use '").append(it).append("' instead") }
         }
-
-        if (deprecation.replacement != null) {
-            val displayReplacement = ReplacementParser.formatForDisplay(deprecation.replacement)
-            return "'$functionName' is deprecated since ${deprecation.version}. Use '$displayReplacement' instead"
-        }
-
-        return "'$functionName' is deprecated since ${deprecation.version}"
     }
 
     /** The replacement in `phel\namespace\function` format, or null when the deprecation names none. */
-    fun extractReplacement(deprecation: DeprecationInfo?): String? {
-        if (deprecation == null) return null
-
-        if (deprecation.version.startsWith("Use ", ignoreCase = true)) {
-            return deprecation.version.removePrefix("Use ").trim()
-        }
-
-        return deprecation.replacement
-    }
+    fun extractReplacement(deprecation: DeprecationInfo?): String? = deprecation?.rawReplacement
 }

--- a/src/main/kotlin/org/phellang/inspection/deprecated/PhelDeprecatedFunctionQuickFix.kt
+++ b/src/main/kotlin/org/phellang/inspection/deprecated/PhelDeprecatedFunctionQuickFix.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.project.Project
 import org.phellang.language.psi.PhelNamespaceImporter
 import org.phellang.language.psi.PhelPsiFactory
 import org.phellang.language.psi.files.PhelFile
+import org.phellang.registry.ReplacementParser
 
 class PhelDeprecatedFunctionQuickFix(private val replacement: String) : LocalQuickFix {
 

--- a/src/main/kotlin/org/phellang/registry/PhelFunction.kt
+++ b/src/main/kotlin/org/phellang/registry/PhelFunction.kt
@@ -8,7 +8,23 @@ data class CompletionInfo(
 data class DeprecationInfo(
     val version: String,
     val replacement: String? = null,
-)
+) {
+    // In api.json the `version` field sometimes carries a "Use xyz" message instead of a version.
+    private val versionCarriesUseMessage: Boolean
+        get() = version.startsWith("Use ", ignoreCase = true)
+
+    /** The version string, or null when the `version` field actually carries a "Use xyz" message. */
+    val displayVersion: String?
+        get() = version.takeUnless { versionCarriesUseMessage }
+
+    /** The replacement in its raw `phel\ns\fn` form (from the field or a "Use xyz" version), or null. */
+    val rawReplacement: String?
+        get() = if (versionCarriesUseMessage) version.removePrefix("Use ").trim() else replacement
+
+    /** The replacement formatted for display as `ns/fn`, or null when the deprecation names none. */
+    val displayReplacement: String?
+        get() = rawReplacement?.let(ReplacementParser::formatForDisplay)
+}
 
 data class DocumentationLinks(
     val github: String = "",
@@ -27,6 +43,10 @@ data class DocumentationInfo(
         // arity on its own line, mirroring the project-symbol popup (PhelDocHtml.projectSymbol).
         signature.takeIf(String::isNotBlank)
             ?.let { append("<code>${it.replace("\n", "<br />")}</code><br /><br />") }
+        // Deprecation notice. Driven by DeprecationInfo's display helpers so the popup and the
+        // deprecated-function inspection (DeprecationMessageBuilder) always name the same version
+        // and replacement.
+        deprecation?.let { appendDeprecationNotice(it) }
         append(summary)
         append("<br />")
 
@@ -36,6 +56,14 @@ data class DocumentationInfo(
             append("</code></pre>")
         }
         append("<br />")
+    }
+
+    private fun StringBuilder.appendDeprecationNotice(deprecation: DeprecationInfo) {
+        append("<b>&#9888; Deprecated")
+        deprecation.displayVersion?.let { append(" since ").append(it) }
+        append("</b>")
+        deprecation.displayReplacement?.let { append(". Use <code>").append(it).append("</code> instead") }
+        append(".<br /><br />")
     }
 }
 

--- a/src/main/kotlin/org/phellang/registry/ReplacementParser.kt
+++ b/src/main/kotlin/org/phellang/registry/ReplacementParser.kt
@@ -1,4 +1,4 @@
-package org.phellang.inspection.deprecated
+package org.phellang.registry
 
 object ReplacementParser {
 

--- a/src/test/kotlin/org/phellang/integration/inspection/PhelDeprecatedFunctionInspectionIntegrationTest.kt
+++ b/src/test/kotlin/org/phellang/integration/inspection/PhelDeprecatedFunctionInspectionIntegrationTest.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test
 import org.phellang.registry.DeprecationInfo
 import org.phellang.registry.PhelFunctionRegistry
 import org.phellang.inspection.deprecated.DeprecationMessageBuilder
-import org.phellang.inspection.deprecated.ReplacementParser
+import org.phellang.registry.ReplacementParser
 
 class PhelDeprecatedFunctionInspectionIntegrationTest {
 

--- a/src/test/kotlin/org/phellang/unit/inspection/PhelDeprecatedFunctionInspectionTest.kt
+++ b/src/test/kotlin/org/phellang/unit/inspection/PhelDeprecatedFunctionInspectionTest.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test
 import org.phellang.registry.DeprecationInfo
 import org.phellang.registry.PhelFunctionRegistry
 import org.phellang.inspection.deprecated.DeprecationMessageBuilder
-import org.phellang.inspection.deprecated.ReplacementParser
+import org.phellang.registry.ReplacementParser
 
 class PhelDeprecatedFunctionInspectionTest {
 

--- a/src/test/kotlin/org/phellang/unit/registry/DocumentationInfoRenderingTest.kt
+++ b/src/test/kotlin/org/phellang/unit/registry/DocumentationInfoRenderingTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.phellang.registry.CompletionInfo
+import org.phellang.registry.DeprecationInfo
 import org.phellang.registry.DocumentationInfo
 import org.phellang.registry.PhelCompletionPriority
 import org.phellang.registry.PhelFunction
@@ -13,16 +14,17 @@ import org.phellang.registry.PhelFunction
  *
  * Multi-arity stdlib functions carry every arity in a single newline-separated signature
  * string (see KotlinCodeGenerator); the popup must render each arity on its own line, the
- * same way the project-symbol popup does (PhelDocHtml.projectSymbol).
+ * same way the project-symbol popup does (PhelDocHtml.projectSymbol). Deprecated functions
+ * must also surface a notice consistent with the deprecated-function inspection.
  */
 class DocumentationInfoRenderingTest {
 
-    private fun functionWithSignature(signature: String) = PhelFunction(
+    private fun functionWithSignature(signature: String, deprecation: DeprecationInfo? = null) = PhelFunction(
         namespace = "trace",
         name = "trace/trace",
         signature = signature,
         completion = CompletionInfo(tailText = "", priority = PhelCompletionPriority.DEBUG_FUNCTIONS),
-        documentation = DocumentationInfo(summary = "Prints value and returns it unchanged"),
+        documentation = DocumentationInfo(summary = "Prints value and returns it unchanged", deprecation = deprecation),
     )
 
     @Test
@@ -47,5 +49,36 @@ class DocumentationInfoRenderingTest {
             html.contains("<code>(inc x)</code>"),
             "Single-arity signature should render as-is, got: $html",
         )
+    }
+
+    @Test
+    fun `deprecation with a version and replacement renders a notice`() {
+        val html = functionWithSignature(
+            "(push xs x)",
+            DeprecationInfo(version = "0.25.0", replacement = "conj"),
+        ).toHtmlDocumentation()
+
+        assertTrue(html.contains("Deprecated"), "Expected a deprecation notice, got: $html")
+        assertTrue(html.contains("0.25.0"), "Expected the deprecation version, got: $html")
+        assertTrue(html.contains("<code>conj</code>"), "Expected the replacement, got: $html")
+    }
+
+    @Test
+    fun `deprecation whose version carries a Use message renders the formatted replacement`() {
+        val html = functionWithSignature(
+            "(str-contains? s x)",
+            DeprecationInfo(version = "Use phel\\string\\contains?"),
+        ).toHtmlDocumentation()
+
+        assertTrue(html.contains("string/contains?"), "Expected the formatted replacement, got: $html")
+        assertFalse(html.contains("phel\\string\\contains?"), "Replacement should be display-formatted, got: $html")
+        assertFalse(html.contains("since"), "A Use-message deprecation carries no version, got: $html")
+    }
+
+    @Test
+    fun `non-deprecated function renders no deprecation notice`() {
+        val html = functionWithSignature("(inc x)").toHtmlDocumentation()
+
+        assertFalse(html.contains("Deprecated"), "A healthy function must not show a deprecation notice, got: $html")
     }
 }

--- a/src/test/kotlin/org/phellang/unit/registry/ReplacementParserTest.kt
+++ b/src/test/kotlin/org/phellang/unit/registry/ReplacementParserTest.kt
@@ -1,9 +1,9 @@
-package org.phellang.unit.inspection.deprecated
+package org.phellang.unit.registry
 
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.phellang.inspection.deprecated.ReplacementParser
+import org.phellang.registry.ReplacementParser
 
 class ReplacementParserTest {
 


### PR DESCRIPTION
## Summary

The `superseded-by` metadata drove the deprecated-function inspection but never reached the hover / quick-documentation popup, so the same symbol looked perfectly healthy on hover while the editor flagged it and offered "Use X instead" (#230). `DocumentationInfo.toHtml` now renders a deprecation notice:

- **version + replacement** (`push`, `put`, `unset`, ...): `⚠ Deprecated since 0.25.0. Use conj instead.`
- **`Use xyz` version quirk** (`str-contains?`): the replacement is display-formatted (`phel\string\contains?` -> `string/contains?`), and no bogus "since" is shown.
- **not deprecated**: nothing rendered.

## Design note (architecture boundary)

`DocumentationInfo.toHtml` lives in the `registry` **leaf**, which `ArchitectureBoundaryTest` forbids from importing any feature package -- so the popup could not call the inspection's `DeprecationMessageBuilder` / `ReplacementParser`. To make the popup and the inspection say the same thing without duplicating logic:

- `ReplacementParser` **moves from `inspection.deprecated` into `registry`** (it parses the `replacement` field, a registry concept). Its test moves alongside it.
- The `Use xyz` version quirk is centralized on `DeprecationInfo` as `displayVersion` / `rawReplacement` / `displayReplacement`.
- `DeprecationMessageBuilder` now reads those helpers; **its output is byte-for-byte unchanged** (all 10 `DeprecationMessageBuilderTest` cases pass), it just no longer owns the quirk logic.

So the popup and the inspection are consistent by construction, and `registry` stays a leaf.

## Test plan

- [x] `DocumentationInfoRenderingTest` -- 3 new cases (version+replacement, `Use xyz` quirk formats to `ns/fn` with no "since", non-deprecated shows nothing) + the existing multi-arity cases. **Green.**
- [x] `DeprecationMessageBuilderTest` (10), `ReplacementParserTest` (moved, 18), `PhelDeprecatedFunctionQuickFixTest`, `PhelDeprecatedFunctionInspectionTest`, `PhelFunctionDeprecationTest` -- all pass; output preserved after the refactor.
- [x] `ArchitectureBoundaryTest` -- passes; `registry` remains a leaf after the `ReplacementParser` move.
- **Self-review (skill step 10):** surfaced only a stale import ordering in the quick-fix, fixed inline. No separate `ref` commit.
- [ ] CI (`build.yml`) build / test / verify green.

Closes #230
