### PR TITLE
Find Phel definitions with Go to Symbol, and show breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ refreshed, since completion, hover and arity checking are all driven by it.
   `(ns …)` form, to run it through the project's `phel` binary. The binary is found the same way the formatter finds
   it (`./bin/phel`, then `./vendor/bin/phel`) and runs with the login shell's environment, so a Homebrew, Herd, asdf
   or mise `php` is on its `PATH` even when the IDE was started from Dock or Spotlight (#263).
+- **Go to Symbol** (Navigate > Symbol) now finds Phel definitions. The project symbol index that already backed
+  completion and arity resolution simply had no route into the platform's name popups; definitions are listed with
+  their namespace, so two functions sharing a name can be told apart, and choosing one jumps to the name itself
+  rather than the top of the file (#264).
+- **Breadcrumbs** above the editor, showing the trail of enclosing forms — `defn greet > let > when`. Only forms that
+  establish context are shown, so the trail does not simply mirror parenthesis depth (#264).
 - An **Unresolved symbol** inspection, reporting a name that exists nowhere in scope. Phel raises
   `PHEL001 Cannot resolve symbol` for these, so the code does not compile (#256, #259).
 - A **Create function** quick fix on that inspection. Where the missing name is being called, it writes a `defn` above

--- a/src/main/kotlin/org/phellang/editor/breadcrumbs/PhelBreadcrumbsProvider.kt
+++ b/src/main/kotlin/org/phellang/editor/breadcrumbs/PhelBreadcrumbsProvider.kt
@@ -1,0 +1,51 @@
+package org.phellang.editor.breadcrumbs
+
+import com.intellij.lang.Language
+import com.intellij.psi.PsiElement
+import com.intellij.ui.breadcrumbs.BreadcrumbsProvider
+import org.phellang.language.infrastructure.PhelLanguage
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelSpecialForms
+import org.phellang.language.psi.utils.PhelPsiUtils
+
+/**
+ * The trail of enclosing forms shown above the editor.
+ *
+ * Lisp is where breadcrumbs earn their keep: a few levels of nesting and the `defn` that opens the
+ * form has scrolled off the top, leaving nothing on screen to say where the caret is.
+ *
+ * Only forms that establish context are shown. A crumb per list would mirror the parenthesis depth,
+ * which the editor already draws, and push the useful outer names off the left edge.
+ */
+class PhelBreadcrumbsProvider : BreadcrumbsProvider {
+
+    override fun getLanguages(): Array<Language> = arrayOf(PhelLanguage)
+
+    override fun acceptElement(element: PsiElement): Boolean = crumbFor(element) != null
+
+    override fun getElementInfo(element: PsiElement): String = crumbFor(element).orEmpty()
+
+    private fun crumbFor(element: PsiElement): String? {
+        val list = element as? PhelList ?: return null
+        val forms = PhelPsiUtils.activeForms(list)
+        val head = PhelPsiUtils.asSymbol(forms.firstOrNull())?.text ?: return null
+
+        if (head !in CONTEXT_FORMS) return null
+
+        // `(defn greet [name] …)` reads better as "defn greet" than as either half alone.
+        val name = forms.getOrNull(1)?.let { PhelPsiUtils.asSymbol(it) }?.text
+        return if (head in PhelSpecialForms.NAME_DECLARING && name != null) "$head $name" else head
+    }
+
+    private companion object {
+        /**
+         * Forms worth a crumb: the ones that name something, plus the binding and control forms deep
+         * enough nesting hides. Kept narrow on purpose — see the class comment.
+         */
+        val CONTEXT_FORMS: Set<String> = PhelSpecialForms.NAME_DECLARING + setOf(
+            "let", "loop", "fn", "binding", "for", "foreach", "dofor", "doseq",
+            "when", "when-not", "when-let", "when-some", "if-let", "if-some",
+            "try", "catch", "finally", "case", "cond", "condp", "testing",
+        )
+    }
+}

--- a/src/main/kotlin/org/phellang/indexing/PhelProjectSymbolScanner.kt
+++ b/src/main/kotlin/org/phellang/indexing/PhelProjectSymbolScanner.kt
@@ -46,7 +46,8 @@ object PhelProjectSymbolScanner {
         if (PhelDefinitionPrivacy.isPrivateKeyword(keyword)) return null
 
         val symbolType = SymbolType.fromKeyword(keyword) ?: return null
-        val name = PhelPsiUtils.asSymbol(forms[1])?.text ?: return null
+        val nameSymbol = PhelPsiUtils.asSymbol(forms[1]) ?: return null
+        val name = nameSymbol.text ?: return null
 
         if (PhelDefinitionPrivacy.isPrivate(forms)) return null
 
@@ -59,6 +60,7 @@ object PhelProjectSymbolScanner {
             type = symbolType,
             file = virtualFile,
             docstring = PhelDocstringReader.docstringOf(forms),
+            nameOffset = PhelPsiUtils.getNameTextOffset(nameSymbol),
         )
     }
 }

--- a/src/main/kotlin/org/phellang/navigation/PhelGotoSymbolContributor.kt
+++ b/src/main/kotlin/org/phellang/navigation/PhelGotoSymbolContributor.kt
@@ -1,0 +1,45 @@
+package org.phellang.navigation
+
+import com.intellij.navigation.ChooseByNameContributorEx
+import com.intellij.navigation.NavigationItem
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.util.Processor
+import com.intellij.util.indexing.FindSymbolParameters
+import com.intellij.util.indexing.IdFilter
+import org.phellang.indexing.PhelProjectSymbolIndex
+import org.phellang.navigation.item.PhelSymbolNavigationItem
+
+/**
+ * Backs Go to Symbol (Navigate > Symbol) with the project's Phel definitions.
+ *
+ * The index this reads was already built and kept current for completion and arity resolution; it
+ * simply had no route into the platform's name popups.
+ */
+class PhelGotoSymbolContributor : ChooseByNameContributorEx {
+
+    override fun processNames(
+        processor: Processor<in String>,
+        scope: GlobalSearchScope,
+        filter: IdFilter?,
+    ) {
+        val project = scope.project ?: return
+        for (symbol in PhelProjectSymbolIndex.getInstance(project).getAllSymbols()) {
+            if (!processor.process(symbol.name)) return
+        }
+    }
+
+    override fun processElementsWithName(
+        name: String,
+        processor: Processor<in NavigationItem>,
+        parameters: FindSymbolParameters,
+    ) {
+        val project = parameters.project
+        val scope = parameters.searchScope
+        for (symbol in PhelProjectSymbolIndex.getInstance(project).findByName(name)) {
+            // A symbol whose file falls outside the requested scope is not a match: Go to Symbol
+            // honours the "project vs all places" toggle through this.
+            if (!scope.contains(symbol.file)) continue
+            if (!processor.process(PhelSymbolNavigationItem(project, symbol))) return
+        }
+    }
+}

--- a/src/main/kotlin/org/phellang/navigation/PhelGotoSymbolContributor.kt
+++ b/src/main/kotlin/org/phellang/navigation/PhelGotoSymbolContributor.kt
@@ -23,7 +23,12 @@ class PhelGotoSymbolContributor : ChooseByNameContributorEx {
         filter: IdFilter?,
     ) {
         val project = scope.project ?: return
+        // Distinct: two namespaces may define the same name, and the popup's name list would
+        // otherwise carry it twice. Both definitions still surface — processElementsWithName
+        // returns one item each.
+        val seen = HashSet<String>()
         for (symbol in PhelProjectSymbolIndex.getInstance(project).getAllSymbols()) {
+            if (!seen.add(symbol.name)) continue
             if (!processor.process(symbol.name)) return
         }
     }

--- a/src/main/kotlin/org/phellang/navigation/item/PhelSymbolNavigationItem.kt
+++ b/src/main/kotlin/org/phellang/navigation/item/PhelSymbolNavigationItem.kt
@@ -20,9 +20,11 @@ class PhelSymbolNavigationItem(
     private val symbol: PhelProjectSymbol,
 ) : NavigationItem {
 
+    private val presentation = Presentation(symbol)
+
     override fun getName(): String = symbol.name
 
-    override fun getPresentation(): ItemPresentation = Presentation(symbol)
+    override fun getPresentation(): ItemPresentation = presentation
 
     override fun navigate(requestFocus: Boolean) {
         if (!canNavigate()) return

--- a/src/main/kotlin/org/phellang/navigation/item/PhelSymbolNavigationItem.kt
+++ b/src/main/kotlin/org/phellang/navigation/item/PhelSymbolNavigationItem.kt
@@ -1,0 +1,45 @@
+package org.phellang.navigation.item
+
+import com.intellij.navigation.ItemPresentation
+import com.intellij.navigation.NavigationItem
+import com.intellij.openapi.fileEditor.OpenFileDescriptor
+import com.intellij.openapi.project.Project
+import org.phellang.language.infrastructure.PhelIcons
+import org.phellang.registry.PhelProjectSymbol
+import javax.swing.Icon
+
+/**
+ * One row in the Go to Symbol popup, backed by an indexed project symbol.
+ *
+ * Deliberately not a PSI element: the index stores a file and an offset, and resolving every
+ * candidate to PSI just to populate the list would parse every Phel file in the project on each
+ * keystroke. Navigation resolves the offset only when a row is actually chosen.
+ */
+class PhelSymbolNavigationItem(
+    private val project: Project,
+    private val symbol: PhelProjectSymbol,
+) : NavigationItem {
+
+    override fun getName(): String = symbol.name
+
+    override fun getPresentation(): ItemPresentation = Presentation(symbol)
+
+    override fun navigate(requestFocus: Boolean) {
+        if (!canNavigate()) return
+        OpenFileDescriptor(project, symbol.file, symbol.nameOffset).navigate(requestFocus)
+    }
+
+    override fun canNavigate(): Boolean = symbol.file.isValid
+
+    override fun canNavigateToSource(): Boolean = canNavigate()
+
+    private class Presentation(private val symbol: PhelProjectSymbol) : ItemPresentation {
+
+        override fun getPresentableText(): String = symbol.name
+
+        /** The namespace, so two definitions sharing a name can be told apart in the popup. */
+        override fun getLocationString(): String = symbol.namespace
+
+        override fun getIcon(unused: Boolean): Icon = PhelIcons.FILE
+    }
+}

--- a/src/main/kotlin/org/phellang/registry/PhelProjectSymbol.kt
+++ b/src/main/kotlin/org/phellang/registry/PhelProjectSymbol.kt
@@ -12,6 +12,14 @@ data class PhelProjectSymbol(
     val file: VirtualFile,
     val docstring: String? = null,
     val arities: List<PhelArity> = PhelArity.parseAll(signature),
+    /**
+     * Offset of the defined name within [file], for navigating straight to the definition.
+     *
+     * Kept current by the same PSI listener that rebuilds the rest of the entry, so it does not
+     * drift as the file is edited. A stale value would still open the right file, only at the wrong
+     * line, which is why nothing downstream treats it as authoritative.
+     */
+    val nameOffset: Int = 0,
 )
 
 /**

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -81,6 +81,10 @@
         <lang.findUsagesProvider
                 language="Phel"
                 implementationClass="org.phellang.language.psi.navigation.PhelFindUsagesProvider"/>
+        <gotoSymbolContributor
+                implementation="org.phellang.navigation.PhelGotoSymbolContributor"/>
+        <breadcrumbsInfoProvider
+                implementation="org.phellang.editor.breadcrumbs.PhelBreadcrumbsProvider"/>
         <psi.referenceContributor
                 language="Phel"
                 implementation="org.phellang.language.psi.references.PhelFilePathReferenceContributor"/>

--- a/src/test/kotlin/org/phellang/integration/editor/PhelBreadcrumbsProviderTest.kt
+++ b/src/test/kotlin/org/phellang/integration/editor/PhelBreadcrumbsProviderTest.kt
@@ -1,0 +1,61 @@
+package org.phellang.integration.editor
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.editor.breadcrumbs.PhelBreadcrumbsProvider
+import org.phellang.integration.PhelIntegrationTestCase
+import org.phellang.language.psi.PhelList
+
+class PhelBreadcrumbsProviderTest : PhelIntegrationTestCase() {
+
+    private val provider = PhelBreadcrumbsProvider()
+
+    /** The crumbs the platform would build for the innermost form, outermost first. */
+    private fun trailAt(text: String, marker: String): List<String> {
+        val file = myFixture.configureByText("core.phel", text)
+        val offset = text.indexOf(marker)
+        val leaf = file.findElementAt(offset) ?: error("no element at $marker")
+
+        return generateSequence<PsiElement>(leaf) { it.parent }
+            .filter { provider.acceptElement(it) }
+            .map { provider.getElementInfo(it) }
+            .toList()
+            .reversed()
+    }
+
+    fun testNamesTheEnclosingDefinition() {
+        assertEquals(listOf("defn greet"), trailAt("(defn greet [] 42)\n", "42"))
+    }
+
+    fun testShowsNestedBindingForms() {
+        val trail = trailAt("(defn greet []\n  (let [a 1]\n    (when a 42)))\n", "42")
+
+        assertEquals(listOf("defn greet", "let", "when"), trail)
+    }
+
+    fun testDoesNotCrumbAPlainCall() {
+        assertEquals(listOf("defn greet"), trailAt("(defn greet [] (println 42))\n", "42"))
+    }
+
+    fun testNamesADefWithoutAParameterVector() {
+        assertEquals(listOf("def limit"), trailAt("(def limit 42)\n", "42"))
+    }
+
+    fun testRendersAnAnonymousFunctionWithoutAName() {
+        val trail = trailAt("(defn greet [] (map (fn [x] 42) []))\n", "42")
+
+        assertEquals(listOf("defn greet", "fn"), trail)
+    }
+
+    fun testAcceptsOnlyLists() {
+        val file = myFixture.configureByText("core.phel", "(defn greet [] 42)\n")
+        val nonLists = PsiTreeUtil.collectElements(file) { it !is PhelList && provider.acceptElement(it) }
+
+        assertEmpty(nonLists.toList())
+    }
+
+    fun testDeclaresThePhelLanguage() {
+        assertEquals(1, provider.languages.size)
+        assertEquals("Phel", provider.languages.single().id)
+    }
+}

--- a/src/test/kotlin/org/phellang/integration/navigation/PhelGotoSymbolContributorTest.kt
+++ b/src/test/kotlin/org/phellang/integration/navigation/PhelGotoSymbolContributorTest.kt
@@ -34,12 +34,16 @@ class PhelGotoSymbolContributorTest : PhelIntegrationTestCase() {
     }
 
     /**
-     * The light fixture's project outlives this class, and the index's lazy full-project scan will
-     * find anything left behind. Without this, every definition named here turns up in the next
-     * class's `getAllSymbols()`.
+     * The light fixture's project, and its symbol index, outlive this class.
+     *
+     * The index is dropped from the index explicitly rather than left to `super.tearDown()`: that
+     * disposes the service, and `Disposer` will not run `dispose()` a second time on an instance it
+     * has already disposed, so from the second test method onward the maps are never cleared. Every
+     * definition named here would otherwise turn up in the next class's `getAllSymbols()`.
      */
     override fun tearDown() {
         try {
+            created.forEach { index().removeFile(it) }
             WriteAction.runAndWait<Throwable> {
                 created.filter { it.isValid }.forEach { it.delete(this) }
             }
@@ -116,6 +120,14 @@ class PhelGotoSymbolContributorTest : PhelIntegrationTestCase() {
         givenIndexed("src/privacy.phel", "(ns app\\privacy)\n(defn- privacy-hidden [] 1)\n(defn privacy-shown [] 2)\n")
 
         assertEquals(listOf("privacy-shown"), names().filter { it.startsWith("privacy-") })
+    }
+
+    /** The name list is a set of names; the two definitions behind a shared one come from the lookup. */
+    fun testListsASharedNameOnlyOnce() {
+        givenIndexed("src/once-a.phel", "(ns app\\oncea)\n(defn once-fn [] 1)\n")
+        givenIndexed("src/once-b.phel", "(ns app\\onceb)\n(defn once-fn [] 2)\n")
+
+        assertEquals(listOf("once-fn"), names().filter { it == "once-fn" })
     }
 
     fun testItemCanNavigate() {

--- a/src/test/kotlin/org/phellang/integration/navigation/PhelGotoSymbolContributorTest.kt
+++ b/src/test/kotlin/org/phellang/integration/navigation/PhelGotoSymbolContributorTest.kt
@@ -1,0 +1,126 @@
+package org.phellang.integration.navigation
+
+import com.intellij.navigation.NavigationItem
+import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.util.CommonProcessors
+import com.intellij.util.indexing.FindSymbolParameters
+import org.phellang.indexing.PhelProjectSymbolIndex
+import org.phellang.integration.PhelIntegrationTestCase
+import org.phellang.language.psi.files.PhelFile
+import org.phellang.navigation.PhelGotoSymbolContributor
+
+/**
+ * Go to Symbol over the project index.
+ *
+ * The index is primed with `refreshFileFromPsi`: the FilenameIndex-driven discovery in `buildIndex`
+ * finds nothing under the light test fixture, as [org.phellang.integration.registry.PhelProjectSymbolIndexBuildTest]
+ * documents.
+ */
+class PhelGotoSymbolContributorTest : PhelIntegrationTestCase() {
+
+    private val contributor = PhelGotoSymbolContributor()
+
+    private fun index() = PhelProjectSymbolIndex.getInstance(project)
+
+    private val created = mutableListOf<VirtualFile>()
+
+    private fun givenIndexed(path: String, text: String): PhelFile {
+        val file = myFixture.addFileToProject(path, text) as PhelFile
+        file.virtualFile?.let { created += it }
+        index().refreshFileFromPsi(file)
+        return file
+    }
+
+    /**
+     * The light fixture's project outlives this class, and the index's lazy full-project scan will
+     * find anything left behind. Without this, every definition named here turns up in the next
+     * class's `getAllSymbols()`.
+     */
+    override fun tearDown() {
+        try {
+            WriteAction.runAndWait<Throwable> {
+                created.filter { it.isValid }.forEach { it.delete(this) }
+            }
+            created.clear()
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    private fun names(): List<String> {
+        val collector = CommonProcessors.CollectProcessor<String>()
+        contributor.processNames(collector, GlobalSearchScope.allScope(project), null)
+        return collector.results.toList()
+    }
+
+    private fun itemsNamed(name: String): List<NavigationItem> {
+        val collector = CommonProcessors.CollectProcessor<NavigationItem>()
+        contributor.processElementsWithName(
+            name,
+            collector,
+            FindSymbolParameters.simple(project, true),
+        )
+        return collector.results.toList()
+    }
+
+    fun testOffersEveryIndexedDefinition() {
+        givenIndexed("src/offers.phel", "(ns app\\offers)\n(defn offered-fn [] 1)\n(def offered-val 2)\n")
+
+        val offered = names().filter { it.startsWith("offered-") }
+
+        assertEquals(listOf("offered-fn", "offered-val"), offered.sorted())
+    }
+
+    fun testFindsADefinitionByName() {
+        givenIndexed("src/found.phel", "(ns app\\found)\n(defn found-fn [] 1)\n")
+
+        val items = itemsNamed("found-fn")
+
+        assertEquals(1, items.size)
+        assertEquals("found-fn", items.single().name)
+    }
+
+    fun testNavigatesToTheDefinitionNotTheTopOfTheFile() {
+        val file = givenIndexed("src/offset.phel", "(ns app\\offset)\n(defn offset-fn [] 1)\n")
+        val expected = file.text.indexOf("offset-fn")
+
+        val symbol = index().findByName("offset-fn").single { it.file == file.virtualFile }
+
+        assertEquals(expected, symbol.nameOffset)
+    }
+
+    /** Two namespaces may define the same name; the popup has to show both, told apart by location. */
+    fun testKeepsBothDefinitionsOfASharedName() {
+        givenIndexed("src/dup-a.phel", "(ns app\\dupa)\n(defn dup-fn [] 1)\n")
+        givenIndexed("src/dup-b.phel", "(ns app\\dupb)\n(defn dup-fn [] 2)\n")
+
+        val items = itemsNamed("dup-fn")
+
+        assertEquals(2, items.size)
+        assertEquals(
+            listOf("app\\dupa", "app\\dupb"),
+            items.mapNotNull { it.presentation?.locationString }.sorted(),
+        )
+    }
+
+    fun testReturnsNothingForAnUnknownName() {
+        givenIndexed("src/unknown.phel", "(ns app\\unknown)\n(defn unknown-fn [] 1)\n")
+
+        assertEmpty(itemsNamed("definitely-not-defined"))
+    }
+
+    /** Private definitions are not indexed, so they must not surface in the popup either. */
+    fun testOmitsPrivateDefinitions() {
+        givenIndexed("src/privacy.phel", "(ns app\\privacy)\n(defn- privacy-hidden [] 1)\n(defn privacy-shown [] 2)\n")
+
+        assertEquals(listOf("privacy-shown"), names().filter { it.startsWith("privacy-") })
+    }
+
+    fun testItemCanNavigate() {
+        givenIndexed("src/nav.phel", "(ns app\\nav)\n(defn nav-fn [] 1)\n")
+
+        assertTrue(itemsNamed("nav-fn").single().canNavigateToSource())
+    }
+}

--- a/src/test/kotlin/org/phellang/unit/architecture/ArchitectureBoundaryTest.kt
+++ b/src/test/kotlin/org/phellang/unit/architecture/ArchitectureBoundaryTest.kt
@@ -199,7 +199,7 @@ class ArchitectureBoundaryTest {
 
         private val FEATURE_PACKAGES = listOf(
             "annotator", "completion", "editor", "inspection",
-            "documentation", "actions", "inlay", "refactoring", "run", "syntax",
+            "documentation", "actions", "inlay", "navigation", "refactoring", "run", "syntax",
         ).map { "$ROOT.$it" }
 
         private val MAIN_ROOT = File("src/main/kotlin")


### PR DESCRIPTION
Wires Phel into Go to Symbol, and adds the breadcrumb trail above the editor.

## Go to Symbol

`Navigate > Symbol` returned nothing for Phel. Everything it needed was already there:
`PhelProjectSymbolIndex` holds every project definition and is kept current by the VFS and PSI
listeners for completion and arity resolution. It simply had no `ChooseByNameContributor`.

`PhelProjectSymbol` gains a `nameOffset` so choosing a row lands on the definition rather than the
top of its file. Navigation items stay out of PSI deliberately: resolving every candidate to a
`PsiElement` to populate the list would parse every Phel file in the project on each keystroke, so
the offset is read only when a row is actually chosen.

Definitions are listed with their namespace, so two functions sharing a name are distinguishable.
Private definitions are not indexed, so they do not appear.

## Breadcrumbs

`defn greet > let > when` above the editor. Only forms that establish context get a crumb: naming
forms, binding forms and control forms. A crumb per list would mirror the parenthesis depth the
editor already draws and push the useful outer names off the left edge.

## A test-isolation bug found on the way

`PhelProjectSymbolIndexBuildTest` started failing once this branch's tests populated the index. The
cause is worth recording: `PhelIntegrationTestCase.tearDown` disposes the index service to clear it,
but `Disposer` will not run `dispose()` a second time on an instance it has already disposed. From
the second test method onward the shared light project's index is therefore never cleared, and its
contents leak into the next test class.

This branch works around it locally by dropping its own files from the index in `tearDown`. The
underlying weakness in the shared base class is untouched and is worth a follow-up: any future test
class that populates the index will hit the same thing.

## Test plan

- `./gradlew test` — 1408 tests, 0 failures, confirmed stable over three consecutive full runs
  (this failure was order-dependent, so one green run was not enough).
- 8 new Go to Symbol tests: lists every indexed definition, finds one by name, navigates to the name
  offset rather than the file start, keeps both definitions of a shared name while listing the name
  once, omits private definitions, returns nothing for an unknown name.
- 7 new breadcrumb tests: names the enclosing definition, nests binding forms, ignores a plain call,
  handles a `def` with no parameter vector and an anonymous `fn`.
- `ArchitectureBoundaryTest` extended to police the new `navigation` feature package.

Not verified in a sandbox IDE: both features were exercised through their extension-point APIs in
tests rather than by launching `runIde`.

Closes #264
