### PR TITLE
ci: automate the release and Marketplace publish pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,9 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.properties.outputs.version }}
+      changelog: ${{ steps.properties.outputs.changelog }}
     steps:
 
       # Free GitHub Actions Environment Disk Space
@@ -41,6 +44,23 @@ jobs:
       # Build plugin
       - name: Build plugin
         run: .github/scripts/gradle-retry.sh buildPlugin
+
+      # Expose the plugin version and the changelog notes for the release-draft job below.
+      - name: Export version and changelog
+        id: properties
+        shell: bash
+        run: |
+          VERSION="$(grep -E '^version = ' build.gradle.kts | head -1 | cut -d'"' -f2)"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          # The current version's changelog section, falling back to Unreleased when it is not
+          # promoted yet (matches patchPluginXml's changeNotes logic in build.gradle.kts).
+          CHANGELOG="$(./gradlew getChangelog --no-header --console=plain -q 2>/dev/null \
+            || ./gradlew getChangelog --unreleased --no-header --console=plain -q 2>/dev/null || true)"
+          {
+            echo "changelog<<CHANGELOG_EOF"
+            echo "$CHANGELOG"
+            echo "CHANGELOG_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       # Enforce the plugin project configuration check. verifyPluginProjectConfiguration only logs a
       # warning and exits 0 (it reports to Gradle's Problems API at WARNING severity), so on its own
@@ -176,3 +196,41 @@ jobs:
         with:
           name: pluginVerifier-result
           path: ${{ github.workspace }}/build/reports/pluginVerifier
+
+  # Refresh a DRAFT GitHub Release for the current version on every green push to main. A draft
+  # publishes nothing; the actual Marketplace publish happens only when a human publishes the
+  # release, which triggers release.yml.
+  releaseDraft:
+    name: Release draft
+    if: github.event_name != 'pull_request'
+    needs: [ build, test, verify ]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Fetch Sources
+        uses: actions/checkout@v7
+
+      # Keep a single draft: drop any previous drafts before recreating the current one.
+      - name: Remove old draft releases
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release list --repo "$GITHUB_REPOSITORY" --json isDraft,tagName \
+            --jq '.[] | select(.isDraft) | .tagName' \
+            | while read -r tag; do
+                [ -n "$tag" ] && gh release delete "$tag" --repo "$GITHUB_REPOSITORY" --yes || true
+              done
+
+      - name: Create release draft
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.build.outputs.version }}
+          CHANGELOG: ${{ needs.build.outputs.changelog }}
+        run: |
+          gh release create "v$VERSION" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$GITHUB_SHA" \
+            --draft \
+            --title "v$VERSION" \
+            --notes "${CHANGELOG:-_No changelog entries for this version._}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Release
+
+# Publishing a GitHub Release (the draft that build.yml keeps refreshed) signs the plugin and
+# uploads it to the JetBrains Marketplace, then attaches the distribution to the release. Requires
+# the four signing/publish secrets: CERTIFICATE_CHAIN, PRIVATE_KEY, PRIVATE_KEY_PASSWORD, PUBLISH_TOKEN.
+on:
+  release:
+    types: [ prereleased, released ]
+
+concurrency:
+  group: release-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Publish to JetBrains Marketplace
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # attach the distribution asset to the release
+    steps:
+      - name: Maximize Build Space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
+          large-packages: false
+
+      # Check out the exact commit the release was cut from.
+      - name: Fetch Sources
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: zulu
+          java-version: 21
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      # Build, sign, and upload to the Marketplace. publishPlugin depends on signPlugin/buildPlugin,
+      # so it produces the signed distribution as a side effect.
+      - name: Publish plugin
+        env:
+          CERTIFICATE_CHAIN: ${{ secrets.CERTIFICATE_CHAIN }}
+          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+          PRIVATE_KEY_PASSWORD: ${{ secrets.PRIVATE_KEY_PASSWORD }}
+          PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
+        run: .github/scripts/gradle-retry.sh publishPlugin
+
+      # Attach the built distribution to the GitHub release.
+      - name: Attach distribution to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            ./build/distributions/*.zip \
+            --repo "$GITHUB_REPOSITORY" --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,7 @@ agnostic-ai.local.yaml
 AGENTS.md
 CLAUDE.md
 # <<< agnostic-ai (managed) <<<
+
+# Plugin signing artifacts — the certificate and private key live in CI secrets, never in git.
+*.pem
+*.crt

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,77 +1,71 @@
 # Release Process
 
-This document describes how to publish a new version of the Phel IntelliJ Plugin.
+Publishing is automated. A **draft GitHub Release** is kept up to date for the current version on
+every green push to `main`; **publishing that release** signs the plugin and uploads it to the
+JetBrains Marketplace. You never build or upload the zip by hand.
 
-## Prerequisites
+## One-time setup
 
-- Push access to the `main` branch
-- Access to the [JetBrains Marketplace](https://plugins.jetbrains.com/) plugin upload UI
+The signing/publish workflow ([`release.yml`](.github/workflows/release.yml)) needs four repository
+secrets (Settings → Secrets and variables → Actions). They are already configured; this is only for
+reference or rotation:
 
-## Release Checklist
+| Secret | Source |
+|---|---|
+| `PUBLISH_TOKEN` | [Marketplace](https://plugins.jetbrains.com/) → your profile → **Tokens** → Generate |
+| `CERTIFICATE_CHAIN`, `PRIVATE_KEY`, `PRIVATE_KEY_PASSWORD` | a [plugin signing certificate](https://plugins.jetbrains.com/docs/intellij/plugin-signing.html) (`openssl`) |
 
-### 1. Update the function registry
+The signing certificate expires (365 days by default) — regenerate and update the two cert secrets
+before then.
 
-If Phel has a new release, update the built-in function registry first.
+## Cutting a release
 
-In IntelliJ, run the **Update Registry Repository** task (or from terminal):
+### 1. Update the function registry (if Phel released)
 
 ```bash
-./gradlew updatePhelRegistry
+./gradlew updatePhelRegistry     # Phel stdlib
+./gradlew updatePhpRegistry      # native PHP docs (php/doc-en), if refreshing those
 ```
 
-### 2. Smoke-test the plugin
+### 2. Smoke-test
 
-Run the **Run Plugin** task in IntelliJ (or `./gradlew runIde`). This opens a sandboxed IDE instance with the plugin loaded. Verify everything works as expected.
+`./gradlew runIde` opens a sandbox IDE with the plugin loaded. Verify the change set works.
 
-### 3. Bump the version and update the changelog
+### 3. Bump the version and promote the changelog
 
-Update `version` in `build.gradle.kts`:
+Set the new `version` in `build.gradle.kts`:
 
 ```kotlin
 version = "X.Y.Z"
 ```
 
 Then promote the `## [Unreleased]` entries in `CHANGELOG.md` into a new `## [X.Y.Z] - YYYY-MM-DD`
-section (or run `./gradlew patchChangelog`, which does this for you). The Marketplace "What's new"
-notes are generated from this section: `patchPluginXml` renders the entry matching `version` into
-`<change-notes>`, so releasing with an empty changelog ships empty release notes.
+section (or run `./gradlew patchChangelog`). This section is the single source of the release notes:
+the draft release and the Marketplace **What's new** (`patchPluginXml` renders it into
+`<change-notes>`) both come from it — so releasing with an empty section ships empty notes.
 
 ### 4. Update IDE compatibility (if needed)
 
-Update `sinceBuild` / `untilBuild` in `build.gradle.kts` if targeting new IDE versions.
+Adjust `sinceBuild` / `untilBuild` in `build.gradle.kts` if targeting new IDE versions.
 
-### 5. Build the distribution
+### 5. Merge to `main`
 
-Run the **Build Distribution** task in IntelliJ (or from terminal):
+Open a PR with the version/changelog bump and merge it. On the resulting green push to `main`, the
+`releaseDraft` job in [`build.yml`](.github/workflows/build.yml) creates or refreshes a **draft**
+GitHub Release `vX.Y.Z` with the changelog notes. A draft publishes nothing.
 
-```bash
-./gradlew buildPlugin
-```
+### 6. Publish the release
 
-This generates the plugin zip at:
+On the repo's **Releases** page, review the draft `vX.Y.Z` (notes and version), then **Publish**.
+That triggers [`release.yml`](.github/workflows/release.yml), which runs `publishPlugin` to sign and
+upload to the Marketplace and attaches the distribution zip to the release. Track the run under
+**Actions**; the Marketplace listing updates after JetBrains' review.
 
-```
-build/distributions/phelplugin-X.Y.Z.zip
-```
+## Manual fallback
 
-### 6. Publish to JetBrains Marketplace
-
-1. Open the [Marketplace plugin page](https://plugins.jetbrains.com/plugin/28459-phel-lang) in your browser.
-2. Go to the plugin upload modal.
-3. Drag and drop the `phelplugin-X.Y.Z.zip` file from `build/distributions/`.
-4. Submit and wait for approval.
-
-Alternatively, with the `PUBLISH_TOKEN` (and `CERTIFICATE_CHAIN`, `PRIVATE_KEY`,
-`PRIVATE_KEY_PASSWORD` for signing) environment variables set, publish from the terminal:
+If the automation is unavailable, publish from a terminal with the four secrets exported as
+environment variables:
 
 ```bash
 ./gradlew publishPlugin
-```
-
-### 7. Commit and push
-
-```bash
-git add build.gradle.kts CHANGELOG.md src/main/kotlin/org/phellang/registry/data
-git commit -m "chore: bump plugin to X.Y.Z and update registry"
-git push origin main
 ```


### PR DESCRIPTION
## Summary

Automates the release/Marketplace publish (#226). The signing/publish plumbing already existed in `build.gradle.kts` but nothing invoked it; this connects it to a **two-stage, human-gated** flow.

### `build.yml` — `releaseDraft` job
- The `build` job now exposes `version` (from `build.gradle.kts`) and `changelog` (`getChangelog --no-header`, falling back to Unreleased) as outputs.
- A new `releaseDraft` job (non-PR pushes to `main`, after `build`/`test`/`verify`, `contents: write`) drops old drafts and creates/refreshes a **draft** GitHub Release `vX.Y.Z` with the changelog notes. **A draft publishes nothing.**

### `release.yml` (new)
- Triggers on `release: [prereleased, released]` — i.e. only when a human **publishes** the draft.
- Runs `publishPlugin` with the four secrets (sign + upload to the Marketplace), then attaches the distribution zip to the release.

### `RELEASE.md`
- Rewritten to the flow: bump `version` + promote `[Unreleased] -> [X.Y.Z]` -> merge -> review the draft -> **Publish**. The old manual `buildPlugin` + drag-and-drop steps are gone (kept only as a terminal fallback).

### `.gitignore`
- Ignores `*.pem` / `*.crt` so the signing certificate and private key can never be committed (they belong in CI secrets).

## Answering the original questions

- **Deploy on every commit?** No. Every push to `main` only refreshes a *draft*; the Marketplace publish happens **only when you publish the release** (which you do after bumping the version).
- **Order for 1.0.0:** merge this -> the four secrets are already set -> bump to `1.0.0` + promote the changelog -> merge -> publish the draft.

## Notes / caveats

- The four secrets (`PUBLISH_TOKEN`, `CERTIFICATE_CHAIN`, `PRIVATE_KEY`, `PRIVATE_KEY_PASSWORD`) are configured. Without them `release.yml` would fail at the sign/publish step.
- After this merges, the first draft will be **`v0.5.3`** (the current version, already released) — harmless; it refreshes to `v1.0.0` once you bump. Don't publish the 0.5.3 draft.
- `release.yml` **cannot be exercised until an actual release is published** (its trigger), so this PR's own CI only validates `build.yml` + `releaseDraft`. Its first real run will be the 1.0.0 publish.

## Test plan

- [x] Both workflows: YAML valid; all embedded `run:` blocks pass `bash -n`.
- [x] `getChangelog --no-header` and the version extraction verified locally.
- [x] `releaseDraft` gating (non-PR, needs build/test/verify, `contents: write`) and `release.yml` trigger/permissions confirmed by parsing.
- [ ] CI (`build.yml`) green; on merge, a `v0.5.3` draft appears under Releases.

Closes #226
