### PR TITLE
ci: harden CI against transient IntelliJ Platform flakes

### DIFF
--- a/.github/scripts/gradle-retry.sh
+++ b/.github/scripts/gradle-retry.sh
@@ -1,32 +1,42 @@
 #!/usr/bin/env bash
 #
-# Runs Gradle, retrying only the known IntelliJ Platform Gradle Plugin race.
+# Runs Gradle, retrying only known-transient CI failures. Two classes are retried; everything
+# else (a real test or compile error) fails immediately so genuine breakage is never masked.
 #
-# IdeLayoutIndexService parses plugin.xml out of the transformed IDE jars to build its
-# bundled-plugin index. The zip filesystem backing those jars is sometimes closed while it is
-# still reading, which surfaces as:
+# 1. The IntelliJ Platform Gradle Plugin bundled-plugin race.
+#    IdeLayoutIndexService parses plugin.xml out of the transformed IDE jars to build its
+#    bundled-plugin index. The zip filesystem backing those jars is sometimes closed while it is
+#    still reading, which surfaces as:
 #
-#   Unable to read descriptor [plugin.xml] from [.../ideaIC-<version>/plugins/java/lib/java-impl.jar]
-#   java.nio.file.ClosedFileSystemException
-#   Following 1 plugins could not be created: plugins/java
+#      Unable to read descriptor [plugin.xml] from [.../ideaIC-<version>/plugins/java/lib/java-impl.jar]
+#      java.nio.file.ClosedFileSystemException
+#      Following 1 plugins could not be created: plugins/java
 #
-# The index then comes back incomplete and the build fails with the misleading
+#    The index then comes back incomplete and the build fails with the misleading
 #
-#   Could not find bundled plugin with ID: 'com.intellij.java'
+#      Could not find bundled plugin with ID: 'com.intellij.java'
 #
-# Upstream: https://github.com/JetBrains/intellij-platform-gradle-plugin/issues/2192
-# (open; JetBrains confirmed it on their own pipeline and their guidance is to re-run).
-# It is a race, so it hits whichever configuration resolves first, which is why it has shown up
-# as ':intellijPlatformRuntimeClasspath' in one job and ':intellijPlatformTestRuntimeClasspath'
-# in another. Delete this script and call ./gradlew directly once the upstream fix ships.
+#    Upstream: https://github.com/JetBrains/intellij-platform-gradle-plugin/issues/2192
+#    (open; JetBrains confirmed it on their own pipeline and their guidance is to re-run). It is a
+#    race, so it hits whichever configuration resolves first. Clearing the transforms cache between
+#    attempts is what makes the retry stick (see below). Delete this handling once #2192 ships a fix.
 #
-# Only this signature is retried. Any other failure, a real test or compile error, fails
-# immediately so genuine breakage is never masked.
+# 2. Transient network failures fetching the platform or Plugin Verifier IDEs, e.g.
+#
+#      Could not resolve idea:ideaIC:2024.3
+#      Read timed out / Connection reset / Premature end of Content-Length
+#
+#    These just need another attempt; no cache surgery. A genuinely wrong IDE coordinate still fails
+#    (it simply exhausts the attempts), so real misconfiguration is not masked, only slowed.
 
 set -uo pipefail
 
-MAX_ATTEMPTS="${GRADLE_RETRY_ATTEMPTS:-3}"
+MAX_ATTEMPTS="${GRADLE_RETRY_ATTEMPTS:-5}"
+
+# The bundled-plugin race — needs the half-extracted IDE dropped, not just a re-run.
 RACE_SIGNATURE='ClosedFileSystemException|Could not find bundled plugin with ID'
+# Transient dependency resolution / download failures — a plain re-run clears them.
+NETWORK_SIGNATURE='Could not resolve idea:ideaIC|Read timed out|Connection (reset|timed out)|Premature end of Content-Length|Could not (GET|HEAD|transfer)|Gateway Time-?out|(502|503|504) '
 
 log="$(mktemp)"
 trap 'rm -f "$log"' EXIT
@@ -47,31 +57,45 @@ for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
         exit 0
     fi
 
-    if ! grep -qE "$RACE_SIGNATURE" "$log"; then
-        echo "::error::Gradle failed for a reason unrelated to intellij-platform-gradle-plugin#2192. Not retrying."
+    hit_race=false; grep -qE "$RACE_SIGNATURE" "$log" && hit_race=true
+    hit_network=false; grep -qE "$NETWORK_SIGNATURE" "$log" && hit_network=true
+
+    if [ "$hit_race" = false ] && [ "$hit_network" = false ]; then
+        echo "::error::Gradle failed for a reason unrelated to a known transient CI flake. Not retrying."
         exit "$status"
     fi
 
