### PR TITLE
ci: auto-rerun the sticky bundled-plugin race on a fresh runner

### DIFF
--- a/.github/workflows/auto-rerun-flaky.yml
+++ b/.github/workflows/auto-rerun-flaky.yml
@@ -1,0 +1,69 @@
+name: Auto-rerun flaky CI
+
+# The IntelliJ Platform Gradle Plugin bundled-plugin race (intellij-platform-gradle-plugin#2192) has
+# a "sticky" manifestation that the in-job retry (.github/scripts/gradle-retry.sh) cannot clear: it
+# can draw on every attempt within a job, and only a *fresh runner* clears it (JetBrains' guidance is
+# "re-run"). When a Build run fails with that signature, re-run its failed jobs on a fresh runner —
+# bounded (to avoid loops) and signature-gated (so genuine failures still surface immediately).
+#
+# workflow_run workflows always run from the default branch, so this only takes effect once merged to
+# main; it cannot be exercised on the PR that adds it. See issue #243.
+
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types: [completed]
+
+permissions:
+  actions: write   # re-run failed jobs
+  contents: read
+
+concurrency:
+  group: auto-rerun-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  rerun:
+    name: Re-run failed jobs on a transient flake
+    # Only failed runs, and stop after a couple of attempts so a genuinely broken run is not looped.
+    # run_attempt is 1 on the first run and increments on each rerun, so `< 3` allows at most two
+    # auto-reruns (attempts 2 and 3).
+    if: >
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.run_attempt < 3
+    runs-on: ubuntu-latest
+    steps:
+      - name: Re-run only when the failure matches a known transient signature
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          # Mirrors .github/scripts/gradle-retry.sh: the bundled-plugin race plus transient IDE
+          # download/resolution failures. A fresh runner clears both; a real test/compile error
+          # matches neither and is left to surface.
+          SIGNATURE: 'ClosedFileSystemException|Could not find bundled plugin with ID|Could not resolve idea:ideaIC|Read timed out|Premature end of Content-Length'
+        run: |
+          set -euo pipefail
+          echo "Build run $RUN_ID failed on attempt $ATTEMPT. Inspecting its logs for a transient signature."
+
+          # Logs can lag a moment behind run completion; give them a few tries.
+          for i in 1 2 3 4 5; do
+            if gh api "repos/$REPO/actions/runs/$RUN_ID/logs" > logs.zip 2>/dev/null && [ -s logs.zip ]; then
+              break
+            fi
+            echo "Logs not available yet (attempt $i); waiting..."
+            sleep 10
+          done
+
+          if [ ! -s logs.zip ]; then
+            echo "::warning::Could not download logs for run $RUN_ID; leaving the failure as-is."
+            exit 0
+          fi
+
+          if unzip -p logs.zip | grep -qE "$SIGNATURE"; then
+            echo "Transient signature found. Re-running failed jobs on a fresh runner (attempt $((ATTEMPT + 1)))."
+            gh run rerun "$RUN_ID" --failed --repo "$REPO"
+          else
+            echo "No transient signature in the logs; leaving the failure so it surfaces."
+          fi


### PR DESCRIPTION
## Summary

The real fix for the sticky `#2192` bundled-plugin race, documented on #243. In-job retry (`gradle-retry.sh`) can't clear the sticky case (PR #244's own Verify drew it 5/5); only a fresh runner does. This adds a `workflow_run` workflow that re-runs a failed **Build** run's failed jobs on a fresh runner — **signature-gated** and **bounded**.

## How it works

- Triggers on **Build** workflow `completed`; the job runs only when `conclusion == 'failure'` and `run_attempt < 3` (so at most two auto-reruns; a genuinely broken run still surfaces).
- Downloads the failed run's logs (`gh api .../runs/<id>/logs`, with a short availability retry) and greps for the transient signature — the bundled-plugin race plus transient IDE download/resolution failures (mirrors `gradle-retry.sh`).
- **Only if matched**, `gh run rerun <id> --failed` on a fresh runner. A real test/compile error matches neither signature and is left to surface immediately.
- Permissions scoped to `actions: write` + `contents: read`; a concurrency group per run.

## Caveat (inherent to `workflow_run`)

`workflow_run` workflows always run from the **default branch**, so this only takes effect once merged to `main` and **cannot be exercised on this PR**. Its own `Build` CI here just confirms the repo still builds; the auto-rerun behavior can only be observed on `main` afterward.

## Verification

- [x] YAML valid; embedded shell `bash -n` clean.
- [x] Trigger (`Build` / `completed`), permissions (`actions: write`), and the bounded, signature-gated guard confirmed by parsing the file.
- No CHANGELOG: CI-only, no user-facing change.

Follow-up to #243.
