### PR TITLE
Run phel fmt with the login shell's environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ refreshed, since completion, hover and arity checking are all driven by it.
 
 ### Fixed
 
+- Reformat Code no longer fails with `env: php: No such file or directory`. `vendor/bin/phel` starts
+  `#!/usr/bin/env php`, and an IDE launched from Dock, Spotlight or Finder on macOS hands its child processes
+  `PATH=/usr/bin:/bin:/usr/sbin:/sbin` — where a PHP installed by Homebrew, Herd, asdf or mise does not appear. The
+  formatter now runs with the login shell's environment. Formatting also gains a 30-second timeout, so a hung `phel`
+  can no longer block the editor (#257).
 - Completion no longer goes silent in ordinary expression positions: the body of a `do`, `try`, `catch`, `finally` or
   `quote`, the exception slot of a `throw`, `recur` arguments, and the value half of a binding — `(let [x …] …)`,
   `(loop [acc …] …)` — all offer completions again (#254).

--- a/src/main/kotlin/org/phellang/editor/format/PhelExternalFormatter.kt
+++ b/src/main/kotlin/org/phellang/editor/format/PhelExternalFormatter.kt
@@ -7,6 +7,7 @@ import com.intellij.psi.PsiFile
 import org.phellang.language.psi.files.PhelFile
 import java.io.File
 import java.util.EnumSet
+import java.util.concurrent.TimeUnit
 
 class PhelExternalFormatter : AsyncDocumentFormattingService() {
 
@@ -49,22 +50,24 @@ class PhelExternalFormatter : AsyncDocumentFormattingService() {
 
         override fun run() {
             val workFile = File.createTempFile("phel-fmt-", ".phel")
+            val outputFile = File.createTempFile("phel-fmt-out-", ".log")
             try {
                 workFile.writeText(request.documentText)
 
-                val started = ProcessBuilder(binary.absolutePath, "fmt", workFile.absolutePath)
-                    .directory(workingDir)
-                    .redirectErrorStream(true)
-                    .start()
+                val started = PhelFormatterProcess.command(binary, workFile, workingDir, outputFile).start()
                 process = started
 
-                val output = started.inputStream.bufferedReader().use { it.readText() }
-                val exitCode = started.waitFor()
+                if (!started.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                    started.destroyForcibly()
+                    request.onError(NOTIFICATION_TITLE, "phel fmt did not finish within $TIMEOUT_SECONDS seconds")
+                    return
+                }
 
-                if (exitCode != 0) {
+                val output = outputFile.readText().trim()
+                if (started.exitValue() != 0) {
                     request.onError(
                         NOTIFICATION_TITLE,
-                        output.ifBlank { "phel fmt exited with code $exitCode" }
+                        output.ifBlank { "phel fmt exited with code ${started.exitValue()}" }
                     )
                     return
                 }
@@ -74,6 +77,7 @@ class PhelExternalFormatter : AsyncDocumentFormattingService() {
                 request.onError(NOTIFICATION_TITLE, e.message ?: e.javaClass.simpleName)
             } finally {
                 workFile.delete()
+                outputFile.delete()
             }
         }
 
@@ -88,5 +92,8 @@ class PhelExternalFormatter : AsyncDocumentFormattingService() {
     private companion object {
         const val NOTIFICATION_GROUP_ID = "Phel"
         const val NOTIFICATION_TITLE = "Phel formatter"
+
+        /** Generous for a formatter, but bounded: a hung process must not block the editor forever. */
+        const val TIMEOUT_SECONDS = 30L
     }
 }

--- a/src/main/kotlin/org/phellang/editor/format/PhelFormatterProcess.kt
+++ b/src/main/kotlin/org/phellang/editor/format/PhelFormatterProcess.kt
@@ -1,0 +1,35 @@
+package org.phellang.editor.format
+
+import com.intellij.util.EnvironmentUtil
+import java.io.File
+
+/** Builds the `phel fmt` invocation, with the environment it needs to actually run. */
+internal object PhelFormatterProcess {
+
+    /**
+     * `vendor/bin/phel` is a PHP script starting `#!/usr/bin/env php`, so running it needs `php` on
+     * the `PATH` of the *child* process.
+     *
+     * [ProcessBuilder] inherits the IDE's environment, and an IDE launched from Dock, Spotlight or
+     * Finder on macOS never sees the login shell's `PATH` — it gets `/usr/bin:/bin:/usr/sbin:/sbin`.
+     * A `php` installed by Homebrew, Herd, asdf or mise is on none of those, so the shebang failed
+     * with `env: php: No such file or directory` even though the binary itself was found and
+     * executable.
+     *
+     * [EnvironmentUtil.getEnvironmentMap] is the platform's answer to exactly this: it reads the
+     * environment from a login shell once and caches it. Everywhere else — Linux, Windows, or the
+     * IDE started from a terminal — it returns the inherited environment, so this is a no-op there.
+     */
+    fun command(binary: File, target: File, workingDir: File, output: File): ProcessBuilder {
+        val builder = ProcessBuilder(binary.absolutePath, "fmt", target.absolutePath)
+            .directory(workingDir)
+            .redirectErrorStream(true)
+            // To a file rather than a pipe: nothing reads the stream until the process is waited on,
+            // and a full pipe buffer would deadlock a chatty run against the timeout below.
+            .redirectOutput(output)
+
+        builder.environment().putAll(EnvironmentUtil.getEnvironmentMap())
+
+        return builder
+    }
+}

--- a/src/test/kotlin/org/phellang/integration/editor/PhelFormatterProcessTest.kt
+++ b/src/test/kotlin/org/phellang/integration/editor/PhelFormatterProcessTest.kt
@@ -1,0 +1,49 @@
+package org.phellang.integration.editor
+
+import com.intellij.util.EnvironmentUtil
+import org.phellang.editor.format.PhelFormatterProcess
+import org.phellang.integration.PhelIntegrationTestCase
+import java.io.File
+
+/**
+ * The formatter must run `phel` with the *shell's* environment, not the IDE's.
+ *
+ * `vendor/bin/phel` starts `#!/usr/bin/env php`, and an IDE launched from Dock or Spotlight on macOS
+ * hands its children `PATH=/usr/bin:/bin:/usr/sbin:/sbin` — where a Homebrew, Herd, asdf or mise
+ * `php` does not appear. Formatting failed with `env: php: No such file or directory` even though
+ * the binary was found and executable.
+ */
+class PhelFormatterProcessTest : PhelIntegrationTestCase() {
+
+    private val binary = File("/somewhere/vendor/bin/phel")
+    private val target = File("/tmp/target.phel")
+    private val workingDir = File("/somewhere")
+    private val output = File("/tmp/out.log")
+
+    fun testCarriesTheShellEnvironment() {
+        val environment = PhelFormatterProcess.command(binary, target, workingDir, output).environment()
+
+        val shell = EnvironmentUtil.getEnvironmentMap()
+        val missing = shell.filter { (key, value) -> environment[key] != value }
+
+        assertTrue("the shell environment must reach the child process, missing: ${missing.keys}", missing.isEmpty())
+    }
+
+    fun testInvokesFmtOnTheTargetFile() {
+        val command = PhelFormatterProcess.command(binary, target, workingDir, output).command()
+
+        assertEquals(listOf(binary.absolutePath, "fmt", target.absolutePath), command)
+    }
+
+    fun testRunsInTheProjectDirectory() {
+        assertEquals(workingDir, PhelFormatterProcess.command(binary, target, workingDir, output).directory())
+    }
+
+    /** To a file, not a pipe: nothing drains the stream before the wait, so a pipe could deadlock. */
+    fun testRedirectsOutputToAFileWithStderrMerged() {
+        val builder = PhelFormatterProcess.command(binary, target, workingDir, output)
+
+        assertEquals(output, builder.redirectOutput().file())
+        assertTrue(builder.redirectErrorStream())
+    }
+}


### PR DESCRIPTION
Reformat Code failed on macOS with:

```
Phel formatter
env: php: No such file or directory
```

## Root cause

Not the formatter, and not binary discovery — `vendor/bin/phel` was found and executable. The failure
is one level down.

`vendor/bin/phel` starts `#!/usr/bin/env php`, so running it needs `php` on the **child process's**
`PATH`. `ProcessBuilder` inherits the IDE's environment, and an IDE launched from Dock, Spotlight or
Finder on macOS never sees the login shell's `PATH` — it gets `/usr/bin:/bin:/usr/sbin:/sbin`. A PHP
installed by Homebrew, Herd, asdf or mise is on none of those, so the shebang resolved nothing and
the process exited **127**.

## Fix

`EnvironmentUtil.getEnvironmentMap()` is the platform's answer to exactly this: it reads a login
shell's environment once and caches it. On Linux, on Windows, and whenever the IDE is started from a
terminal, it returns the inherited environment — so this is a no-op everywhere the bug did not occur.

Two robustness gaps in the same method came with it, both reachable once a real process runs:

- **No timeout.** `waitFor()` was unbounded, so a hung `phel` blocked formatting indefinitely. Now 30
  seconds, after which the process is destroyed and the timeout is reported.
- **Pipe → temp file.** Nothing drained the output stream until the wait returned, so with a timeout
  in place a chatty run could fill the pipe buffer and deadlock.

## Verification

Measured at three levels.

**1. Shell** — reproduced the exact error under the PATH a GUI-launched IDE provides:

```
$ env -i PATH=/usr/bin:/bin:/usr/sbin:/sbin ./vendor/bin/phel fmt /tmp/x.phel
env: php: No such file or directory
$ ./vendor/bin/phel fmt /tmp/x.phel
Formatted files:  1) /tmp/x.phel
```

**2. The plugin's own invocation, against a real project** (`Chemaclass/phel-doom`), with a
deliberately stripped `PATH`:

| | exit | file reformatted | output |
|---|---|---|---|
| before | 127 | no | `env: php: No such file or directory` |
| after | 0 | **yes** | `Formatted files:` |

**3. Regression test** — `PhelFormatterProcessTest` pins the contract: the shell environment reaches
the child process, `fmt` is invoked on the target, the working directory is the project, and output
is redirected to a file with stderr merged. The phel-doom harness used for (2) was deliberately not
committed — it hardcoded a local path and would be meaningless on CI.

## Deliberately not included

Two related gaps, both new features rather than this bug:

- **A configurable interpreter path.** The one case `EnvironmentUtil` cannot rescue is PHP existing
  only inside Docker/DDEV, with no runnable local binary at all.
- **Searching upward from the edited file** for `vendor/bin/phel`, for monorepos where the Phel
  project is not at the IDE project root.

## Test plan

- [x] `./gradlew build --rerun-tasks` green
- [x] Reproduced the reported failure, then confirmed it fixed, against a real Phel project
- [x] Regression test added

https://claude.ai/code/session_01NXHErTmpWYSar12eDpLXAy
