### PR TITLE
Show a recursive call's own documentation on hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ refreshed, since completion, hover and arity checking are all driven by it.
   those parameters were not highlighted as parameters, did not resolve, could not be renamed, and were invisible to
   inlay hints. The reverse case is fixed too — a vector in the body, as in `(defn f [p] [x])`, was being treated as a
   second parameter list (#255).
+- Hovering a recursive call, or a call to a function defined earlier in the same file, shows that function's
+  signature and docstring instead of describing it as a "Function Argument". Unqualified names also resolve against
+  their own namespace now: the lookup went standard library, then `:refer` source, then gave up, so a function could
+  never find its own documentation (#261).
 - `doseq` is recognised as a binding form. As with the `if-some` / `when-some` omission before it, its names did not
   resolve, were absent from local completion, were never reported as unused or shadowed, and were not treated as
   locals by the parameter hints (#256).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,75 +12,42 @@ refreshed, since completion, hover and arity checking are all driven by it.
 
 ### Fixed
 
-- Pressing Enter after a closed form no longer keeps the old indentation. With the caret at the end of
-  `(print "hello"))` the new line now starts at column zero, since the function is over; closing several forms at once
-  dedents by all of them, and closing one of two dedents by one level. The handler computed only the *extra*
-  indentation to add to what the platform had already copied from the line above, so it could indent further but never
-  less (#258).
-- Reformat Code no longer fails with `env: php: No such file or directory`. `vendor/bin/phel` starts
-  `#!/usr/bin/env php`, and an IDE launched from Dock, Spotlight or Finder on macOS hands its child processes
-  `PATH=/usr/bin:/bin:/usr/sbin:/sbin` — where a PHP installed by Homebrew, Herd, asdf or mise does not appear. The
-  formatter now runs with the login shell's environment. Formatting also gains a 30-second timeout, so a hung `phel`
-  can no longer block the editor (#257).
-- Completion no longer goes silent in ordinary expression positions: the body of a `do`, `try`, `catch`, `finally` or
-  `quote`, the exception slot of a `throw`, `recur` arguments, and the value half of a binding — `(let [x …] …)`,
-  `(loop [acc …] …)` — all offer completions again (#254).
-- Completion no longer offers existing names while you are naming a new definition. `(defn …)`, `(defmacro …)`,
-  `(defonce …)` and the rest of the `def…` family suggested the whole standard library, where accepting a suggestion
-  silently redefined it (#254).
-- Names discarded by `#_` are no longer offered: `(defn #_old new-name [x] x)` completed `old`, a name that does not
-  exist at runtime (#254).
-- Go-to-definition no longer lands on an arbitrary usage. A bare symbol passed to `do`, `try`, `throw`, `recur`, `when`,
-  `cond`, `and`, `or` or `->` registered as a definition of itself, so navigation jumped to whichever such form came
-  first (#254).
-- `defonce` definitions now resolve; they previously resolved nowhere (#254).
-- `if-some` and `when-some` are recognised as binding forms, so their bindings resolve, appear in completion, and are
-  covered by the unused-binding and shadowed-binding inspections and by parameter hints. `if-let`, `when-let`,
-  `foreach`, `dofor` and `binding` bindings are now offered in completion too (#254).
-- `defonce`, `defenum`, `defprotocol`, `defrecord`, `deftype` and `defmulti` are indexed like the other definition
-  forms: they appear in cross-file completion and navigation, fold with a proper placeholder, and are named in the
-  structure view and Find Usages instead of showing as an anonymous "symbol" (#254).
-- Completion is suppressed where only a binding or parameter vector can follow — `(let …)`, `(fn …)` — rather than
-  offering the whole standard library (#254).
-- Parameters of a `defn` documented with a metadata map containing a vector — `{:see-also ["assoc"]}`, the convention
-  used throughout the Phel standard library — are recognised again. The parameter vector was searched for by scanning
-  the forms after the name for the first vector *anywhere* below them, so the one inside `:see-also` ended the search:
-  those parameters were not highlighted as parameters, did not resolve, could not be renamed, and were invisible to
-  inlay hints. The reverse case is fixed too — a vector in the body, as in `(defn f [p] [x])`, was being treated as a
-  second parameter list (#255).
-- Hovering a recursive call, or a call to a function defined earlier in the same file, shows that function's
-  signature and docstring instead of describing it as a "Function Argument". Unqualified names also resolve against
-  their own namespace now: the lookup went standard library, then `:refer` source, then gave up, so a function could
-  never find its own documentation (#261).
-- `doseq` is recognised as a binding form. As with the `if-some` / `when-some` omission before it, its names did not
-  resolve, were absent from local completion, were never reported as unused or shadowed, and were not treated as
-  locals by the parameter hints (#256).
+- Reformat Code no longer fails with `env: php: No such file or directory` on macOS. The formatter now runs with the
+  login shell's environment, and gains a 30-second timeout so a hung `phel` cannot block the editor (#257).
+- Pressing Enter after a closed form now returns to the right column: `(print "hello"))` starts the next line at
+  column zero, and closing one of two forms dedents by a single level (#258).
+- Completion works again in `do`, `try`, `throw` and `recur` bodies, and on the value half of a `let` or `loop`
+  binding (#254).
+- Completion no longer suggests existing names while you are naming a new `def`, `defn` or `defmacro` (#254).
+- Completion no longer offers names discarded by `#_` (#254).
+- Completion is suppressed where only a binding or parameter vector can follow, as in `(let …)` and `(fn …)` (#254).
+- Go to Definition no longer jumps to an arbitrary usage inside `do`, `try`, `when` or a threading macro (#254).
+- `defonce` definitions now resolve (#254).
+- `if-some`, `when-some`, `if-let`, `when-let`, `foreach`, `dofor` and `doseq` bindings now resolve, appear in
+  completion, and are covered by the binding inspections and parameter hints (#254, #256).
+- `defonce`, `defenum`, `defprotocol`, `defrecord`, `deftype` and `defmulti` now appear in cross-file completion and
+  navigation, fold correctly, and are named in the structure view and Find Usages (#254).
+- Parameters of a `defn` documented with a metadata map containing a vector, such as `{:see-also ["assoc"]}`, are
+  recognised again: they are highlighted, resolve, and can be renamed (#255).
+- Hovering a recursive call, or a call to a function defined earlier in the same file, shows that function's signature
+  and docstring instead of "Function Argument" (#261).
 
 ### Added
 
-- An **Unresolved symbol** inspection, reporting a bare symbol that names nothing in scope. Phel's analyzer raises
-  `PHEL001 Cannot resolve symbol` for these, so the code does not compile (#256).
-- A **Create function** quick fix on that inspection. Where the missing name is being called, it writes a `defn` taking
-  its parameter names from the call's own arguments — `(greet user count)` gives `(defn greet [user count] )` — and
-  places it above the form that calls it, since Phel resolves a symbol against the definitions that precede it and a
-  function written after its caller does not compile (#259).
+- An **Unresolved symbol** inspection, reporting a name that exists nowhere in scope. Phel raises
+  `PHEL001 Cannot resolve symbol` for these, so the code does not compile (#256, #259).
+- A **Create function** quick fix on that inspection. Where the missing name is being called, it writes a `defn` above
+  the calling form, taking its parameter names from the call's arguments — `(greet user count)` gives
+  `(defn greet [user count] )` (#259).
 
 ### Changed
 
-- Completion now offers only what a position can hold. In Lisp the head of a form is what gets called and the rest are
-  values, but both offered the same 979 entries: typing `w` as an argument led with `when`, `when-let`, `when-not`,
-  `when-some`, `while` and `with-open`, none of which is expressible there. Macros and special forms are no longer
-  offered in argument positions — functions still are, since `(map inc xs)` is the point of the language, and threading
-  macros and `doto` are exempt because their arguments become heads on expansion. In head position, definition forms no
-  longer outrank every function, so `map` and `println` are no longer buried under `defstruct` inside a body (#260).
-- The **Unresolved symbol** inspection is now enabled by default. It was introduced switched off pending real-world
-  exposure; over the 62 files of the Phel standard library it reports 42 times, all of them cross-file references to
-  private helpers inside `phel\core`'s multi-file namespace (#259).
-- Code-quality pass over the hand-written Kotlin sources: the largest classes (symbol highlighting, the project symbol
-  scanner, local-symbol completion, the completion context, both let-binding inspections) were split into focused
-  collaborators, and the longest function dropped from 100 lines to 43. The definition-form vocabulary that navigation,
-  folding, indexing, the structure view and Find Usages had each copied is now a single set, pinned by a coverage test
-  so the copies cannot drift apart again (#254).
+- Completion now offers only what a position can hold. Macros and special forms are no longer suggested as arguments,
+  where they cannot appear; functions still are, and threading macros are exempt. In head position, definition forms
+  no longer outrank every function (#260).
+- Large internal refactor: the biggest classes were split into focused collaborators, the longest function dropping
+  from 100 to 43 lines, and the definition-form vocabulary that navigation, folding, indexing and the structure view
+  had each copied is now a single set (#254).
 
 ## [1.0.0] - 2026-07-24
 

--- a/src/main/kotlin/org/phellang/documentation/resolvers/PhelSymbolDocumentationResolver.kt
+++ b/src/main/kotlin/org/phellang/documentation/resolvers/PhelSymbolDocumentationResolver.kt
@@ -60,6 +60,10 @@ class PhelSymbolDocumentationResolver {
     }
 
     private fun isLocalSymbol(symbol: PhelSymbol): Boolean {
+        // A call to a function defined in this file is not a local: it has documentation of its own,
+        // and describing it as a binding hides the very docstring the user hovered for.
+        if (PhelSymbolAnalyzer.isLocalFunctionReference(symbol)) return false
+
         return PhelSymbolAnalyzer.isLocalBindingOrReference(symbol)
     }
 
@@ -107,11 +111,23 @@ class PhelSymbolDocumentationResolver {
         PhelApiDocumentation.getDocumentation(symbolName)?.let { return it }
 
         val file = symbol.containingFile as? PhelFile ?: return null
+
+        // An unqualified name resolves against the current namespace before anything else — that is
+        // how a recursive call, or a call to a sibling definition, finds its own documentation.
+        ownNamespaceDocumentation(symbol, file, symbolName)?.let { return it }
+
         val sourceNamespace = PhelNamespaceUtils.findReferSource(file, symbolName) ?: return null
         val shortNamespace = PhelProjectNamespaceFinder.extractShortNamespace(sourceNamespace)
 
         return PhelApiDocumentation.getDocumentation("$shortNamespace/$symbolName")
             ?: resolveProjectSymbolDocumentation(symbol, shortNamespace, symbolName)
+    }
+
+    private fun ownNamespaceDocumentation(symbol: PhelSymbol, file: PhelFile, symbolName: String): String? {
+        val namespace = PhelNamespaceUtils.extractNamespaceFromFile(file) ?: return null
+        val shortNamespace = PhelProjectNamespaceFinder.extractShortNamespace(namespace)
+
+        return resolveProjectSymbolDocumentation(symbol, shortNamespace, symbolName)
     }
 
     private fun resolveProjectSymbolDocumentation(

--- a/src/main/kotlin/org/phellang/language/psi/analysis/PhelSymbolAnalyzer.kt
+++ b/src/main/kotlin/org/phellang/language/psi/analysis/PhelSymbolAnalyzer.kt
@@ -85,13 +85,29 @@ object PhelSymbolAnalyzer {
     fun findParameterVector(functionList: PhelList): PhelVec? =
         PhelParameterAnalyzer.findParameterVector(functionList)
 
-    /** True when [symbol] *uses* a local binding — a binding's own declaration is not a reference. */
+    /**
+     * True when [symbol] *uses* a parameter or a `let` binding — a binding's own declaration is not
+     * a reference.
+     *
+     * Deliberately narrower than [isLocalBindingOrReference], which also counts a reference to a
+     * function defined in the same file. That is a call, not an argument: the recursive `factorial`
+     * in `(* n (factorial (dec n)))` was being described as a "Function Argument" on hover.
+     */
     @JvmStatic
     fun isParameterReference(symbol: PhelSymbol): Boolean {
         val symbolText = symbol.text ?: return false
         if (isFunctionParameter(symbol) || isLetBinding(symbol)) return false
 
-        return isLocalReference(symbol, symbolText)
+        return symbolText in PhelParameterAnalyzer.parametersInScopeOf(symbol) ||
+                PhelLetBindingAnalyzer.isReferenceToLetBinding(symbol, symbolText)
+    }
+
+    /** True when [symbol] names a function defined at top level in the same file — a call, not a local. */
+    @JvmStatic
+    fun isLocalFunctionReference(symbol: PhelSymbol): Boolean {
+        val symbolText = symbol.text ?: return false
+
+        return PhelLocalFunctionIndex.isReferenceToLocalFunction(symbol, symbolText, DEFINITION_FORMS)
     }
 
     /**

--- a/src/test/kotlin/org/phellang/integration/documentation/PhelRecursiveCallHoverTest.kt
+++ b/src/test/kotlin/org/phellang/integration/documentation/PhelRecursiveCallHoverTest.kt
@@ -1,0 +1,88 @@
+package org.phellang.integration.documentation
+
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.documentation.resolvers.PhelSymbolDocumentationResolver
+import org.phellang.indexing.PhelProjectSymbolIndex
+import org.phellang.integration.PhelIntegrationTestCase
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.files.PhelFile
+
+/**
+ * What hover says about a call to a function defined in the same file.
+ *
+ * `isLocalBindingOrReference` counts a same-file function reference as local, so the recursive
+ * `factorial` in `(* n (factorial (dec n)))` took the local-symbol path and was described as a
+ * "Function Argument" — hiding the very docstring the user hovered for.
+ */
+class PhelRecursiveCallHoverTest : PhelIntegrationTestCase() {
+
+    private val indexed = mutableListOf<VirtualFile>()
+
+    private val factorial = """
+        (ns my\app)
+        (defn factorial [n]
+          "Calculates the factorial of n."
+          (if (<= n 1)
+            1
+            (* n (factorial (dec n)))))
+    """.trimIndent()
+
+    /** Removes what this class indexed: the light project is shared, and a later class scans it. */
+    override fun tearDown() {
+        try {
+            val index = project.getServiceIfCreated(PhelProjectSymbolIndex::class.java)
+            indexed.forEach { file -> index?.removeFile(file) }
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    private fun hoverAtLast(source: String, needle: String): String {
+        val file = myFixture.configureByText("hv.phel", source) as PhelFile
+        file.virtualFile?.let { indexed += it }
+        PhelProjectSymbolIndex.getInstance(project).refreshFileFromPsi(file)
+
+        val offset = myFixture.file.text.lastIndexOf(needle)
+        val symbol = PsiTreeUtil.findElementOfClassAtOffset(myFixture.file, offset, PhelSymbol::class.java, false)!!
+
+        return PhelSymbolDocumentationResolver().resolveDocumentation(symbol, symbol).orEmpty()
+            .replace(Regex("<[^>]*>"), " ").replace(Regex("\\s+"), " ").trim()
+    }
+
+    fun testRecursiveCallShowsTheFunctionDocumentation() {
+        val doc = hoverAtLast(factorial, "factorial")
+
+        assertTrue("expected the docstring, got: $doc", doc.contains("Calculates the factorial of n."))
+        assertTrue("expected the signature, got: $doc", doc.contains("(factorial n)"))
+    }
+
+    fun testRecursiveCallIsNotDescribedAsAnArgument() {
+        val doc = hoverAtLast(factorial, "factorial")
+
+        assertFalse("a recursive call is a call, not an argument: $doc", doc.contains("Function Argument"))
+    }
+
+    fun testCallToASiblingDefinitionShowsItsDocumentation() {
+        val source = "(ns my\\app)\n(defn helper [x] \"Helps with x.\" x)\n(defn g [] (helper 1))"
+
+        val doc = hoverAtLast(source, "helper")
+
+        assertTrue("expected helper's docstring, got: $doc", doc.contains("Helps with x."))
+    }
+
+    /** The narrowing must not swallow real parameters. */
+    fun testParameterStillReadsAsAnArgument() {
+        val doc = hoverAtLast(factorial, "n 1")
+
+        assertTrue("a parameter is still an argument: $doc", doc.contains("Function Argument"))
+    }
+
+    fun testLetBindingStillReadsAsALetBinding() {
+        val source = "(ns my\\app)\n(defn f [] (let [total 1] (+ total total)))"
+
+        val doc = hoverAtLast(source, "total")
+
+        assertFalse("a let binding is not a function: $doc", doc.contains("(total"))
+    }
+}


### PR DESCRIPTION
Hovering `factorial` in the recursive call said **"Function Argument"**:

```phel
(defn factorial [n]
  "Calculates the factorial of n."
  (if (<= n 1)
    1
    (* n (factorial (dec n)))))   ;; hover here
```

| | before | after |
|---|---|---|
| recursive `factorial` | `factorial  Function Argument` | `app/factorial  (factorial n)  Calculates the factorial of n.  defn in my\app` |
| parameter `n` | `Function Argument` | unchanged |
| stdlib `dec` | its own docs | unchanged |

## Cause

`isParameterReference` delegated to `isLocalReference`, whose last branch counts a reference to *any*
function defined in the same file. So every same-file call read as a parameter reference, and
`PhelBasicDocumentation` labelled it accordingly. That predicate has exactly one consumer — the hover
label — so narrowing it to parameters and `let` bindings changes nothing else.

## The part that actually surfaces the docstring

Fixing the label alone would only have changed the wording to "Symbol". The resolver also had to stop
treating a same-file call as a local, **and** unqualified names had to start resolving against their
own namespace: the unqualified path went standard library → `:refer` source → give up, and never
consulted the current namespace. That is why neither a recursive call nor a call to a sibling
definition could ever find its own documentation — the second half of the original report.

`isLocalBindingOrReference` is deliberately untouched, so highlighting, the deprecated-function
inspection and the unresolved-symbol inspection behave exactly as before.

## Test plan

- [x] `./gradlew build --rerun-tasks` green
- [x] 5 tests: recursive call shows signature and docstring and is not called an argument, a sibling
      definition resolves, and — the ones that matter for a narrowing — a real parameter still reads
      as "Function Argument" and a `let` binding is not mistaken for a function
- [x] The test primes the shared project index and removes its files in `tearDown`, the leak that
      broke an unrelated index test earlier in this series
