### PR TITLE
Find a defn's parameter vector past its metadata map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ refreshed, since completion, hover and arity checking are all driven by it.
   the forms after the name for the first vector *anywhere* below them, so the one inside `:see-also` ended the search:
   those parameters were not highlighted as parameters, did not resolve, could not be renamed, and were invisible to
   inlay hints. The reverse case is fixed too — a vector in the body, as in `(defn f [p] [x])`, was being treated as a
-  second parameter list (#254).
+  second parameter list (#255).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ refreshed, since completion, hover and arity checking are all driven by it.
   structure view and Find Usages instead of showing as an anonymous "symbol" (#254).
 - Completion is suppressed where only a binding or parameter vector can follow — `(let …)`, `(fn …)` — rather than
   offering the whole standard library (#254).
+- Parameters of a `defn` documented with a metadata map containing a vector — `{:see-also ["assoc"]}`, the convention
+  used throughout the Phel standard library — are recognised again. The parameter vector was searched for by scanning
+  the forms after the name for the first vector *anywhere* below them, so the one inside `:see-also` ended the search:
+  those parameters were not highlighted as parameters, did not resolve, could not be renamed, and were invisible to
+  inlay hints. The reverse case is fixed too — a vector in the body, as in `(defn f [p] [x])`, was being treated as a
+  second parameter list (#254).
 
 ### Changed
 

--- a/src/main/kotlin/org/phellang/language/psi/analysis/PhelFormWalker.kt
+++ b/src/main/kotlin/org/phellang/language/psi/analysis/PhelFormWalker.kt
@@ -39,6 +39,16 @@ internal object PhelFormWalker {
         else -> PsiTreeUtil.findChildOfType(element, PhelVec::class.java)
     }
 
+    /**
+     * True when [element] is a [T] or is the form wrapper directly around one.
+     *
+     * Direct children only, unlike [vectorOf]. Searching descendants makes a metadata map look like
+     * whatever it happens to contain: `{:see-also ["a" "b"]}` reads as a vector, which is how the
+     * parameter vector of a documented `defn` came to be misidentified.
+     */
+    inline fun <reified T : PsiElement> isOrDirectlyWraps(element: PsiElement): Boolean =
+        element is T || element.children.any { it is T }
+
     /** True when [candidate] either IS [target] or is the form wrapper around it. */
     fun isSameOrWrapperOf(candidate: PsiElement?, target: PhelVec): Boolean =
         candidate === target || candidate === target.parent

--- a/src/main/kotlin/org/phellang/language/psi/analysis/PhelParameterAnalyzer.kt
+++ b/src/main/kotlin/org/phellang/language/psi/analysis/PhelParameterAnalyzer.kt
@@ -3,6 +3,9 @@ package org.phellang.language.psi.analysis
 import com.intellij.openapi.util.Key
 import com.intellij.psi.util.CachedValue
 import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.PsiElement
+import org.phellang.language.psi.PhelLiteral
+import org.phellang.language.psi.PhelMap
 import org.phellang.language.psi.PhelForm
 import org.phellang.language.psi.PhelList
 import org.phellang.language.psi.PhelSpecialForms
@@ -45,11 +48,20 @@ internal object PhelParameterAnalyzer {
         return when (functionType) {
             "fn" -> children.getOrNull(1)?.let(PhelFormWalker::vectorOf)
             "defn", "defn-", "defmacro", "defmacro-" ->
-                children.drop(2).firstNotNullOfOrNull(PhelFormWalker::vectorOf)
+                children.drop(2).firstOrNull { !isSignaturePrelude(it) }?.let(PhelFormWalker::vectorOf)
 
             else -> null
         }
     }
+
+    /**
+     * A docstring or a metadata map may sit between the name and the parameter vector; nothing else
+     * may. Skipping them explicitly is what keeps a vector *inside* the metadata — Phel's standard
+     * library writes `{:see-also ["update-in" "assoc"]}` on most of its definitions — from being
+     * taken for the parameter vector, or from ending the search before the real one is reached.
+     */
+    private fun isSignaturePrelude(form: PsiElement): Boolean =
+        PhelFormWalker.isOrDirectlyWraps<PhelLiteral>(form) || PhelFormWalker.isOrDirectlyWraps<PhelMap>(form)
 
     /** Names bound by every arity of [functionList]. Cached: highlighting asks once per symbol. */
     private fun parameterNamesOf(functionList: PhelList): Set<String> =
@@ -110,16 +122,22 @@ internal object PhelParameterAnalyzer {
     }
 
     /**
-     * The parameter vector of a `defn` is the *first* vector after the name. Meeting a different
-     * vector first means [targetVec] lives in the body, not the signature.
+     * The parameter vector of a `defn` is the first form after the name that is not a docstring or a
+     * metadata map. Anything else standing there means [targetVec] lives in the body.
+     *
+     * This used to bail on meeting *any* vector among the descendants of an earlier form, so the
+     * `["update-in" "assoc"]` inside a `{:see-also ...}` map ended the search and the parameters of
+     * every documented `defn` in the standard library went unrecognised — unhighlighted, unresolved
+     * and unrenameable.
      */
     private fun isDefnParameterVector(forms: Array<PhelForm>, targetVec: PhelVec): Boolean {
         for (form in forms.drop(2)) {
             if (PhelFormWalker.isSameOrWrapperOf(form, targetVec)) return true
+            if (isSignaturePrelude(form)) continue
 
-            val other = PsiTreeUtil.findChildOfType(form, PhelVec::class.java)
-            if (other != null && other !== targetVec) return false
+            return false
         }
+
         return false
     }
 }

--- a/src/test/kotlin/org/phellang/integration/psi/PhelParameterVectorTest.kt
+++ b/src/test/kotlin/org/phellang/integration/psi/PhelParameterVectorTest.kt
@@ -1,0 +1,79 @@
+package org.phellang.integration.psi
+
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.integration.PhelIntegrationTestCase
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.analysis.PhelSymbolAnalyzer
+
+/**
+ * Locating a `defn`'s parameter vector past its docstring and metadata.
+ *
+ * Phel's standard library documents almost every definition with
+ * `{:example "..." :see-also ["a" "b"]}`. The search used to stop at the first vector found anywhere
+ * below an earlier form, so the vector inside `:see-also` ended it and the real parameters were never
+ * seen — they were not highlighted as parameters, did not resolve, and could not be renamed, in most
+ * of the standard library and in any project following the same convention.
+ */
+class PhelParameterVectorTest : PhelIntegrationTestCase() {
+
+    private var fileIndex = 0
+
+    /** Whether the last occurrence of [name] is recognised as a local binding or a reference to one. */
+    private fun isLocal(source: String, name: String): Boolean {
+        myFixture.configureByText("pv${fileIndex++}.phel", "(ns my\\app)\n$source")
+
+        val offset = myFixture.file.text.lastIndexOf(name)
+        val symbol = PsiTreeUtil.findElementOfClassAtOffset(myFixture.file, offset, PhelSymbol::class.java, false)
+
+        return symbol != null && PhelSymbolAnalyzer.isLocalBindingOrReference(symbol)
+    }
+
+    private fun assertParameter(source: String, name: String) =
+        assertTrue("`$name` should be a parameter in:\n$source", isLocal(source, name))
+
+    private fun assertNotParameter(source: String, name: String) =
+        assertFalse("`$name` should NOT be a parameter in:\n$source", isLocal(source, name))
+
+    fun testPlainDefn() = assertParameter("(defn f [p] (println p))", "p")
+
+    fun testDocstringBeforeTheVector() = assertParameter("(defn f \"doc\" [p] (println p))", "p")
+
+    fun testMetadataMapBeforeTheVector() =
+        assertParameter("(defn f \"doc\" {:example \"e\"} [p] (println p))", "p")
+
+    /** The shape that was broken: a vector nested inside the metadata map. */
+    fun testMetadataMapContainingAVector() =
+        assertParameter("(defn f \"doc\" {:see-also [\"a\" \"b\"]} [p] (println p))", "p")
+
+    fun testVerbatimStandardLibraryShape() {
+        val source = """
+            (defn update
+              "Updates a value in a datastructure by applying `f` to the current value."
+              {:example "(update {:count 5} :count inc)"
+               :see-also ["update-in" "assoc"]}
+              [ds k f & args]
+              (assoc ds k (apply f (get ds k) args)))
+        """.trimIndent()
+
+        assertParameter(source, "ds")
+        assertParameter(source, "args")
+    }
+
+    fun testVariadicNameAfterAmpersandIsAParameter() =
+        assertParameter("(defn f \"doc\" {:see-also [\"x\"]} [& rest] (println rest))", "rest")
+
+    /** A vector in the body is a literal, not a parameter list — the guard that made this fiddly. */
+    fun testVectorInTheBodyIsNotAParameterVector() =
+        assertNotParameter("(defn f [] (println [not-a-param]))", "not-a-param")
+
+    fun testSecondVectorAfterTheParametersIsNotAParameterVector() =
+        assertNotParameter("(defn f [p] [also-not-a-param])", "also-not-a-param")
+
+    fun testMultiArityStillResolves() {
+        val source = "(defn f \"doc\" {:see-also [\"x\"]} ([a] a) ([a b] (+ a b)))"
+
+        assertParameter(source, "b")
+    }
+
+    fun testFnIsUnaffected() = assertParameter("(defn g [] (fn [p] (println p)))", "p")
+}


### PR DESCRIPTION
Follow-up to #254, which merged before this could be added to it.

## The bug

Locating a `defn`'s parameter vector scanned the forms after the name and stopped at the first
vector found *anywhere below* one of them. Phel's standard library documents nearly every definition
like this:

```phel
(defn update
  "Updates a value in a datastructure by applying `f` to the current value."
  {:example "(update {:count 5} :count inc)"
   :see-also ["update-in" "assoc"]}     ;; <- a vector, inside the metadata map
  [ds k f & args]
  (assoc ds k (apply f (get ds k) args)))
```

The vector inside `:see-also` ended the search, so `[ds k f & args]` was never recognised.

`isFunctionParameter` feeds `isDefinition` and `isLocalBindingOrReference`, which most of the
analysis stands on — so in any file following that convention the parameters were **not highlighted
as parameters, did not resolve, could not be renamed, and were invisible to inlay hints**.

`findParameterVector` had the same fault through `vectorOf`'s descendant search, and would have
returned `["update-in" "assoc"]` as the parameter list itself.

## The fix

Both now skip only the two forms allowed to precede the parameter vector — a docstring and a
metadata map — and treat anything else as proof the target vector lives in the body.

That also fixes the opposite error, which I was not looking for: the old scan accepted a *second*
vector, so `(defn f [p] [x])` bound `x` as a parameter.

## Evidence

Measured by running a symbol-resolution pass over all 62 files / 17,542 lines of
`phel-lang/src/phel`:

| | reports |
|---|---|
| before | 1707 |
| after | 851 |

Four of the ten new tests fail against the previous behaviour, including `testVerbatimStandardLibraryShape`,
which is `phel\core`'s `update` copied verbatim. The other six pass both before and after, pinning
that plain `defn`, docstrings, metadata without a vector, multi-arity and `fn` were never broken and
still are not.

## Test plan

- [x] `./gradlew build --rerun-tasks` green on top of merged `main`
- [x] New tests verified failing on the previous behaviour and passing after
- [x] Negative cases pinned: a vector in the body, and a second vector after the parameters, are not
      parameter vectors

https://claude.ai/code/session_01NXHErTmpWYSar12eDpLXAy
