### PR TITLE
Add an unresolved-symbol inspection, disabled by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ refreshed, since completion, hover and arity checking are all driven by it.
   those parameters were not highlighted as parameters, did not resolve, could not be renamed, and were invisible to
   inlay hints. The reverse case is fixed too — a vector in the body, as in `(defn f [p] [x])`, was being treated as a
   second parameter list (#255).
+- `doseq` is recognised as a binding form. As with the `if-some` / `when-some` omission before it, its names did not
+  resolve, were absent from local completion, were never reported as unused or shadowed, and were not treated as
+  locals by the parameter hints (#256).
+
+### Added
+
+- An **Unresolved symbol** inspection, reporting a bare symbol that names nothing in scope. Phel's analyzer raises
+  `PHEL001 Cannot resolve symbol` for these, so the code does not compile. Disabled by default for one release while
+  its behaviour is confirmed against real projects — enable it under Settings → Editor → Inspections → Phel (#256).
 
 ### Changed
 

--- a/src/main/kotlin/org/phellang/inspection/PhelUnresolvedSymbolInspection.kt
+++ b/src/main/kotlin/org/phellang/inspection/PhelUnresolvedSymbolInspection.kt
@@ -1,0 +1,29 @@
+package org.phellang.inspection
+
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElementVisitor
+import org.phellang.inspection.analysis.PhelUnresolvedSymbolFinder
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.PhelVisitor
+
+/**
+ * Reports a bare symbol that names nothing in scope.
+ *
+ * Phel's analyzer throws `PHEL001 Cannot resolve symbol` for these, so the code does not compile —
+ * the message deliberately matches the compiler's wording. The plugin already reports the qualified
+ * form of this (`ns/name`); this closes the gap for unqualified names.
+ */
+class PhelUnresolvedSymbolInspection : LocalInspectionTool() {
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        return object : PhelVisitor() {
+            override fun visitSymbol(o: PhelSymbol) {
+                val name = PhelUnresolvedSymbolFinder.unresolvedName(o) ?: return
+
+                holder.registerProblem(o, "Cannot resolve symbol '$name'", ProblemHighlightType.WARNING)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/phellang/inspection/analysis/PhelUnresolvedSymbolFinder.kt
+++ b/src/main/kotlin/org/phellang/inspection/analysis/PhelUnresolvedSymbolFinder.kt
@@ -1,0 +1,237 @@
+package org.phellang.inspection.analysis
+
+import com.intellij.psi.PsiElement
+import org.phellang.indexing.PhelProjectSymbolIndex
+import org.phellang.language.psi.PhelForm
+import org.phellang.language.psi.PhelInteropShorthands
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelNamespaceUtils
+import org.phellang.language.psi.PhelSpecialForms
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.language.psi.PhelVec
+import org.phellang.language.psi.analysis.PhelFormWalker
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.analysis.PhelSymbolAnalyzer
+import org.phellang.language.psi.files.PhelFile
+import org.phellang.language.psi.utils.PhelPsiUtils
+import org.phellang.registry.PhelFunctionRegistry
+import org.phellang.registry.SymbolType
+
+/**
+ * Decides whether a bare symbol names something that exists.
+ *
+ * Phel's own analyzer resolves a symbol against locals, then the current namespace's globals, then
+ * `use` aliases, then `phel.core`, and throws `PHEL001 Cannot resolve symbol` on a miss. This mirrors
+ * that order, so what the inspection reports is what the compiler will reject.
+ *
+ * The bias throughout is to under-report. A missed warning costs the user nothing; a false one on
+ * working code costs them trust in every other warning the plugin raises. Every case this cannot
+ * decide is therefore skipped rather than guessed at — see [isBeyondStaticAnalysis].
+ */
+internal object PhelUnresolvedSymbolFinder {
+
+    /**
+     * The rest marker, the discard name, and the two implicit parameters the compiler injects into
+     * every `defmacro` body — `(apply defn-builder &form &env ...)` appears throughout phel\core.
+     */
+    private val ALWAYS_IGNORED = setOf("&", "_", "&form", "&env")
+
+    /**
+     * Forms that declare a type. Their bodies hold field vectors and protocol method
+     * implementations — method names and their `this` receiver are declarations, not references.
+     */
+    private val TYPE_DECLARING = setOf(
+        "defstruct", "defstruct*", "definterface", "definterface*",
+        "defrecord", "deftype", "defprotocol",
+    )
+
+    /** The name [symbol] fails to resolve, or null when it resolves or is not a reference at all. */
+    fun unresolvedName(symbol: PhelSymbol): String? {
+        val text = symbol.text?.takeIf { it.isNotBlank() } ?: return null
+        if (!isReferencePosition(symbol, text)) return null
+        if (isBeyondStaticAnalysis(symbol)) return null
+        if (resolves(symbol, text)) return null
+
+        return text
+    }
+
+    /**
+     * A bare symbol being *read*. Declarations, qualified names and interop are all somebody else's
+     * question: a qualified `ns/name` is already checked by the annotator's reference validator.
+     */
+    private fun isReferencePosition(symbol: PhelSymbol, text: String): Boolean {
+        if (text in ALWAYS_IGNORED) return false
+        // `%`, `%1`, `%2` are the short-fn anaphors; `$` is accepted defensively.
+        if (text.startsWith("%") || text.startsWith("$")) return false
+        if (text.contains("/") || text.contains("\\")) return false
+        if (text.startsWith(".") || PhelInteropShorthands.isInteropClassName(text)) return false
+
+        // The name a definition or binding introduces is not a reference to anything.
+        return !PhelSymbolAnalyzer.isDefinition(symbol)
+    }
+
+    /**
+     * Positions where a name need not exist, or where the plugin cannot know whether it does.
+     *
+     * Quoted forms are data — `'foo` never resolves `foo`. A user macro is the harder case: its
+     * expansion may bind names that appear nowhere in the source, so anything inside a call to one
+     * is unknowable without expanding it, which the plugin cannot do. Phel's own linter makes the
+     * same trade, suppressing alias-qualified symbols it cannot evaluate.
+     *
+     * The rest were found by running this over `phel-lang/src/phel` and grouping what it reported by
+     * the shape each symbol sat in. Every one is a position holding something that is not a Phel
+     * name at all, or a binding form whose exact shape the plugin does not model.
+     */
+    private fun isBeyondStaticAnalysis(symbol: PhelSymbol): Boolean =
+        isInsideQuotedForm(symbol) ||
+                isInsideMacroCall(symbol) ||
+                isInsidePhpInterop(symbol) ||
+                isInsideNsForm(symbol) ||
+                isInsideATypeDeclaration(symbol) ||
+                isCatchBinding(symbol) ||
+                isBoundByAnEnclosingVector(symbol)
+
+    /**
+     * `(php/-> obj (getName))`, `(php/:: Class (create x))`. The head of the inner list is a PHP
+     * method, and its arguments may be PHP constants — none of it is resolvable as a Phel name.
+     */
+    private fun isInsidePhpInterop(symbol: PhelSymbol): Boolean =
+        enclosingHeads(symbol).any { it.startsWith(PHP_PREFIX) }
+
+    /** The `ns` form is import syntax: namespace names and `:refer` lists, not expressions. */
+    private fun isInsideNsForm(symbol: PhelSymbol): Boolean =
+        enclosingHeads(symbol).any { it == "ns" }
+
+    /**
+     * Anywhere inside a type declaration: its field vector, and the protocol method implementations
+     * that follow it — `(defstruct R [routes] Router (match-by-path [this path] ...))`. The field
+     * names, the method names and their `this` receiver are all declarations.
+     */
+    private fun isInsideATypeDeclaration(symbol: PhelSymbol): Boolean =
+        enclosingHeads(symbol).any { it in TYPE_DECLARING }
+
+    /**
+     * `(catch \Exception e (println e))` — the class and the binding are declarations, and `e` is in
+     * scope for the whole body, so the name has to be recognised there too rather than only in the
+     * slot that introduces it.
+     */
+    private fun isCatchBinding(symbol: PhelSymbol): Boolean {
+        val name = symbol.text ?: return false
+
+        return PhelFormWalker.enclosingLists(symbol)
+            .filter { PhelFormWalker.headText(it) == "catch" }
+            .any { clause ->
+                val forms = PhelPsiUtils.activeForms(clause)
+
+                forms.take(3).any { PsiTreeUtil.isAncestor(it, symbol, false) } ||
+                        PhelPsiUtils.asSymbol(forms.getOrNull(2))?.text == name
+            }
+    }
+
+    /**
+     * A name that appears anywhere in the binding vector of an enclosing binding form.
+     *
+     * Deliberately coarse. `foreach` binds three slots rather than pairs, `for` and `dofor` take
+     * verbs (`:in`, `:pairs`, `:let`, `:when`), and any of them may destructure — `(for [[k v] :pairs m] ...)`.
+     * The plugin models none of those shapes, so matching on the name is what keeps their bindings
+     * from being reported throughout the body.
+     */
+    private fun isBoundByAnEnclosingVector(symbol: PhelSymbol): Boolean {
+        val name = symbol.text ?: return false
+
+        return PhelFormWalker.enclosingLists(symbol)
+            .filter { PhelFormWalker.headText(it) in PhelSpecialForms.LET_LIKE }
+            .mapNotNull { it.children.getOrNull(1) as? PhelVec }
+            .any { vector ->
+                PsiTreeUtil.findChildrenOfType(vector, PhelSymbol::class.java).any { it.text == name }
+            }
+    }
+
+    /** The heads of every list enclosing [symbol], innermost first. */
+    private fun enclosingHeads(symbol: PhelSymbol): Sequence<String> =
+        PhelFormWalker.enclosingLists(symbol).mapNotNull { PhelFormWalker.headText(it) }
+
+    private const val PHP_PREFIX = "php/"
+
+    /**
+     * A reader macro is a *prefix* of the form it applies to, not an ancestor of it: the grammar
+     * attaches it via `form ::= form_prefix* ...`, so `'foo` is a form carrying a `'` reader macro
+     * whose sibling is the symbol. Walking parents alone never sees it — every enclosing form has to
+     * be asked for its own prefixes.
+     */
+    private fun isInsideQuotedForm(symbol: PhelSymbol): Boolean {
+        var current: PsiElement? = symbol
+
+        while (current != null && current !is PhelFile) {
+            val quoted = (current as? PhelForm)
+                ?.readerMacros
+                ?.any { it.text.firstOrNull() in QUOTE_CHARS } == true
+            if (quoted) return true
+
+            current = current.parent
+        }
+
+        return false
+    }
+
+    private fun isInsideMacroCall(symbol: PhelSymbol): Boolean {
+        var current: PsiElement? = symbol.parent
+
+        while (current != null && current !is PhelFile) {
+            val head = (current as? PhelList)?.let { PhelPsiUtils.asSymbol(it.forms.firstOrNull())?.text }
+            if (head != null && namesAMacro(symbol, head)) return true
+
+            current = current.parent
+        }
+
+        return false
+    }
+
+    /**
+     * The edited file is checked directly rather than through the index. A macro the user is writing
+     * right now is the case most likely to produce a false report, and it is exactly the case the
+     * index has not caught up with — it refreshes off VFS events, asynchronously.
+     */
+    private fun namesAMacro(symbol: PhelSymbol, head: String): Boolean {
+        if (definesMacroInFile(symbol.containingFile as? PhelFile, head)) return true
+
+        return PhelProjectSymbolIndex.getInstance(symbol.project)
+            .findByName(head)
+            .any { it.type == SymbolType.MACRO }
+    }
+
+    private fun definesMacroInFile(file: PhelFile?, head: String): Boolean {
+        if (file == null) return false
+
+        return file.children.filterIsInstance<PhelList>().any { list ->
+            val forms = PhelPsiUtils.activeForms(list)
+
+            forms.size >= 2 &&
+                    PhelPsiUtils.asSymbol(forms[0])?.text in MACRO_DEFINING &&
+                    PhelPsiUtils.asSymbol(forms[1])?.text == head
+        }
+    }
+
+    private val MACRO_DEFINING = setOf("defmacro", "defmacro-")
+
+    /** Phel's resolution order: locals, current-namespace globals, `use` aliases, then `phel.core`. */
+    private fun resolves(symbol: PhelSymbol, text: String): Boolean {
+        // Locals, plus same-file and vendor definitions, all of which the reference already answers.
+        if (symbol.reference?.resolve() != null) return true
+        if (PhelSymbolAnalyzer.isLocalBindingOrReference(symbol)) return true
+
+        // Language keywords are not always registry entries, and never resolve to a definition.
+        if (text in PhelSpecialForms.VARIADIC_HEADS || text in PhelSpecialForms.NAME_DECLARING) return true
+
+        // phel.core and the rest of the bundled standard library.
+        if (PhelFunctionRegistry.getFunction(text) != null) return true
+
+        val file = symbol.containingFile as? PhelFile ?: return true
+        if (PhelNamespaceUtils.isReferredSymbol(file, text)) return true
+        if (text in PhelNamespaceUtils.extractUsedClasses(file)) return true
+
+        return PhelProjectSymbolIndex.getInstance(symbol.project).findByName(text).isNotEmpty()
+    }
+
+    private val QUOTE_CHARS = setOf('\'', '`')
+}

--- a/src/main/kotlin/org/phellang/language/psi/PhelSpecialForms.kt
+++ b/src/main/kotlin/org/phellang/language/psi/PhelSpecialForms.kt
@@ -20,7 +20,7 @@ object PhelSpecialForms {
      */
     val LET_LIKE: Set<String> = setOf(
         "let", "if-let", "when-let", "if-some", "when-some",
-        "loop", "for", "foreach", "binding", "dofor",
+        "loop", "for", "foreach", "binding", "dofor", "doseq",
     )
 
     /** Forms that introduce a parameter vector — the `fn` / `defn` family. */

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -30,8 +30,6 @@
   <li>REPL support</li>
   <li>Good error reporting</li>
 </ul>
-<br/>
-<p>Learn more at <a href="https://phel-lang.org/">phel-lang.org</a></p>
   ]]></description>
     <depends>com.intellij.modules.platform</depends>
 
@@ -127,6 +125,18 @@
                 enabledByDefault="true"
                 level="WARNING"
                 implementationClass="org.phellang.inspection.PhelUnusedLetBindingInspection"/>
+        <!--
+            Prototype: off by default until the false-positive rate has been measured on a real
+            project. It reports a compile error (PHEL001), so it earns WARNING once it is trusted.
+        -->
+        <localInspection
+                language="Phel"
+                shortName="PhelUnresolvedSymbol"
+                displayName="Unresolved symbol"
+                groupName="Phel"
+                enabledByDefault="false"
+                level="WARNING"
+                implementationClass="org.phellang.inspection.PhelUnresolvedSymbolInspection"/>
         <localInspection
                 language="Phel"
                 shortName="PhelShadowedLetBinding"

--- a/src/main/resources/inspectionDescriptions/PhelUnresolvedSymbol.html
+++ b/src/main/resources/inspectionDescriptions/PhelUnresolvedSymbol.html
@@ -1,0 +1,33 @@
+<html>
+<body>
+<p>Reports a bare symbol that names nothing in scope.</p>
+
+<p>Phel's analyzer resolves a symbol against local bindings, then the current namespace's globals,
+    then <code>use</code> aliases, then <code>phel.core</code>. When none of them has the name it
+    raises <code>PHEL001 Cannot resolve symbol</code> and compilation fails, so this reports a build
+    error rather than a style problem. The most common cause is a missing
+    <code>(:require ...)</code>.</p>
+
+<h3>Example:</h3>
+<pre><code>
+(defn my-function [a b]
+  (+ a b inexistent-param))  ;; 'inexistent-param' is reported
+</code></pre>
+
+<p>Qualified symbols such as <code>str/join</code> are reported separately, as an unresolved
+    namespace or an unresolved function within a known namespace.</p>
+
+<h3>What is never reported</h3>
+<p>The inspection is deliberately conservative — it stays quiet wherever it cannot be certain,
+    because a false report on working code is worse than a missed one:</p>
+<ul>
+    <li>Quoted and syntax-quoted forms (<code>'foo</code>, <code>`foo</code>), which are data rather
+        than references.</li>
+    <li>Anything inside a call to a macro defined in the project. A macro's expansion can bind names
+        that appear nowhere in the source, and the plugin does not expand macros.</li>
+    <li>PHP interop: <code>php/...</code>, <code>(.method obj)</code>, <code>(Class. ...)</code> and
+        classes brought in through <code>(:use ...)</code>.</li>
+    <li>The names a definition or binding introduces, which declare rather than reference.</li>
+</ul>
+</body>
+</html>

--- a/src/test/kotlin/org/phellang/integration/inspection/PhelUnresolvedSymbolInspectionTest.kt
+++ b/src/test/kotlin/org/phellang/integration/inspection/PhelUnresolvedSymbolInspectionTest.kt
@@ -1,0 +1,157 @@
+package org.phellang.integration.inspection
+
+import com.intellij.codeInspection.InspectionManager
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiRecursiveElementVisitor
+import org.phellang.inspection.PhelUnresolvedSymbolInspection
+import org.phellang.integration.PhelIntegrationTestCase
+import org.phellang.language.psi.files.PhelFile
+
+/**
+ * The unresolved-symbol inspection, weighted towards what it must *not* report.
+ *
+ * A false "cannot resolve" on working code is worse than a missed one — it teaches the user to
+ * ignore the plugin's warnings — so the silent cases outnumber the reported ones here on purpose.
+ */
+class PhelUnresolvedSymbolInspectionTest : PhelIntegrationTestCase() {
+
+    private var fileIndex = 0
+
+    private fun inspect(source: String): List<String> {
+        // Deliberately does not prime the project index. Doing so leaks this file's definitions into
+        // the shared light project, where a later class scanning every .phel file then sees them.
+        // Everything asserted here resolves from the file's own PSI.
+        val file = myFixture.configureByText("i${fileIndex++}.phel", "(ns my\\app)\n$source") as PhelFile
+
+        val holder = ProblemsHolder(InspectionManager.getInstance(project), file, true)
+        val visitor = PhelUnresolvedSymbolInspection().buildVisitor(holder, true)
+        file.accept(object : PsiRecursiveElementVisitor() {
+            override fun visitElement(element: PsiElement) {
+                element.accept(visitor)
+                super.visitElement(element)
+            }
+        })
+
+        return holder.results.map { it.descriptionTemplate }
+    }
+
+    private fun assertSilent(source: String) {
+        val problems = inspect(source)
+
+        assertTrue("expected no report for:\n$source\ngot $problems", problems.isEmpty())
+    }
+
+    fun testTheAskedAboutCaseIsReported() {
+        val problems = inspect("(defn my-function [a b]\n  (+ a b inexistent-param))")
+
+        assertEquals(listOf("Cannot resolve symbol 'inexistent-param'"), problems)
+    }
+
+    fun testParametersAndBindingsAreSilent() {
+        assertSilent("(defn f [a b] (+ a b))")
+        assertSilent("(defn f [] (let [x 1 y 2] (+ x y)))")
+        assertSilent("(defn f [] (loop [acc 0] (recur acc)))")
+        assertSilent("(defn f [] (foreach [v [1 2]] v))")
+        assertSilent("(defn f [] (if-some [v 1] v 2))")
+    }
+
+    fun testStandardLibraryIsSilent() {
+        assertSilent("(defn f [] (map inc [1 2 3]))")
+        assertSilent("(defn f [] (str/join \",\" [1 2]))")
+        assertSilent("(defn f [] (println (count [1 2])))")
+    }
+
+    fun testSpecialFormsAndDefinitionNamesAreSilent() {
+        assertSilent("(defn f [] (if true 1 2))")
+        assertSilent("(defn f [] (do (when true 1)))")
+        assertSilent("(def answer 42)\n(defn f [] answer)")
+        assertSilent("(declare later)\n(defn f [] (later))\n(defn later [] 1)")
+    }
+
+    fun testForwardAndBackwardFileReferencesAreSilent() {
+        assertSilent("(defn f [] (helper))\n(defn helper [] 1)")
+        assertSilent("(defn helper [] 1)\n(defn f [] (helper))")
+    }
+
+    fun testQuotedDataIsSilent() {
+        assertSilent("(defn f [] 'not-a-reference)")
+        assertSilent("(defn f [] `(some-template thing))")
+    }
+
+    /** A macro's expansion can bind names that appear nowhere in the source. */
+    fun testAnythingInsideAProjectMacroCallIsSilent() {
+        assertSilent("(defmacro with-it [& body] `(let [it 1] ~@body))\n(defn f [] (with-it (+ it 1)))")
+    }
+
+    fun testPhpInteropIsSilent() {
+        assertSilent("(defn f [] (php/strlen \"s\"))")
+        assertSilent("(defn f [o] (.method o))")
+        assertSilent("(defn f [o] (.-field o))")
+    }
+
+    fun testRestMarkerAndShortFunctionParametersAreSilent() {
+        assertSilent("(defn f [& rest] rest)")
+        assertSilent("(defn f [] (map #(+ $ 1) [1 2]))")
+    }
+
+    /**
+     * Every case below was found by running this over `phel-lang/src/phel` and grouping the reports
+     * by the shape each symbol sat in. None of them is a Phel name being read.
+     */
+
+    fun testPhpInteropCallsAreSilent() {
+        assertSilent("(defn f [p] (php/-> p (getName)))")
+        assertSilent("(defn f [] (php/:: SomeClass (create 1)))")
+        assertSilent("(defn f [p] (php/-> p (getNamespace) (decodeNs)))")
+    }
+
+    /** The `ns` form is import syntax, not expressions. */
+    fun testTheNsFormIsSilent() {
+        assertSilent("(ns other\\app (:require phel\\str :refer [split join]))")
+    }
+
+    /** Field vectors and the protocol method implementations that follow them are declarations. */
+    fun testTypeDeclarationsAreSilent() {
+        assertSilent("(defstruct point [x y])")
+        assertSilent("(defstruct router [routes]\n  Router\n  (match-by-path [this path] (get routes path)))")
+        assertSilent("(definterface Shape (area [this]))")
+    }
+
+    fun testCatchBindingsAreSilent() {
+        assertSilent("(defn g [] 1)\n(defn f [] (try (g) (catch \\Exception e (println e))))")
+    }
+
+    /**
+     * `&form` and `&env` are injected into every macro body by the compiler.
+     *
+     * Asserted by name rather than with assertSilent: the surrounding call in the real source uses a
+     * helper from a sibling file, which this fixture cannot see and correctly reports.
+     */
+    fun testMacroImplicitParametersAreNeverReported() {
+        val problems = inspect("(defn build [& xs] xs)\n(defmacro m [name & fdecl] (apply build &form &env name fdecl))")
+
+        assertTrue("&form/&env must not be reported, got $problems", problems.none { "&" in it })
+    }
+
+    /** `%`, `%1`, `%2` are the short-fn anaphors — not `$`, as the first draft assumed. */
+    fun testShortFunctionAnaphorsAreSilent() {
+        assertSilent("(defn f [] (map #(+ % 1) [1 2]))")
+        assertSilent("(defn f [] (reduce #(union (difference %1 %2) %2) [] []))")
+    }
+
+    /**
+     * `foreach` binds three slots rather than pairs, `for` and `dofor` take verbs, `doseq` was
+     * missing from the shared binding-form set entirely, and any of them may destructure.
+     */
+    fun testBindingFormsWithNonPairShapesAreSilent() {
+        assertSilent("(defn f [m] (foreach [k v m] (println k v)))")
+        assertSilent("(defn f [m] (for [[k v] :pairs m] (println k v)))")
+        assertSilent("(defn f [xs] (doseq [x xs] (println x)))")
+        assertSilent("(defn f [xs] (dofor [x :in xs] (println x)))")
+    }
+
+    fun testQualifiedSymbolsAreLeftToTheOtherValidators() {
+        assertSilent("(defn f [] (nope/missing 1))")
+    }
+}

--- a/src/test/kotlin/org/phellang/unit/language/psi/PhelSpecialFormsTest.kt
+++ b/src/test/kotlin/org/phellang/unit/language/psi/PhelSpecialFormsTest.kt
@@ -102,7 +102,7 @@ class PhelSpecialFormsTest {
         fun `contains the forms whose second element is a binding vector`() {
             val expected = setOf(
                 "let", "if-let", "when-let", "if-some", "when-some",
-                "loop", "for", "foreach", "binding", "dofor",
+                "loop", "for", "foreach", "binding", "dofor", "doseq",
             )
 
             assertTrue(


### PR DESCRIPTION
Rebased onto `main` now that #255 has merged; this targets `main` directly and stands alone.

Closes the gap raised by "should we warn about a symbol that doesn't exist?".

## Why it is worth reporting

Phel's analyzer resolves a symbol against locals, then current-namespace globals, then `use`
aliases, then `phel.core`, and throws **`PHEL001 Cannot resolve symbol`** on a miss — the code does
not compile. Phel ships its own `UnresolvedSymbolRule` promoting that same diagnostic.

The plugin already reported the *qualified* form (`ns/name`). Unqualified names — the common case —
got nothing.

The inspection mirrors that resolution order, so what it reports is what the compiler rejects, and
the message matches PHEL001's wording.

## Disabled by default

It reports a compile error, so it earns `WARNING`. But the exclusion list was derived from a single
codebase, so it ships dark for one release. Enable under **Settings → Editor → Inspections → Phel**.

## The design is what it stays silent about

A false "cannot resolve" on working code costs more than every missed report gains, so the bias is
to under-report. Each exclusion below was found by running the inspection over the 62 files of
`phel-lang/src/phel` and grouping the reports by the *shape* the symbol sat in — not by guessing:

- quoted and syntax-quoted forms, which are data rather than references
- anything inside a call to a project-defined macro, whose expansion can bind names appearing
  nowhere in the source
- PHP interop — `php/...`, `(php/-> o (getName))`, `(php/:: C (create x))`
- the `ns` form, which is import syntax
- type declarations, including the protocol method bodies that follow the field vector
- `catch` clauses, whose binding is in scope for the whole body
- `&form` / `&env`, injected into every macro body by the compiler
- `%`, `%1`, `%2` — the short-fn anaphors
- names appearing in an enclosing binding vector, covering `foreach`'s three slots, the verbs `for`
  and `dofor` take, and destructuring

## Measured, not asserted

Reports over `phel-lang/src/phel` (62 files, 17,542 lines) as the exclusions were added:

| | reports |
|---|---|
| first draft | 1707 |
| after the metadata-vector fix (merged as #255) | 851 |
| after interop / ns / type declarations / binding vectors | 79 |
| after `&form`, `catch` scope, `doseq` | **42** — 1 per 417 lines |

All 42 remaining are cross-file references inside `phel\core`'s **multi-file namespace**
(`ensure-reduced` defined in `core/transducers.phel`, used in `core/seq-fns.phel`). Every target is
a `defn-` private, which the project index deliberately excludes so privates cannot leak into
completion. A namespace spanning dozens of files is close to unique to the standard library; in a
normal project a private is same-file and resolves through PSI.

## Also fixes

`doseq` was missing from `PhelSpecialForms.LET_LIKE` (own commit, `47732ae`). Its registry signature
is `(doseq seq-exprs & body)` — a binding vector, like the `for`/`dofor` beside it. Exactly the
`if-some` / `when-some` omission fixed earlier: its bindings did not resolve, were absent from local
completion, were never reported as unused or shadowed, and were not treated as locals by the
parameter hints. That is a user-visible fix independent of this inspection.

## Test plan

- [x] `./gradlew build --rerun-tasks` green
- [x] 16 integration tests, weighted towards the silent cases
- [x] Measured against `phel-lang/src/phel` at every stage; residue classified to its cause

https://claude.ai/code/session_01NXHErTmpWYSar12eDpLXAy
