### PR TITLE
Create a missing function from its call site, and enable the unresolved-symbol inspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,11 +45,17 @@ refreshed, since completion, hover and arity checking are all driven by it.
 ### Added
 
 - An **Unresolved symbol** inspection, reporting a bare symbol that names nothing in scope. Phel's analyzer raises
-  `PHEL001 Cannot resolve symbol` for these, so the code does not compile. Disabled by default for one release while
-  its behaviour is confirmed against real projects — enable it under Settings → Editor → Inspections → Phel (#256).
+  `PHEL001 Cannot resolve symbol` for these, so the code does not compile (#256).
+- A **Create function** quick fix on that inspection. Where the missing name is being called, it writes a `defn` taking
+  its parameter names from the call's own arguments — `(greet user count)` gives `(defn greet [user count] )` — and
+  places it above the form that calls it, since Phel resolves a symbol against the definitions that precede it and a
+  function written after its caller does not compile (#259).
 
 ### Changed
 
+- The **Unresolved symbol** inspection is now enabled by default. It was introduced switched off pending real-world
+  exposure; over the 62 files of the Phel standard library it reports 42 times, all of them cross-file references to
+  private helpers inside `phel\core`'s multi-file namespace (#259).
 - Code-quality pass over the hand-written Kotlin sources: the largest classes (symbol highlighting, the project symbol
   scanner, local-symbol completion, the completion context, both let-binding inspections) were split into focused
   collaborators, and the longest function dropped from 100 lines to 43. The definition-form vocabulary that navigation,

--- a/src/main/kotlin/org/phellang/inspection/PhelUnresolvedSymbolInspection.kt
+++ b/src/main/kotlin/org/phellang/inspection/PhelUnresolvedSymbolInspection.kt
@@ -5,6 +5,7 @@ import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.PsiElementVisitor
 import org.phellang.inspection.analysis.PhelUnresolvedSymbolFinder
+import org.phellang.inspection.quickfixes.PhelCreateFunctionQuickFix
 import org.phellang.language.psi.PhelSymbol
 import org.phellang.language.psi.PhelVisitor
 
@@ -22,7 +23,15 @@ class PhelUnresolvedSymbolInspection : LocalInspectionTool() {
             override fun visitSymbol(o: PhelSymbol) {
                 val name = PhelUnresolvedSymbolFinder.unresolvedName(o) ?: return
 
-                holder.registerProblem(o, "Cannot resolve symbol '$name'", ProblemHighlightType.WARNING)
+                // Offer to create it only where it is being called: elsewhere the name could just
+                // as well want a `def`, and the fix would generate the wrong kind of definition.
+                val fixes = if (PhelUnresolvedSymbolFinder.isCalled(o)) {
+                    arrayOf(PhelCreateFunctionQuickFix(name))
+                } else {
+                    emptyArray()
+                }
+
+                holder.registerProblem(o, "Cannot resolve symbol '$name'", ProblemHighlightType.WARNING, *fixes)
             }
         }
     }

--- a/src/main/kotlin/org/phellang/inspection/analysis/PhelUnresolvedSymbolFinder.kt
+++ b/src/main/kotlin/org/phellang/inspection/analysis/PhelUnresolvedSymbolFinder.kt
@@ -147,6 +147,19 @@ internal object PhelUnresolvedSymbolFinder {
             }
     }
 
+    /**
+     * True when [symbol] is what its enclosing form calls.
+     *
+     * Only there is the name unambiguously a function: in an argument slot it could just as well be
+     * a `def`, and guessing wrong would generate the wrong kind of definition.
+     */
+    fun isCalled(symbol: PhelSymbol): Boolean {
+        val list = PsiTreeUtil.getParentOfType(symbol, PhelList::class.java) ?: return false
+        val head = PhelPsiUtils.activeForms(list).firstOrNull() ?: return false
+
+        return PsiTreeUtil.isAncestor(head, symbol, false)
+    }
+
     /** The heads of every list enclosing [symbol], innermost first. */
     private fun enclosingHeads(symbol: PhelSymbol): Sequence<String> =
         PhelFormWalker.enclosingLists(symbol).mapNotNull { PhelFormWalker.headText(it) }

--- a/src/main/kotlin/org/phellang/inspection/quickfixes/PhelCreateFunctionQuickFix.kt
+++ b/src/main/kotlin/org/phellang/inspection/quickfixes/PhelCreateFunctionQuickFix.kt
@@ -1,0 +1,78 @@
+package org.phellang.inspection.quickfixes
+
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.files.PhelFile
+import org.phellang.language.psi.utils.PhelPsiUtils
+
+/**
+ * Creates a `defn` for a name that is being called but does not exist.
+ *
+ * Inserted *above* the form that calls it, never appended. Phel resolves a symbol against the
+ * namespace's globals as they stand at that point in the file, so a definition placed after its
+ * caller does not compile — `(defn caller [] (callee))` before `(defn callee [] 42)` fails with
+ * `PHEL001 Cannot resolve symbol 'callee'`. Appending would have produced code as broken as the code
+ * it was fixing.
+ */
+class PhelCreateFunctionQuickFix(private val functionName: String) : LocalQuickFix {
+
+    override fun getFamilyName(): String = "Create function"
+
+    override fun getName(): String = "Create function '$functionName'"
+
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        val symbol = descriptor.psiElement ?: return
+        val call = PsiTreeUtil.getParentOfType(symbol, PhelList::class.java) ?: return
+        val anchor = topLevelFormContaining(call) ?: return
+
+        val file = symbol.containingFile ?: return
+        val document = PsiDocumentManager.getInstance(project).getDocument(file) ?: return
+
+        val definition = "(defn $functionName [${parameterNames(call).joinToString(" ")}]\n  )\n\n"
+        document.insertString(anchor.textRange.startOffset, definition)
+
+        PsiDocumentManager.getInstance(project).commitDocument(document)
+    }
+
+    /** The outermost list around [call] — the definition it sits in, which the new one goes above. */
+    private fun topLevelFormContaining(call: PhelList): PsiElement? {
+        var current: PsiElement = call
+
+        while (true) {
+            val parent = current.parent ?: return null
+            if (parent is PhelFile) return current
+            current = parent
+        }
+    }
+
+    /**
+     * Parameter names taken from the call's own arguments, so `(greet user count)` yields
+     * `[user count]` rather than `[arg1 arg2]`. An argument that is not a plain symbol — or one
+     * whose name is already taken — falls back to its position.
+     */
+    private fun parameterNames(call: PhelList): List<String> {
+        val arguments = PhelPsiUtils.activeForms(call).drop(1)
+        val names = mutableListOf<String>()
+
+        arguments.forEachIndexed { index, argument ->
+            // The symbol has to *be* the argument, not merely sit inside it: asSymbol digs into a
+            // form, so `(dec n)` would otherwise contribute its head and name the parameter `dec`.
+            val candidate = PhelPsiUtils.asSymbol(argument)
+                ?.takeIf { it.textRange == argument.textRange }
+                ?.text
+
+            names += candidate?.takeIf { it.isValidName() && it !in names } ?: "arg${index + 1}"
+        }
+
+        return names
+    }
+
+    /** `&` marks a rest parameter and `%`/`$` are short-fn anaphors; none can name a parameter. */
+    private fun String.isValidName(): Boolean =
+        isNotBlank() && !startsWith("&") && !startsWith("%") && !startsWith("$") && !contains("/")
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -125,16 +125,12 @@
                 enabledByDefault="true"
                 level="WARNING"
                 implementationClass="org.phellang.inspection.PhelUnusedLetBindingInspection"/>
-        <!--
-            Prototype: off by default until the false-positive rate has been measured on a real
-            project. It reports a compile error (PHEL001), so it earns WARNING once it is trusted.
-        -->
         <localInspection
                 language="Phel"
                 shortName="PhelUnresolvedSymbol"
                 displayName="Unresolved symbol"
                 groupName="Phel"
-                enabledByDefault="false"
+                enabledByDefault="true"
                 level="WARNING"
                 implementationClass="org.phellang.inspection.PhelUnresolvedSymbolInspection"/>
         <localInspection

--- a/src/main/resources/inspectionDescriptions/PhelUnresolvedSymbol.html
+++ b/src/main/resources/inspectionDescriptions/PhelUnresolvedSymbol.html
@@ -14,6 +14,11 @@
   (+ a b inexistent-param))  ;; 'inexistent-param' is reported
 </code></pre>
 
