### PR TITLE
Format Phel without a phel binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ refreshed, since completion, hover and arity checking are all driven by it.
 
 ### Added
 
+- A **built-in formatter**, used when the project has no `phel` binary. Reformat Code, format-on-paste and
+  reindent-selection now work before `composer install`, in a scratch file, or where the binary is not on one of the
+  searched paths. `phel format` stays the preferred path and still wins whenever it is available; the built-in one
+  indents two spaces per level, matching what pressing Enter already does (#265).
+- A **Code Style page** for Phel (Settings > Editor > Code Style > Phel), so indentation is configurable and persists
+  per project (#265).
 - A **run configuration** for Phel files. Right-click a `.phel` file, or use the Run icon in the gutter beside its
   `(ns …)` form, to run it through the project's `phel` binary. The binary is found the same way the formatter finds
   it (`./bin/phel`, then `./vendor/bin/phel`) and runs with the login shell's environment, so a Homebrew, Herd, asdf
@@ -52,6 +58,9 @@ refreshed, since completion, hover and arity checking are all driven by it.
 
 ### Changed
 
+- The `phel` binary is now also looked up on the login shell's `PATH`, after `./bin/phel` and `./vendor/bin/phel`. A
+  project-local binary still wins, so a version pinned through Composer is never overridden by a global install
+  (#265).
 - Completion now offers only what a position can hold. Macros and special forms are no longer suggested as arguments,
   where they cannot appear; functions still are, and threading macros are exempt. In head position, definition forms
   no longer outrank every function (#260).

--- a/src/main/kotlin/org/phellang/core/cli/PhelCliLocator.kt
+++ b/src/main/kotlin/org/phellang/core/cli/PhelCliLocator.kt
@@ -11,19 +11,52 @@ import java.io.File
  */
 object PhelCliLocator {
 
-    private val CANDIDATES = listOf("bin/phel", "vendor/bin/phel")
+    private val PROJECT_CANDIDATES = listOf("bin/phel", "vendor/bin/phel")
+
+    private const val EXECUTABLE_NAME = "phel"
 
     /** What [locate] looks for, phrased for an error message shown to the user. */
-    const val SEARCHED_PATHS = "./bin/phel and ./vendor/bin/phel relative to project root"
+    const val SEARCHED_PATHS = "./bin/phel and ./vendor/bin/phel relative to project root, then PATH"
 
     /** Kept here so the formatter and the runner report a missing binary identically. */
     const val NOT_FOUND_MESSAGE = "Phel binary not found. Looked for $SEARCHED_PATHS."
 
-    fun locate(basePath: String): File? {
-        for (candidate in CANDIDATES) {
-            val file = File(basePath, candidate)
-            if (file.isFile && file.canExecute()) return file
-        }
-        return null
-    }
+    /**
+     * Project-local first, then the shell's `PATH`.
+     *
+     * Order matters: a project pinning a `phel` version through Composer must win over whatever
+     * happens to be installed globally, or formatting output would depend on the machine.
+     */
+    fun locate(basePath: String): File? = locate(basePath, loginShellPathEntries())
+
+    /**
+     * Takes the `PATH` entries explicitly so a test can pin them. Resolving them internally would
+     * make every assertion depend on whether the machine running it happens to have `phel`
+     * installed.
+     */
+    internal fun locate(basePath: String, pathEntries: List<String>): File? =
+        locateInProject(basePath) ?: locateOnPath(pathEntries)
+
+    private fun locateInProject(basePath: String): File? =
+        PROJECT_CANDIDATES.asSequence()
+            .map { File(basePath, it) }
+            .firstOrNull { it.isExecutableFile() }
+
+    private fun locateOnPath(pathEntries: List<String>): File? =
+        pathEntries.asSequence()
+            .map { File(it, EXECUTABLE_NAME) }
+            .firstOrNull { it.isExecutableFile() }
+
+    /**
+     * The *login shell's* `PATH`, not the IDE's. An IDE started from Dock or Spotlight on macOS has
+     * only `/usr/bin:/bin:/usr/sbin:/sbin`, where a Homebrew or mise `phel` never appears — the same
+     * reason the child process needs [PhelCliEnvironment].
+     */
+    private fun loginShellPathEntries(): List<String> =
+        PhelCliEnvironment.loginShellEnvironment()["PATH"]
+            ?.split(File.pathSeparatorChar)
+            ?.filter { it.isNotBlank() }
+            .orEmpty()
+
+    private fun File.isExecutableFile(): Boolean = isFile && canExecute()
 }

--- a/src/main/kotlin/org/phellang/editor/format/PhelExternalFormatter.kt
+++ b/src/main/kotlin/org/phellang/editor/format/PhelExternalFormatter.kt
@@ -19,7 +19,18 @@ class PhelExternalFormatter : AsyncDocumentFormattingService() {
     override fun getFeatures(): MutableSet<FormattingService.Feature> =
         EnumSet.noneOf(FormattingService.Feature::class.java)
 
-    override fun canFormat(file: PsiFile): Boolean = file is PhelFile
+    /**
+     * Only when the project actually has a `phel` binary.
+     *
+     * Claiming a file this service cannot format would shadow [PhelFormattingModelBuilder]: the
+     * platform stops at the first formatting service that accepts the file, so Reformat Code would
+     * report an error instead of falling back to the built-in formatter.
+     */
+    override fun canFormat(file: PsiFile): Boolean {
+        if (file !is PhelFile) return false
+        val basePath = file.project.basePath ?: return false
+        return PhelCliLocator.locate(basePath) != null
+    }
 
     override fun createFormattingTask(request: AsyncFormattingRequest): FormattingTask? {
         val basePath = request.context.project.basePath

--- a/src/main/kotlin/org/phellang/editor/format/PhelFormattingModelBuilder.kt
+++ b/src/main/kotlin/org/phellang/editor/format/PhelFormattingModelBuilder.kt
@@ -1,0 +1,33 @@
+package org.phellang.editor.format
+
+import com.intellij.formatting.FormattingContext
+import com.intellij.formatting.FormattingModel
+import com.intellij.formatting.FormattingModelBuilder
+import com.intellij.formatting.FormattingModelProvider
+import com.intellij.formatting.Indent
+import org.phellang.editor.format.blocks.PhelBlock
+
+/**
+ * The built-in formatter, used when `phel format` is unavailable.
+ *
+ * [PhelExternalFormatter] is the preferred path and wins whenever the project has a `phel` binary,
+ * because it is the canonical formatter. This one exists so Reformat Code, format-on-paste and
+ * reindent-selection do something sensible before `composer install`, in a scratch file, or in a
+ * layout where the binary is not where the locator looks.
+ */
+class PhelFormattingModelBuilder : FormattingModelBuilder {
+
+    override fun createModel(formattingContext: FormattingContext): FormattingModel {
+        val settings = formattingContext.codeStyleSettings
+        val file = formattingContext.containingFile
+
+        val root = PhelBlock(
+            node = file.node,
+            wrap = null,
+            alignment = null,
+            indent = Indent.getNoneIndent(),
+        )
+
+        return FormattingModelProvider.createFormattingModelForPsiFile(file, root, settings)
+    }
+}

--- a/src/main/kotlin/org/phellang/editor/format/PhelLanguageCodeStyleSettingsProvider.kt
+++ b/src/main/kotlin/org/phellang/editor/format/PhelLanguageCodeStyleSettingsProvider.kt
@@ -1,0 +1,45 @@
+package org.phellang.editor.format
+
+import com.intellij.application.options.IndentOptionsEditor
+import com.intellij.application.options.SmartIndentOptionsEditor
+import com.intellij.lang.Language
+import com.intellij.psi.codeStyle.CommonCodeStyleSettings
+import com.intellij.psi.codeStyle.LanguageCodeStyleSettingsProvider
+import org.phellang.language.infrastructure.PhelLanguage
+
+/** Gives Phel a Code Style page, so indentation is configurable and persists per project. */
+class PhelLanguageCodeStyleSettingsProvider : LanguageCodeStyleSettingsProvider() {
+
+    override fun getLanguage(): Language = PhelLanguage
+
+    override fun getIndentOptionsEditor(): IndentOptionsEditor = SmartIndentOptionsEditor()
+
+    override fun customizeDefaults(
+        commonSettings: CommonCodeStyleSettings,
+        indentOptions: CommonCodeStyleSettings.IndentOptions,
+    ) {
+        // Two spaces per level, matching the Enter handler and Lisp convention generally.
+        indentOptions.INDENT_SIZE = DEFAULT_INDENT
+        indentOptions.CONTINUATION_INDENT_SIZE = DEFAULT_INDENT
+        indentOptions.TAB_SIZE = DEFAULT_INDENT
+        indentOptions.USE_TAB_CHARACTER = false
+    }
+
+    override fun getCodeSample(settingsType: SettingsType): String = CODE_SAMPLE
+
+    private companion object {
+        const val DEFAULT_INDENT = 2
+
+        val CODE_SAMPLE = """
+            (ns app\example
+              (:require phel\str :as str))
+
+            (defn greet
+              "Returns a greeting for the given name."
+              [name]
+              (let [trimmed (str/trim name)]
+                (when (pos? (php/strlen trimmed))
+                  (str "Hello, " trimmed))))
+        """.trimIndent()
+    }
+}

--- a/src/main/kotlin/org/phellang/editor/format/blocks/PhelBlock.kt
+++ b/src/main/kotlin/org/phellang/editor/format/blocks/PhelBlock.kt
@@ -8,11 +8,7 @@ import com.intellij.formatting.Wrap
 import com.intellij.lang.ASTNode
 import com.intellij.psi.TokenType
 import com.intellij.psi.formatter.common.AbstractBlock
-import org.phellang.language.psi.PhelList
-import org.phellang.language.psi.PhelMap
-import org.phellang.language.psi.PhelSet
 import org.phellang.language.psi.PhelTypes
-import org.phellang.language.psi.PhelVec
 
 /**
  * One node in the formatting tree.
@@ -81,14 +77,16 @@ class PhelBlock(
      * — which are structural, not visual. Indenting inside those too gave three levels of
      * indentation for two levels of parentheses.
      */
-    private fun ASTNode.isBracketed(): Boolean =
-        psi is PhelList || psi is PhelVec || psi is PhelMap || psi is PhelSet
+    private fun ASTNode.isBracketed(): Boolean = elementType in CONTAINERS
 
     private fun ASTNode.isWhitespaceOrEmpty(): Boolean =
         elementType == TokenType.WHITE_SPACE || textRange.isEmpty
 
     private companion object {
         const val KEEP_BLANK_LINES = 1
+
+        /** The bracketed containers. Matched on element type: `getSpacing` runs per sibling pair. */
+        val CONTAINERS = setOf(PhelTypes.LIST, PhelTypes.VEC, PhelTypes.MAP, PhelTypes.SET)
 
         val BRACKETS = setOf(
             PhelTypes.PAREN1, PhelTypes.PAREN2,

--- a/src/main/kotlin/org/phellang/editor/format/blocks/PhelBlock.kt
+++ b/src/main/kotlin/org/phellang/editor/format/blocks/PhelBlock.kt
@@ -1,0 +1,100 @@
+package org.phellang.editor.format.blocks
+
+import com.intellij.formatting.Alignment
+import com.intellij.formatting.Block
+import com.intellij.formatting.Indent
+import com.intellij.formatting.Spacing
+import com.intellij.formatting.Wrap
+import com.intellij.lang.ASTNode
+import com.intellij.psi.TokenType
+import com.intellij.psi.formatter.common.AbstractBlock
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelMap
+import org.phellang.language.psi.PhelSet
+import org.phellang.language.psi.PhelTypes
+import org.phellang.language.psi.PhelVec
+
+/**
+ * One node in the formatting tree.
+ *
+ * Deliberately simple: every form nested inside a bracket indents by exactly one level, matching
+ * what the Enter handler already does (`PhelEnterHandlerIndentationCalculator`, one level per open
+ * paren). Reformat and Enter disagreeing about the same line would be worse than either rule alone.
+ *
+ * No call-argument alignment. Clojure-family formatters align arguments under the first one for
+ * calls while keeping a fixed body indent for special forms, which needs a per-head rule table and
+ * gets the remaining cases visibly wrong. `phel format` is the canonical formatter and stays the
+ * preferred path; this is the fallback for projects that have no `phel` binary yet, so predictable
+ * beats clever.
+ */
+class PhelBlock(
+    node: ASTNode,
+    wrap: Wrap?,
+    alignment: Alignment?,
+    private val indent: Indent,
+) : AbstractBlock(node, wrap, alignment) {
+
+    override fun buildChildren(): List<Block> {
+        val childIndent = if (myNode.isBracketed()) Indent.getNormalIndent() else Indent.getNoneIndent()
+
+        val children = mutableListOf<Block>()
+        var child = myNode.firstChildNode
+
+        while (child != null) {
+            if (!child.isWhitespaceOrEmpty()) {
+                // Brackets sit at the enclosing level; applying the body indent to the closing one
+                // would push it off the end of the body it closes.
+                val indentForChild = if (child.elementType in BRACKETS) Indent.getNoneIndent() else childIndent
+                children += PhelBlock(child, null, null, indentForChild)
+            }
+            child = child.treeNext
+        }
+
+        return children
+    }
+
+    override fun getIndent(): Indent = indent
+
+    /**
+     * One space between forms, none against a bracket.
+     *
+     * `keepLineBreaks = true` throughout: a line break the author put between two forms is a
+     * deliberate layout choice, and collapsing it would reflow the file onto one line.
+     */
+    override fun getSpacing(child1: Block?, child2: Block): Spacing? {
+        if (child1 == null) return null
+
+        val hugsBracket = child1.isBracket() || child2.isBracket()
+        val spaces = if (hugsBracket) 0 else 1
+
+        return Spacing.createSpacing(spaces, spaces, 0, true, KEEP_BLANK_LINES)
+    }
+
+    override fun isLeaf(): Boolean = myNode.firstChildNode == null
+
+    private fun Block.isBracket(): Boolean = this is PhelBlock && node?.elementType in BRACKETS
+
+    /**
+     * Only a bracketed container introduces an indent level.
+     *
+     * The tree also holds wrapper nodes — the file itself, and the `form` rule around every element
+     * — which are structural, not visual. Indenting inside those too gave three levels of
+     * indentation for two levels of parentheses.
+     */
+    private fun ASTNode.isBracketed(): Boolean =
+        psi is PhelList || psi is PhelVec || psi is PhelMap || psi is PhelSet
+
+    private fun ASTNode.isWhitespaceOrEmpty(): Boolean =
+        elementType == TokenType.WHITE_SPACE || textRange.isEmpty
+
+    private companion object {
+        const val KEEP_BLANK_LINES = 1
+
+        val BRACKETS = setOf(
+            PhelTypes.PAREN1, PhelTypes.PAREN2,
+            PhelTypes.BRACKET1, PhelTypes.BRACKET2,
+            PhelTypes.BRACE1, PhelTypes.BRACE2,
+            PhelTypes.HASH_BRACE, PhelTypes.HASH_PAREN,
+        )
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -146,6 +146,11 @@
                 level="WARNING"
                 implementationClass="org.phellang.inspection.PhelShadowedLetBindingInspection"/>
         <formattingService implementation="org.phellang.editor.format.PhelExternalFormatter"/>
+        <lang.formatter
+                language="Phel"
+                implementationClass="org.phellang.editor.format.PhelFormattingModelBuilder"/>
+        <langCodeStyleSettingsProvider
+                implementation="org.phellang.editor.format.PhelLanguageCodeStyleSettingsProvider"/>
         <configurationType
                 implementation="org.phellang.run.PhelRunConfigurationType"/>
         <runConfigurationProducer

--- a/src/test/kotlin/org/phellang/integration/editor/PhelFormattingModelBuilderTest.kt
+++ b/src/test/kotlin/org/phellang/integration/editor/PhelFormattingModelBuilderTest.kt
@@ -1,0 +1,73 @@
+package org.phellang.integration.editor
+
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.psi.codeStyle.CodeStyleManager
+import org.phellang.integration.PhelIntegrationTestCase
+
+/**
+ * The built-in formatter, used when the project has no `phel` binary.
+ *
+ * Asserts indentation and spacing, not a full canonical layout: `phel format` remains the canonical
+ * formatter and this is the fallback, so it aims to be predictable rather than to reproduce the CLI
+ * byte for byte. Line breaks the author chose are preserved throughout.
+ */
+class PhelFormattingModelBuilderTest : PhelIntegrationTestCase() {
+
+    private fun reformatted(text: String): String {
+        val file = myFixture.configureByText("core.phel", text)
+        WriteCommandAction.runWriteCommandAction(project) {
+            CodeStyleManager.getInstance(project).reformat(file)
+        }
+        return file.text
+    }
+
+    fun testIndentsABodyByOneLevel() {
+        val formatted = reformatted("(defn greet []\n\"hi\")\n")
+
+        assertEquals("(defn greet []\n  \"hi\")\n", formatted)
+    }
+
+    fun testIndentsNestedFormsCumulatively() {
+        val formatted = reformatted("(defn greet []\n(let [a 1]\n(println a)))\n")
+
+        assertEquals("(defn greet []\n  (let [a 1]\n    (println a)))\n", formatted)
+    }
+
+    fun testRemovesPaddingInsideParentheses() {
+        assertEquals("(println \"hi\")\n", reformatted("( println \"hi\" )\n"))
+    }
+
+    fun testRemovesPaddingInsideVectorsAndMaps() {
+        assertEquals("[1 2 3]\n", reformatted("[ 1 2 3 ]\n"))
+        assertEquals("{:a 1}\n", reformatted("{ :a 1 }\n"))
+    }
+
+    fun testCollapsesRunsOfSpacesBetweenForms() {
+        assertEquals("(println 1 2)\n", reformatted("(println   1     2)\n"))
+    }
+
+    /** A deliberate line break is the author's; collapsing it would reflow the file onto one line. */
+    fun testKeepsAuthoredLineBreaks() {
+        val formatted = reformatted("(println\n  1\n  2)\n")
+
+        assertEquals("(println\n  1\n  2)\n", formatted)
+    }
+
+    fun testLeavesTopLevelFormsUnindented() {
+        val formatted = reformatted("(ns app\\core)\n(defn greet [] 1)\n")
+
+        assertEquals("(ns app\\core)\n(defn greet [] 1)\n", formatted)
+    }
+
+    fun testDedentsAnOverIndentedBody() {
+        val formatted = reformatted("(defn greet []\n        \"hi\")\n")
+
+        assertEquals("(defn greet []\n  \"hi\")\n", formatted)
+    }
+
+    fun testLeavesAWellFormattedFileUnchanged() {
+        val source = "(ns app\\core)\n\n(defn greet [name]\n  (let [a 1]\n    (println name a)))\n"
+
+        assertEquals(source, reformatted(source))
+    }
+}

--- a/src/test/kotlin/org/phellang/unit/core/PhelCliLocatorTest.kt
+++ b/src/test/kotlin/org/phellang/unit/core/PhelCliLocatorTest.kt
@@ -9,14 +9,21 @@ import java.nio.file.Path
 import kotlin.io.path.createDirectories
 import kotlin.io.path.createFile
 
+/**
+ * `PATH` entries are passed explicitly throughout. The production overload reads them from the login
+ * shell, which would otherwise make every assertion here depend on whether the machine running the
+ * suite happens to have `phel` installed.
+ */
 class PhelCliLocatorTest {
+
+    private val noPath = emptyList<String>()
 
     @Test
     fun `prefers bin phel over vendor bin phel`(@TempDir root: Path) {
         val bin = createExecutable(root, "bin/phel")
         createExecutable(root, "vendor/bin/phel")
 
-        val located = PhelCliLocator.locate(root.toString())
+        val located = PhelCliLocator.locate(root.toString(), noPath)
 
         assertEquals(bin.toFile().absolutePath, located?.absolutePath)
     }
@@ -25,14 +32,14 @@ class PhelCliLocatorTest {
     fun `falls back to vendor bin phel when bin phel missing`(@TempDir root: Path) {
         val vendor = createExecutable(root, "vendor/bin/phel")
 
-        val located = PhelCliLocator.locate(root.toString())
+        val located = PhelCliLocator.locate(root.toString(), noPath)
 
         assertEquals(vendor.toFile().absolutePath, located?.absolutePath)
     }
 
     @Test
     fun `returns null when no candidate exists`(@TempDir root: Path) {
-        assertNull(PhelCliLocator.locate(root.toString()))
+        assertNull(PhelCliLocator.locate(root.toString(), noPath))
     }
 
     @Test
@@ -42,7 +49,49 @@ class PhelCliLocatorTest {
         path.createFile()
         path.toFile().setExecutable(false)
 
-        assertNull(PhelCliLocator.locate(root.toString()))
+        assertNull(PhelCliLocator.locate(root.toString(), noPath))
+    }
+
+    @Test
+    fun `falls back to PATH when the project has no binary`(@TempDir root: Path, @TempDir elsewhere: Path) {
+        val onPath = createExecutable(elsewhere, "phel")
+
+        val located = PhelCliLocator.locate(root.toString(), listOf(elsewhere.toString()))
+
+        assertEquals(onPath.toFile().absolutePath, located?.absolutePath)
+    }
+
+    /** A project pinning a version through Composer must win over whatever is installed globally. */
+    @Test
+    fun `prefers the project binary over one on PATH`(@TempDir root: Path, @TempDir elsewhere: Path) {
+        val vendor = createExecutable(root, "vendor/bin/phel")
+        createExecutable(elsewhere, "phel")
+
+        val located = PhelCliLocator.locate(root.toString(), listOf(elsewhere.toString()))
+
+        assertEquals(vendor.toFile().absolutePath, located?.absolutePath)
+    }
+
+    @Test
+    fun `takes the first PATH entry holding an executable phel`(
+        @TempDir root: Path,
+        @TempDir first: Path,
+        @TempDir second: Path,
+    ) {
+        val found = createExecutable(second, "phel")
+
+        val located = PhelCliLocator.locate(root.toString(), listOf(first.toString(), second.toString()))
+
+        assertEquals(found.toFile().absolutePath, located?.absolutePath)
+    }
+
+    @Test
+    fun `ignores a non-executable phel on PATH`(@TempDir root: Path, @TempDir elsewhere: Path) {
+        val path = elsewhere.resolve("phel")
+        path.createFile()
+        path.toFile().setExecutable(false)
+
+        assertNull(PhelCliLocator.locate(root.toString(), listOf(elsewhere.toString())))
     }
 
     private fun createExecutable(root: Path, relative: String): Path {


### PR DESCRIPTION
Formatting was available only when `./bin/phel` or `./vendor/bin/phel` existed. There was no
`FormattingModelBuilder` at all, so before `composer install`, in a scratch file, or in a layout the
locator does not cover, Reformat Code did nothing, and there was no format-on-paste, no
reindent-selection and no Code Style page.

## The fallback, and how it defers

`PhelExternalFormatter` stays the preferred path, because `phel format` is canonical. It now claims a
file only when a binary is actually present. That part matters: the platform stops at the first
formatting service that accepts a file, so a service that accepts a file it cannot format would
*shadow* the built-in builder rather than defer to it.

`PhelFormattingModelBuilder` indents two spaces per bracket level, matching
`PhelEnterHandlerIndentationCalculator`. Reformat and Enter disagreeing about the same line would be
worse than either rule alone.

It deliberately does **not** align call arguments under the first argument. Clojure-family
formatters do that for calls while keeping a fixed body indent for special forms, which needs a
per-head rule table and gets the remaining cases visibly wrong. For a fallback, predictable beats
clever, and anyone who wants the real thing has `phel format`.

Authored line breaks are preserved throughout, so reformatting never reflows a file onto one line.

## Locator

Now falls back to the login shell's `PATH` after the two project-local paths. Project-local wins, so
a version pinned through Composer is never overridden by a global install. It reads the *login
shell's* `PATH` for the same reason the child process needs it (#257): an IDE started from Dock or
Spotlight has only `/usr/bin:/bin:/usr/sbin:/sbin`.

`locate` gained an internal overload taking the `PATH` entries, so the tests do not depend on
whether the machine running them has `phel` installed.

## One correction to the issue

#265 lists "surface a notification when Reformat Code is invoked and no binary is found, instead of
failing silently". That was wrong: `PhelExternalFormatter` already called `request.onError` with the
registered `Phel` notification group, so it did notify. With this change the question is moot, since
a missing binary now routes to the built-in formatter instead of erroring.

## What is still open on #265

- A Code Style page exists but exposes only indentation. Spacing and wrapping options have nothing
  behind them yet, since the formatter has no rules they would control.

## Test plan

- `./gradlew test` — 1421 tests, 0 failures, confirmed over three consecutive full runs.
- 9 new formatter tests: indents a body, indents nested forms cumulatively, dedents an over-indented
  body, strips padding inside `()`/`[]`/`{}`, collapses runs of spaces, keeps authored line breaks,
  leaves top-level forms unindented, leaves a well-formatted file byte-identical.
- 4 new locator tests: falls back to `PATH`, prefers the project binary over one on `PATH`, takes the
  first `PATH` entry that has one, ignores a non-executable one.

Not verified in a sandbox IDE: the Code Style page renders through its settings provider in tests
only, and the external-vs-builtin handover was asserted through `canFormat` rather than by running
`phel format`.

Related to #265
