### PR TITLE
chore: bump plugin to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ refreshed, since completion, hover and arity checking are all driven by it.
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-07-24
+
 ### Added
 
 - `trace` namespace support; registry refreshed to **Phel 0.49.0**.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import org.jetbrains.grammarkit.tasks.GenerateParserTask
 import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginProjectConfigurationTask
 
 group = "org.phellang"
-version = "0.5.3"
+version = "1.0.0"
 
 plugins {
     id("java")


### PR DESCRIPTION
## Summary

Cuts the **1.0.0** release: bumps `version` in `build.gradle.kts` (0.5.3 → 1.0.0) and promotes the `## [Unreleased]` changelog into `## [1.0.0] - 2026-07-24`, leaving an empty `[Unreleased]` for future work.

## What ships in 1.0.0 (user-facing, since 0.5.3)

- Native PHP function docs + completion via `php/` (core extensions from `php/doc-en`, php.net links) — #240.
- Deprecation / superseded-by shown in the documentation popup — #230.
- `trace` namespace; registry refreshed to Phel 0.49.0.
- `CODE_OF_CONDUCT.md` — #229.
- Fixes: multi-arity signature rendering (#231), `#_` form-comment resolution, cancellable/off-EDT symbol index, metadata-based private detection.
- Build/infra: issue forms (#227), Gradle configuration cache + generator-race fix (#228), distribution slimming, Codecov coverage.

(CI-only changes — release automation, flakiness hardening — are intentionally omitted from the user-facing notes.)

## What happens on merge

1. `releaseDraft` refreshes the draft GitHub Release from `v0.5.3` to **`v1.0.0`** with these notes.
2. Review the `v1.0.0` draft under **Releases**, then **Publish** it.
3. `release.yml` runs `publishPlugin` (sign + Marketplace upload) and attaches the zip.

## Verification

- [x] `getChangelog --no-header` returns the 1.0.0 section (drives both the draft notes and `patchPluginXml` change-notes).
- [x] `version = "1.0.0"`; `[Unreleased]` emptied, `[1.0.0] - 2026-07-24` added.
- [ ] CI green; on merge, the draft becomes `v1.0.0`.

Prepares the 1.0.0 release (no issue).