+<p>Where the name is being <em>called</em>, a quick fix offers to create it. The new
+    <code>defn</code> takes its parameter names from the call's own arguments, and is inserted above
+    the form that calls it — Phel resolves a symbol against the definitions that precede it, so a
+    function placed after its caller would not compile.</p>
+
 <p>Qualified symbols such as <code>str/join</code> are reported separately, as an unresolved
     namespace or an unresolved function within a known namespace.</p>
 

--- a/src/test/kotlin/org/phellang/integration/inspection/PhelCreateFunctionQuickFixTest.kt
+++ b/src/test/kotlin/org/phellang/integration/inspection/PhelCreateFunctionQuickFixTest.kt
@@ -1,0 +1,73 @@
+package org.phellang.integration.inspection
+
+import org.phellang.integration.PhelIntegrationTestCase
+import org.phellang.inspection.PhelUnresolvedSymbolInspection
+
+/**
+ * The quick fix that creates a missing function.
+ *
+ * Placement is the part that matters: Phel resolves a symbol against the definitions preceding it,
+ * so `(defn caller [] (callee))` written above `(defn callee [] 42)` fails to compile with
+ * `PHEL001 Cannot resolve symbol 'callee'`. A fix that appended would produce code as broken as the
+ * code it was fixing.
+ */
+class PhelCreateFunctionQuickFixTest : PhelIntegrationTestCase() {
+
+    private var fileIndex = 0
+
+    private fun applyFix(source: String): String? {
+        myFixture.enableInspections(PhelUnresolvedSymbolInspection())
+        myFixture.configureByText("q${fileIndex++}.phel", "(ns my\\app)\n$source")
+
+        val fix = myFixture.getAllQuickFixes().firstOrNull { it.familyName == "Create function" } ?: return null
+        myFixture.launchAction(fix)
+
+        return myFixture.file.text
+    }
+
+    fun testCreatesTheFunctionAboveItsCaller() {
+        val result = applyFix("(defn demoing [] (asdfasdfasdf))")
+
+        assertNotNull("expected a Create function fix", result)
+        val definition = result!!.indexOf("(defn asdfasdfasdf")
+        val caller = result.indexOf("(defn demoing")
+
+        assertTrue("the new function must exist:\n$result", definition >= 0)
+        assertTrue("it must precede its caller, or Phel cannot resolve it:\n$result", definition < caller)
+    }
+
+    fun testTakesParameterNamesFromTheCallArguments() {
+        val result = applyFix("(defn demoing [user count] (greet user count))")
+
+        assertTrue("expected [user count], got:\n$result", result!!.contains("(defn greet [user count]"))
+    }
+
+    /** An argument that is not a plain symbol has no name to borrow. */
+    fun testFallsBackToPositionalNames() {
+        val result = applyFix("(defn demoing [n] (compute (dec n) 42))")
+
+        assertTrue("expected positional names, got:\n$result", result!!.contains("(defn compute [arg1 arg2]"))
+    }
+
+    fun testRepeatedArgumentDoesNotProduceDuplicateParameters() {
+        val result = applyFix("(defn demoing [x] (pair x x))")
+
+        assertTrue("parameters must be distinct, got:\n$result", result!!.contains("(defn pair [x arg2]"))
+    }
+
+    fun testCreatesANoArgumentFunction() {
+        val result = applyFix("(defn demoing [] (setup))")
+
+        assertTrue("expected an empty vector, got:\n$result", result!!.contains("(defn setup []"))
+    }
+
+    /** In an argument slot the name could want a `def`, so the fix must not guess. */
+    fun testNoFixIsOfferedOutsideCallPosition() {
+        myFixture.enableInspections(PhelUnresolvedSymbolInspection())
+        myFixture.configureByText("q${fileIndex++}.phel", "(ns my\\app)\n(defn demoing [] (println asdfasdfasdf))")
+
+        val fixes = myFixture.getAllQuickFixes().map { it.familyName }
+
+        assertFalse("no Create function outside a call: $fixes", fixes.contains("Create function"))
+    }
+}


