### PR TITLE
Dedent the new line when Enter closes a form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ refreshed, since completion, hover and arity checking are all driven by it.
 
 ### Fixed
 
+- Pressing Enter after a closed form no longer keeps the old indentation. With the caret at the end of
+  `(print "hello"))` the new line now starts at column zero, since the function is over; closing several forms at once
+  dedents by all of them, and closing one of two dedents by one level. The handler computed only the *extra*
+  indentation to add to what the platform had already copied from the line above, so it could indent further but never
+  less (#258).
 - Completion no longer goes silent in ordinary expression positions: the body of a `do`, `try`, `catch`, `finally` or
   `quote`, the exception slot of a `throw`, `recur` arguments, and the value half of a binding — `(let [x …] …)`,
   `(loop [acc …] …)` — all offer completions again (#254).

--- a/src/main/kotlin/org/phellang/editor/enter/PhelEnterHandlerDelegate.kt
+++ b/src/main/kotlin/org/phellang/editor/enter/PhelEnterHandlerDelegate.kt
@@ -30,8 +30,8 @@ class PhelEnterHandlerDelegate : EnterHandlerDelegate {
 
         val lineInfo = documentProcessor.extractLineInformation(document, caretOffset)
         
-        val indentationSpaces = indentationCalculator.calculateIndentation(
-            document, lineInfo.currentLineNumber, lineInfo.textBeforeCaret, lineInfo.currentLineText
+        val targetIndentation = indentationCalculator.targetIndentation(
+            document, lineInfo.currentLineNumber, lineInfo.textBeforeCaret
         )
 
         originalHandler?.execute(editor, editor.caretModel.currentCaret, dataContext)
@@ -45,7 +45,7 @@ class PhelEnterHandlerDelegate : EnterHandlerDelegate {
         val closingParenthesisText = parenthesisManager.createClosingParenthesisText(currentIndentationSpaces)
 
         documentProcessor.applyIndentationAndParenthesis(
-            document, editor, caretPosition, indentationSpaces, shouldAddClosingParen, closingParenthesisText
+            document, editor, caretPosition, targetIndentation, shouldAddClosingParen, closingParenthesisText
         )
 
         return EnterHandlerDelegate.Result.Stop

--- a/src/main/kotlin/org/phellang/editor/enter/PhelEnterHandlerDocumentProcessor.kt
+++ b/src/main/kotlin/org/phellang/editor/enter/PhelEnterHandlerDocumentProcessor.kt
@@ -14,23 +14,37 @@ class PhelEnterHandlerDocumentProcessor {
         return LineInformation(currentLineNumber, textBeforeCaret, currentLineText)
     }
 
+    /**
+     * Replaces the new line's leading whitespace with [indentation], rather than adding to it.
+     *
+     * The platform's enter handler has already run and copied the previous line's indentation, so
+     * inserting could only ever indent further. Setting it is what allows a line to be *less*
+     * indented than the one above — which is the normal case the moment a form closes.
+     */
     fun applyIndentationAndParenthesis(
         document: Document,
         editor: Editor,
         caretPosition: Int,
-        indentationSpaces: String,
+        indentation: String,
         shouldAddClosingParen: Boolean,
         closingParenthesisText: String
     ) {
-        if (indentationSpaces.isNotEmpty()) {
-            document.insertString(caretPosition, indentationSpaces)
-            val newCaretPosition = caretPosition + indentationSpaces.length
+        val lineNumber = document.getLineNumber(caretPosition)
+        val lineStart = document.getLineStartOffset(lineNumber)
+        val lineEnd = document.getLineEndOffset(lineNumber)
 
-            if (shouldAddClosingParen) {
-                document.insertString(newCaretPosition, closingParenthesisText)
-            }
+        // Only the leading run: text already on the line (enter pressed mid-line) must survive.
+        val existing = document.text.substring(lineStart, lineEnd).takeWhile { it == ' ' || it == '\t' }.length
 
-            editor.caretModel.moveToOffset(newCaretPosition)
+        if (document.text.substring(lineStart, lineStart + existing) != indentation) {
+            document.replaceString(lineStart, lineStart + existing, indentation)
         }
+
+        val newCaretPosition = lineStart + indentation.length
+        if (shouldAddClosingParen) {
+            document.insertString(newCaretPosition, closingParenthesisText)
+        }
+
+        editor.caretModel.moveToOffset(newCaretPosition)
     }
 }

--- a/src/main/kotlin/org/phellang/editor/enter/PhelEnterHandlerIndentationCalculator.kt
+++ b/src/main/kotlin/org/phellang/editor/enter/PhelEnterHandlerIndentationCalculator.kt
@@ -7,19 +7,26 @@ class PhelEnterHandlerIndentationCalculator {
 
     private val indentationCalculator = PhelIndentationCalculator()
 
-    fun calculateIndentation(document: Document, currentLineNumber: Int, textBeforeCaret: String, currentLineText: String): String {
-        val indentationLevel = indentationCalculator.calculateIndentationLevel(
-            document, currentLineNumber, textBeforeCaret
-        )
+    /**
+     * The indentation the new line should end up with: one level per still-open parenthesis.
+     *
+     * Absolute, not relative. This used to return only the *extra* indentation to add on top of what
+     * the platform's enter handler had already copied from the previous line, clamped at zero — so it
+     * could indent further but never less. Closing a form therefore left the new line at the old
+     * depth: enter after `(print "hello"))` gave two spaces where the form was over and the answer
+     * was none, and after `(print 1)))` gave four.
+     */
+    fun targetIndentation(document: Document, currentLineNumber: Int, textBeforeCaret: String): String {
+        val level = indentationCalculator.calculateIndentationLevel(document, currentLineNumber, textBeforeCaret)
 
-        val currentIndentationSpaces = currentLineText.takeWhile { it.isWhitespace() }.length
-        val currentIndentationLevel = currentIndentationSpaces / 2 // Assuming 2 spaces per level
-
-        val additionalIndentationLevel = indentationLevel - currentIndentationLevel
-        return " ".repeat(maxOf(0, additionalIndentationLevel) * 2) // 2 spaces per level
+        return " ".repeat(level * SPACES_PER_LEVEL)
     }
 
     fun getCurrentIndentationSpaces(currentLineText: String): Int {
         return currentLineText.takeWhile { it.isWhitespace() }.length
+    }
+
+    private companion object {
+        const val SPACES_PER_LEVEL = 2
     }
 }

--- a/src/test/kotlin/org/phellang/integration/editor/PhelEnterIndentationTest.kt
+++ b/src/test/kotlin/org/phellang/integration/editor/PhelEnterIndentationTest.kt
@@ -1,0 +1,68 @@
+package org.phellang.integration.editor
+
+import org.phellang.integration.PhelIntegrationTestCase
+
+/**
+ * Where the caret lands after ENTER.
+ *
+ * The indentation of the new line is one level per still-open parenthesis, so closing a form must
+ * *reduce* it. The handler used to compute only the extra indentation to add to what the platform
+ * had already copied from the previous line, clamped at zero — it could indent further but never
+ * less, so `(print "hello"))` left the next line two spaces in, and `(print 1)))` four, when both
+ * forms were over.
+ */
+class PhelEnterIndentationTest : PhelIntegrationTestCase() {
+
+    private var fileIndex = 0
+
+    /** The number of leading spaces on the line the caret ends up on. */
+    private fun indentAfterEnter(source: String): Int {
+        myFixture.configureByText("ei${fileIndex++}.phel", source)
+        myFixture.type('\n')
+
+        val document = myFixture.editor.document
+        val line = document.getLineNumber(myFixture.editor.caretModel.offset)
+        val text = document.text.substring(document.getLineStartOffset(line), document.getLineEndOffset(line))
+
+        return text.takeWhile { it == ' ' }.length
+    }
+
+    fun testClosedTopLevelFormReturnsToColumnZero() {
+        assertEquals(0, indentAfterEnter("(defn some-fn []\n  (print \"hello\"))<caret>"))
+    }
+
+    fun testClosingSeveralFormsAtOnceReturnsToColumnZero() {
+        assertEquals(0, indentAfterEnter("(defn f []\n  (when true\n    (print 1)))<caret>"))
+    }
+
+    /** Closing one of two open forms dedents by one level, not all the way. */
+    fun testClosingOneOfTwoFormsDedentsByOneLevel() {
+        assertEquals(2, indentAfterEnter("(defn f []\n  (when true\n    (print 1))<caret>"))
+    }
+
+    fun testOpenFormKeepsItsBodyIndented() {
+        assertEquals(2, indentAfterEnter("(defn some-fn []\n  (print \"hello\")<caret>"))
+    }
+
+    fun testHeadLineIndentsItsBody() {
+        assertEquals(2, indentAfterEnter("(defn some-fn []<caret>"))
+    }
+
+    fun testNestedOpenFormsIndentCumulatively() {
+        assertEquals(4, indentAfterEnter("(defn f []\n  (when true<caret>"))
+    }
+
+    fun testTopLevelStaysAtColumnZero() {
+        assertEquals(0, indentAfterEnter("(def a 1)<caret>"))
+    }
+
+    /** A closing paren inside a string is not a closing paren. */
+    fun testParenthesesInStringsDoNotAffectIndentation() {
+        assertEquals(2, indentAfterEnter("(defn f []\n  (print \"))\")<caret>"))
+    }
+
+    /** Nor is one in a comment. */
+    fun testParenthesesInCommentsDoNotAffectIndentation() {
+        assertEquals(2, indentAfterEnter("(defn f []\n  (print 1) ; ))\n  (print 2)<caret>"))
+    }
+}

--- a/src/test/kotlin/org/phellang/unit/editor/enter/PhelEnterHandlerDocumentProcessorTest.kt
+++ b/src/test/kotlin/org/phellang/unit/editor/enter/PhelEnterHandlerDocumentProcessorTest.kt
@@ -1,17 +1,28 @@
 package org.phellang.unit.editor.enter
 
-import org.junit.jupiter.api.Assertions.*
+import com.intellij.openapi.editor.CaretModel
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.editor.Editor
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
-import org.mockito.Mockito.*
+import org.mockito.Mockito.anyInt
+import org.mockito.Mockito.anyString
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
 import org.phellang.editor.enter.PhelEnterHandlerDocumentProcessor
-import com.intellij.openapi.editor.Document
-import com.intellij.openapi.editor.Editor
-import com.intellij.openapi.editor.CaretModel
 
+/**
+ * The processor *sets* the new line's indentation rather than adding to it.
+ *
+ * By the time it runs, the platform's enter handler has already copied the previous line's
+ * indentation, so inserting could only ever indent further. Closing a form needs the opposite, which
+ * is why enter after `(print "hello"))` used to leave the next line two spaces in.
+ */
 @ExtendWith(MockitoExtension::class)
 class PhelEnterHandlerDocumentProcessorTest {
 
@@ -33,14 +44,12 @@ class PhelEnterHandlerDocumentProcessorTest {
 
     @Test
     fun `should extract line information correctly`() {
-        val caretOffset = 10
-
-        `when`(mockDocument.getLineNumber(caretOffset)).thenReturn(0)
+        `when`(mockDocument.getLineNumber(10)).thenReturn(0)
         `when`(mockDocument.getLineStartOffset(0)).thenReturn(0)
         `when`(mockDocument.getLineEndOffset(0)).thenReturn(14)
         `when`(mockDocument.text).thenReturn("(defn test [])")
 
-        val result = processor.extractLineInformation(mockDocument, caretOffset)
+        val result = processor.extractLineInformation(mockDocument, 10)
 
         assertEquals(0, result.currentLineNumber)
         assertEquals("(defn test", result.textBeforeCaret)
@@ -48,48 +57,71 @@ class PhelEnterHandlerDocumentProcessorTest {
     }
 
     @Test
-    fun `should apply indentation without closing parenthesis`() {
-        val caretPosition = 20
-        val indentationSpaces = "  "
+    fun `should replace the leading whitespace with the target indentation`() {
+        stubCaretLine(FOUR_SPACE_LINE)
 
-        `when`(mockEditor.caretModel).thenReturn(mockCaretModel)
+        processor.applyIndentationAndParenthesis(mockDocument, mockEditor, CARET_AFTER_FOUR, "  ", false, "")
 
-        processor.applyIndentationAndParenthesis(
-            mockDocument, mockEditor, caretPosition, indentationSpaces, false, ""
-        )
+        verify(mockDocument).replaceString(LINE_START, CARET_AFTER_FOUR, "  ")
+        verify(mockCaretModel).moveToOffset(LINE_START + 2)
+    }
 
-        verify(mockDocument).insertString(caretPosition, indentationSpaces)
-        verify(mockCaretModel).moveToOffset(caretPosition + indentationSpaces.length)
+    /** The case the old insert-only contract could not express: dedent once the form is closed. */
+    @Test
+    fun `should remove the leading whitespace entirely when the target is empty`() {
+        stubCaretLine(FOUR_SPACE_LINE)
+
+        processor.applyIndentationAndParenthesis(mockDocument, mockEditor, CARET_AFTER_FOUR, "", false, "")
+
+        verify(mockDocument).replaceString(LINE_START, CARET_AFTER_FOUR, "")
+        verify(mockCaretModel).moveToOffset(LINE_START)
     }
 
     @Test
-    fun `should apply indentation with closing parenthesis`() {
-        val caretPosition = 20
-        val indentationSpaces = "  "
-        val closingParenthesisText = "\n)"
+    fun `should leave the document alone when the indentation already matches`() {
+        stubCaretLine("(defn f []\n  ")
 
-        `when`(mockEditor.caretModel).thenReturn(mockCaretModel)
+        processor.applyIndentationAndParenthesis(mockDocument, mockEditor, LINE_START + 2, "  ", false, "")
 
-        processor.applyIndentationAndParenthesis(
-            mockDocument, mockEditor, caretPosition, indentationSpaces, true, closingParenthesisText
-        )
-
-        val newCaretPosition = caretPosition + indentationSpaces.length
-        verify(mockDocument).insertString(caretPosition, indentationSpaces)
-        verify(mockDocument).insertString(newCaretPosition, closingParenthesisText)
-        verify(mockCaretModel).moveToOffset(newCaretPosition)
+        verify(mockDocument, never()).replaceString(anyInt(), anyInt(), anyString())
+        verify(mockCaretModel).moveToOffset(LINE_START + 2)
     }
 
     @Test
-    fun `should not apply anything when indentation is empty`() {
-        val caretPosition = 20
-        val indentationSpaces = ""
+    fun `should append the closing parenthesis after the indentation`() {
+        stubCaretLine(FOUR_SPACE_LINE)
 
-        processor.applyIndentationAndParenthesis(
-            mockDocument, mockEditor, caretPosition, indentationSpaces, false, ""
-        )
+        processor.applyIndentationAndParenthesis(mockDocument, mockEditor, CARET_AFTER_FOUR, "  ", true, "\n)")
 
-        verify(mockDocument, never()).insertString(anyInt(), anyString())
-        verify(mockEditor, never()).caretModel
+        verify(mockDocument).replaceString(LINE_START, CARET_AFTER_FOUR, "  ")
+        verify(mockDocument).insertString(LINE_START + 2, "\n)")
+        verify(mockCaretModel).moveToOffset(LINE_START + 2)
+    }
+
+    /** Only the leading run is replaced — text already on the line survives. */
+    @Test
+    fun `should keep text that follows the leading whitespace`() {
+        stubCaretLine("(defn f []\n    (print 1)")
+
+        processor.applyIndentationAndParenthesis(mockDocument, mockEditor, CARET_AFTER_FOUR, "", false, "")
+
+        verify(mockDocument).replaceString(LINE_START, CARET_AFTER_FOUR, "")
+    }
+
+    private fun stubCaretLine(text: String) {
+        `when`(mockDocument.getLineNumber(anyInt())).thenReturn(1)
+        `when`(mockDocument.getLineStartOffset(1)).thenReturn(LINE_START)
+        `when`(mockDocument.getLineEndOffset(1)).thenReturn(text.length)
+        `when`(mockDocument.text).thenReturn(text)
+        `when`(mockEditor.caretModel).thenReturn(mockCaretModel)
+    }
+
+    private companion object {
+        /** `(defn f []` plus its newline is 11 characters, so the second line starts at 11. */
+        const val LINE_START = 11
+
+        const val FOUR_SPACE_LINE = "(defn f []\n    "
+
+        const val CARET_AFTER_FOUR = LINE_START + 4
     }
 }


### PR DESCRIPTION
With the caret at the end of a closed form, Enter kept the indentation of the line above:

```phel
(defn some-fn []
  (print "hello"))
  ▮              ;; two spaces, though the function is over
```

## What it does now

Measured by driving the real Enter through an editor fixture:

| caret after | before | after |
|---|---|---|
| `(print "hello"))` — form closed | 2 spaces | **0** |
| `(print 1)))` — three forms closed | 4 spaces | **0** |
| `(print 1))` — one of two closed | 4 spaces | **2** |
| `(print "hello")` — still open | 2 spaces | 2 |
| `(defn some-fn []` — head line | 2 spaces | 2 |

Indenting always worked. **De**-indenting never did.

## Root cause

Two halves of `preprocessEnter` combined to make it impossible.

`PhelEnterHandlerIndentationCalculator` returned only the *extra* indentation to add on top of what
the platform's enter handler had already copied from the line above, clamped with `maxOf(0, …)`.
`PhelEnterHandlerDocumentProcessor` then only ever called `insertString`, and only when that string
was non-empty.

So a line needing *less* indentation than the one above produced `""` and no edit at all — the
copied indentation simply stayed.

## Fix

The calculator returns the **absolute** target (one level per still-open parenthesis) and the
processor **replaces** the new line's leading whitespace rather than adding to it. Only the leading
run is touched, so pressing Enter mid-line keeps the text that follows.

## Tests

`PhelEnterIndentationTest` — 9 cases covering both directions, including the two easiest to get
wrong: a *partial* dedent (closing one of two forms lands at 2, not 0), and parentheses inside
strings and comments not counting toward the depth.

**Three existing unit tests were rewritten, not deleted.** They pinned the old insert-only contract,
and one — `should not apply anything when indentation is empty` — asserted the bug itself as
intended behaviour and would have blocked this fix. They now pin the replace contract, including
that an unchanged indentation writes nothing to the document.

## Test plan

- [x] `./gradlew build --rerun-tasks` green
- [x] Each case verified against the real editor before and after
- [x] Existing enter tests updated deliberately, with the reason recorded

https://claude.ai/code/session_01NXHErTmpWYSar12eDpLXAy
