### PR TITLE
ci: attach only the signed zip to the GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,11 +49,11 @@ jobs:
           PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
         run: .github/scripts/gradle-retry.sh publishPlugin
 
-      # Attach the built distribution to the GitHub release.
-      - name: Attach distribution to the release
+      # Attach the signed distribution (the artifact that ships to the Marketplace) to the release.
+      - name: Attach signed distribution to the release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release upload "${{ github.event.release.tag_name }}" \
-            ./build/distributions/*.zip \
+            ./build/distributions/*-signed.zip \
             --repo "$GITHUB_REPOSITORY" --clobber


### PR DESCRIPTION
Follow-up to #226. The release-asset upload used `./build/distributions/*.zip`, which attached both the unsigned `phelplugin-<v>.zip` and the signed `phelplugin-<v>-signed.zip` (visible on the v1.0.0 release). Narrow the glob to `*-signed.zip` so only the signed distribution — the artifact that ships to the Marketplace — is attached.

Takes effect on the next published release. Validated: YAML parses.