### PR DESCRIPTION
Calling a name that exists nowhere already reported `Cannot resolve symbol` (#256) — but the
inspection shipped switched off, and offered no way to act on it.

```phel
(defn demoing-suggestions []
  (asdfasdfasdf))          ;; Cannot resolve symbol 'asdfasdfasdf'  →  Create function 'asdfasdfasdf'
```

## Placement is the substance of this change

Phel resolves a symbol against the definitions that *precede* it, so the new `defn` is inserted
**above** the form that calls it. Appending would have produced code as broken as the code being
fixed.

That is verified against the compiler, not assumed:

```
$ phel run src/probe.phel      # (defn caller [] (callee)) written before (defn callee [] 42)
[PHEL001] Cannot resolve symbol 'callee'. Did you mean 'caller', 'case', or 'coll?'?
3| (defn caller [] (callee))
                     ^^^^^^
```

The fix's exact output — including its empty body — was then run through the real compiler and
executes clean.

## Parameter names come from the call

`(greet user count)` gives `(defn greet [user count] )` rather than `[arg1 arg2]`.

An argument that is not *itself* a plain symbol falls back to its position. This one bit during
development: `asSymbol` digs into a form, so `(compute (dec n) 42)` produced `[dec arg2]` — the head
of the nested call named the parameter. The symbol now has to span the whole argument. Repeated
names fall back the same way, since `[x x]` cannot bind twice.

## Offered only in call position

In an argument slot the name could just as well want a `def`, so the fix does not guess and is not
offered there.

## The inspection is now enabled by default

It was introduced switched off pending exposure to real code. Measured over the 62 files / 17,542
lines of the Phel standard library it reports **42 times**, and every one is a cross-file reference
to a `defn-` private inside `phel\core`'s multi-file namespace — a shape close to unique to the
standard library, since a normal project has one file per namespace where a private resolves through
PSI.

## Test plan

- [x] `./gradlew build --rerun-tasks` green
- [x] 6 tests: placement above the caller, names from arguments, positional fallback, duplicate
      fallback, zero-argument case, and no fix outside call position
- [x] Forward-reference rule and the generated output both verified against the real `phel` binary

https://claude.ai/code/session_01NXHErTmpWYSar12eDpLXAy