-    echo "::warning::Attempt ${attempt}/${MAX_ATTEMPTS} hit the bundled-plugin race (intellij-platform-gradle-plugin#2192)."
-
-    # The incomplete index survives in two places, and a retry has to clear both.
-    #
-    # IdeLayoutIndexService is a shared build service, so the daemon replays it in-process:
-    # without the stop, retries failed in ~1s having never re-read the jars.
-    ./gradlew --stop >/dev/null 2>&1 || true
-    #
-    # It also survives on disk. With only the daemon stopped, retries still failed in ~10s on a
-    # provably fresh daemon ("1 stopped Daemon could not be reused") and without the originating
-    # ClosedFileSystemException, while re-running the whole job on a clean runner has always
-    # worked. So the interrupted read leaves the extracted IDE unusable, and it has to be
-    # re-extracted. The archive stays in modules-2, so this costs extraction, not a download.
-    shopt -s nullglob
-    stale=(~/.gradle/caches/*/transforms ~/.gradle/caches/transforms-*)
-    if [ ${#stale[@]} -gt 0 ]; then
-        echo "Re-extracting the IDE: dropping ${stale[*]}"
-        rm -rf "${stale[@]}"
+    if [ "$attempt" -eq "$MAX_ATTEMPTS" ]; then
+        break
     fi
+
+    if [ "$hit_race" = true ]; then
+        echo "::warning::Attempt ${attempt}/${MAX_ATTEMPTS} hit the bundled-plugin race (intellij-platform-gradle-plugin#2192)."
+    else
+        echo "::warning::Attempt ${attempt}/${MAX_ATTEMPTS} hit a transient network/resolution failure."
+    fi
+
+    # The shared IdeLayoutIndexService is replayed in-process, so stop the daemon: without this,
+    # retries returned in ~1s having never re-read the jars.
+    ./gradlew --stop >/dev/null 2>&1 || true
+
+    # The race also survives on disk as a half-extracted IDE. With only the daemon stopped, retries
+    # still failed on a provably fresh daemon without the originating ClosedFileSystemException,
+    # while re-running the whole job on a clean runner always worked. So the interrupted read leaves
+    # the extracted IDE unusable and it has to be re-extracted. The archive stays in modules-2, so
+    # this costs extraction, not a download. A pure network failure does not need this.
+    if [ "$hit_race" = true ]; then
+        shopt -s nullglob
+        stale=(~/.gradle/caches/*/transforms ~/.gradle/caches/transforms-*)
+        if [ ${#stale[@]} -gt 0 ]; then
+            echo "Re-extracting the IDE: dropping ${stale[*]}"
+            rm -rf "${stale[@]}"
+        fi
+    fi
+
+    # Back off before retrying; network wobbles in particular benefit from a short pause.
+    sleep $((attempt * 5))
 done
 
-echo "::error::Still hitting the bundled-plugin race after ${MAX_ATTEMPTS} attempts."
+echo "::error::Still failing with a transient signature after ${MAX_ATTEMPTS} attempts."
 exit 1

--- a/src/test/kotlin/org/phellang/unit/documentation/resolvers/PhelSymbolDocumentationResolverTest.kt
+++ b/src/test/kotlin/org/phellang/unit/documentation/resolvers/PhelSymbolDocumentationResolverTest.kt
@@ -1,6 +1,7 @@
 package org.phellang.unit.documentation.resolvers
 
 import com.intellij.psi.PsiElement
+import java.util.concurrent.CopyOnWriteArrayList
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -85,7 +86,10 @@ class PhelSymbolDocumentationResolverTest {
 
     @Test
     fun `should maintain thread safety`() {
-        val resolvers = mutableListOf<PhelSymbolDocumentationResolver>()
+        // Thread-safe on purpose: the workers below add concurrently, so a plain ArrayList would
+        // race and drop an add (the flake behind #243). The resolver has no shared construction
+        // state, so the collection was the only unsafe part.
+        val resolvers = CopyOnWriteArrayList<PhelSymbolDocumentationResolver>()
         val threads = mutableListOf<Thread>()
 
         repeat(5) {


### PR DESCRIPTION
## Summary

Fixes the three CI-flakiness modes from #243 (all confirmed transient this session, none real breakage).

### `gradle-retry.sh`
- **Bundled-plugin race (`#2192`)** could draw on all 3 retry attempts (hit #236 / #241 / #242). Raise the default `GRADLE_RETRY_ATTEMPTS` to **5** and add a backoff between attempts.
- **Transient IDE download / resolution** failures (`Could not resolve idea:ideaIC:2024.3`, read timeouts, 5xx) were **not** in the retry signature, so they failed fast (hit #241). Added a `NETWORK_SIGNATURE`. The transforms-cache drop stays **scoped to the race** (a network wobble just needs another attempt, not re-extraction). Real test/compile errors still fail immediately.

### Flaky thread-safety test
`PhelSymbolDocumentationResolverTest > should maintain thread safety` intermittently asserted `expected: <5> but was: <4>` (hit #242). Root cause: the test collected results from 5 threads into a plain `ArrayList`, which raced and dropped an add. Fixed by collecting into a `CopyOnWriteArrayList`. **The resolver under test has no shared construction state and `PhelApiDocumentation` caches via `ConcurrentHashMap.computeIfAbsent`, so this was the test's own race, not a production one.**

## Verification

- [x] `bash -n gradle-retry.sh` — valid; exec bit preserved (`100755`).
- [x] The fixed test run **10× locally with `--rerun-tasks` → 0 failures** (was intermittently red).
- No CHANGELOG entry: this is CI/test-infra hardening with no user-facing behavior change (the changelog feeds the Marketplace "What's new").
- [ ] CI (`build.yml`) green.

Closes #243
