### PR TITLE
fix(ci): skip release-draft when the version is already published

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -228,6 +228,12 @@ jobs:
           VERSION: ${{ needs.build.outputs.version }}
           CHANGELOG: ${{ needs.build.outputs.changelog }}
         run: |
+          # Old drafts were already removed, so if a release for this version still exists it is a
+          # published one — the version has not been bumped since it shipped. Nothing to draft.
+          if gh release view "v$VERSION" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release v$VERSION is already published; nothing to draft until the next version bump."
+            exit 0
+          fi
           gh release create "v$VERSION" \
             --repo "$GITHUB_REPOSITORY" \
             --target "$GITHUB_SHA" \


### PR DESCRIPTION
Follow-up to #226. Once a version ships (e.g. `v1.0.0`), the `releaseDraft` job kept trying to create a **draft** for that same tag on every push to `main`. The "remove old drafts" step only deletes drafts, not the published release, so `gh release create v1.0.0 --draft` failed with "release already exists" — turning the `main` build red on every commit until the next version bump.

**Fix:** after the drafts are cleared, if a release for `v$VERSION` still exists it must be the published one, so skip creating a draft. Draft creation resumes automatically once the version is bumped.

Validated: `build.yml` YAML parses; the step's shell passes `bash -n`.