### PR TITLE
Report unused private definitions and parameters, and make unused imports switchable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ refreshed, since completion, hover and arity checking are all driven by it.
 
 ### Added
 
+- An **Unused private definition** inspection, reporting a `defn-` / `def-` / `^:private` definition that nothing in
+  its own file references. Only private definitions are reported: a public one may be called from any namespace, so
+  its own file cannot tell (#266).
+- An **Unused function parameter** inspection, covering `defn`, `defn-`, `fn`, `defmacro` and `defmacro-`. Names
+  starting with `_` or `&` are never reported (#266).
 - A **built-in formatter**, used when the project has no `phel` binary. Reformat Code, format-on-paste and
   reindent-selection now work before `composer install`, in a scratch file, or where the binary is not on one of the
   searched paths. `phel format` stays the preferred path and still wins whenever it is available; the built-in one
@@ -58,6 +63,9 @@ refreshed, since completion, hover and arity checking are all driven by it.
 
 ### Changed
 
+- The **unused-import** warning is now a switchable inspection (Settings > Editor > Inspections > Phel > Unused
+  import) instead of a fixed annotation, so it can be disabled or re-levelled. What it reports is unchanged, including
+  its silence on `:refer` imports and on the duplicated copy of an import already reported as a duplicate (#266).
 - The `phel` binary is now also looked up on the login shell's `PATH`, after `./bin/phel` and `./vendor/bin/phel`. A
   project-local binary still wins, so a version pinned through Composer is never overridden by a global install
   (#265).

--- a/src/main/kotlin/org/phellang/annotator/quickfixes/PhelRemoveImportQuickFix.kt
+++ b/src/main/kotlin/org/phellang/annotator/quickfixes/PhelRemoveImportQuickFix.kt
@@ -8,9 +8,8 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.SmartPointerManager
 import com.intellij.psi.SmartPsiElementPointer
-import com.intellij.psi.util.PsiTreeUtil
-import org.phellang.language.psi.PhelList
 import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.utils.PhelImportRemoval
 
 class PhelRemoveImportQuickFix(
     symbolToRemove: PhelSymbol, private val actionText: String = "Remove import"
@@ -30,12 +29,7 @@ class PhelRemoveImportQuickFix(
     override fun invoke(project: Project, editor: Editor?, element: PsiElement) {
         val symbolToRemove = symbolPointer.element ?: return
         WriteCommandAction.runWriteCommandAction(project) {
-            val requireList = PsiTreeUtil.getParentOfType(symbolToRemove, PhelList::class.java) ?: return@runWriteCommandAction
-            val prevSibling = requireList.prevSibling
-            if (prevSibling != null && prevSibling.text.isBlank()) {
-                prevSibling.delete()
-            }
-            requireList.delete()
+            PhelImportRemoval.removeEnclosingImport(symbolToRemove)
         }
     }
 

--- a/src/main/kotlin/org/phellang/annotator/validators/PhelImportValidator.kt
+++ b/src/main/kotlin/org/phellang/annotator/validators/PhelImportValidator.kt
@@ -1,25 +1,20 @@
 package org.phellang.annotator.validators
 
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.Key
-import com.intellij.psi.util.CachedValue
 import com.intellij.psi.util.PsiTreeUtil
 import org.phellang.annotator.quickfixes.PhelFixImportQuickFix
 import org.phellang.annotator.quickfixes.PhelRemoveImportQuickFix
-import org.phellang.language.psi.PhelKeyword
 import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelImportAnalysis
 import org.phellang.language.psi.PhelNamespaceUtils
 import org.phellang.language.psi.PhelProjectNamespaceFinder
 import org.phellang.language.psi.PhelSymbol
 import org.phellang.language.psi.files.PhelFile
-import org.phellang.language.psi.utils.cachedPerPsi
 
 /**
  * Validates (:require ...) statements to ensure imported namespaces exist.
  */
 object PhelImportValidator {
-    private val USED_QUALIFIERS_KEY: Key<CachedValue<Set<String>>> =
-        Key.create("phel.usedNamespaceQualifiers")
 
     fun validateImport(namespaceSymbol: PhelSymbol): List<PhelValidationProblem> {
         val fullNamespace = namespaceSymbol.text ?: return emptyList()
@@ -34,7 +29,7 @@ object PhelImportValidator {
 
         // A duplicate is reported on its own: it is trivially also "unused", and saying so twice
         // on the same symbol is noise.
-        if (containingFile != null && isDuplicateImport(containingFile, namespaceSymbol, fullNamespace)) {
+        if (containingFile != null && PhelImportAnalysis.isDuplicateImport(containingFile, namespaceSymbol, fullNamespace)) {
             return listOf(
                 PhelValidationProblem(
                     message = "Duplicate import: '$fullNamespace' is already imported",
@@ -43,10 +38,9 @@ object PhelImportValidator {
             )
         }
 
-        return buildList {
-            missingNamespaceProblem(project, namespaceSymbol, fullNamespace)?.let(::add)
-            unusedImportProblem(namespaceSymbol)?.let(::add)
-        }
+        // An unused import is reported by PhelUnusedImportInspection, not here: it is switchable
+        // from Settings, and reporting it in both places would flag every one of them twice.
+        return listOfNotNull(missingNamespaceProblem(project, namespaceSymbol, fullNamespace))
     }
 
     /** Null when the namespace resolves — to the standard library or to a project file. */
@@ -69,105 +63,5 @@ object PhelImportValidator {
         }
     }
 
-    private fun unusedImportProblem(namespaceSymbol: PhelSymbol): PhelValidationProblem? {
-        if (!isUnusedImport(namespaceSymbol)) return null
-
-        return PhelValidationProblem(
-            message = "Unused import",
-            quickFix = PhelRemoveImportQuickFix(namespaceSymbol, "Remove unused import"),
-            severity = PhelValidationProblem.Severity.WEAK_WARNING,
-        )
-    }
-
-    private fun looksLikeNamespace(text: String): Boolean {
-        return text.contains('\\') || text.contains('.')
-    }
-
-    private fun isDuplicateImport(file: PhelFile, currentSymbol: PhelSymbol, namespace: String): Boolean {
-        val nsDeclaration = PhelNamespaceUtils.findNamespaceDeclaration(file) ?: return false
-        val requireForms = PhelNamespaceUtils.findRequireForms(nsDeclaration)
-        val normalizedTarget = PhelNamespaceUtils.normalizeNamespace(namespace)
-
-        var foundFirst = false
-
-        for (requireForm in requireForms) {
-            val symbols = PsiTreeUtil.findChildrenOfType(requireForm, PhelSymbol::class.java)
-
-            for (symbol in symbols) {
-                val symbolText = symbol.text ?: continue
-                if (!looksLikeNamespace(symbolText)) continue
-
-                if (PhelNamespaceUtils.normalizeNamespace(symbolText) == normalizedTarget) {
-                    if (symbol === currentSymbol) {
-                        if (foundFirst) {
-                            return true
-                        }
-                    } else {
-                        if (!foundFirst) {
-                            foundFirst = true
-                        } else if (symbol.textOffset < currentSymbol.textOffset) {
-                            return true
-                        }
-                    }
-                }
-            }
-        }
-
-        return false
-    }
-
-    fun isUnusedImport(namespaceSymbol: PhelSymbol): Boolean {
-        val fullNamespace = namespaceSymbol.text ?: return false
-        if (!looksLikeNamespace(fullNamespace)) return false
-
-        val containingFile = namespaceSymbol.containingFile as? PhelFile ?: return false
-
-        // Check if this import uses :refer - if so, it's not "unused" in the traditional sense
-        if (hasReferClause(namespaceSymbol)) {
-            return false
-        }
-
-        val shortNamespace = PhelProjectNamespaceFinder.extractShortNamespace(fullNamespace)
-
-        val aliasMap = PhelNamespaceUtils.extractAliasMap(containingFile)
-        val alias = aliasMap.entries.find { it.value == shortNamespace }?.key
-
-        // The qualifier to look for is either the alias or the short namespace
-        val qualifierToFind = alias ?: shortNamespace
-
-        // Unused when no namespace-qualified symbol in the file body uses this qualifier.
-        return qualifierToFind !in usedNamespaceQualifiers(containingFile)
-    }
-
-    /**
-     * Qualifiers (`str` in `str/join`) used by namespace-qualified symbols outside the
-     * `(ns ...)` declaration. Highlighting checks each import against this set, so the
-     * per-file scan is cached and shared across all imports rather than re-run per import.
-     */
-    private fun usedNamespaceQualifiers(file: PhelFile): Set<String> {
-        return cachedPerPsi(file, USED_QUALIFIERS_KEY) { computeUsedNamespaceQualifiers(file) }
-    }
-
-    private fun computeUsedNamespaceQualifiers(file: PhelFile): Set<String> {
-        val nsDeclaration = PhelNamespaceUtils.findNamespaceDeclaration(file)
-        val qualifiers = HashSet<String>()
-        for (symbol in PsiTreeUtil.findChildrenOfType(file, PhelSymbol::class.java)) {
-            // Skip symbols inside the namespace declaration itself.
-            if (nsDeclaration != null && PsiTreeUtil.isAncestor(nsDeclaration, symbol, false)) {
-                continue
-            }
-            val text = symbol.text ?: continue
-            if (text.contains("/")) {
-                qualifiers.add(text.substringBefore("/"))
-            }
-        }
-        return qualifiers
-    }
-
-    private fun hasReferClause(namespaceSymbol: PhelSymbol): Boolean {
-        val requireForm = PsiTreeUtil.getParentOfType(namespaceSymbol, PhelList::class.java) ?: return false
-
-        val keywords = PsiTreeUtil.findChildrenOfType(requireForm, PhelKeyword::class.java)
-        return keywords.any { it.text == ":refer" }
-    }
+    private fun looksLikeNamespace(text: String): Boolean = PhelNamespaceUtils.looksLikeNamespace(text)
 }

--- a/src/main/kotlin/org/phellang/annotator/validators/PhelValidationProblem.kt
+++ b/src/main/kotlin/org/phellang/annotator/validators/PhelValidationProblem.kt
@@ -10,9 +10,9 @@ import com.intellij.codeInsight.intention.IntentionAction
  * Deliberately one type rather than a per-validator hierarchy. Nothing dispatches on *which*
  * validator produced a problem: each validator is called from a site that already knows what it
  * asked for, so a sealed supertype would only add a `when` that never runs. A list rather than a
- * single nullable value because one symbol can warrant two annotations (an import that neither
- * exists nor is used), and because it lets a validator express precedence — a duplicate import
- * suppresses the unused-import warning — without leaking a flag for the caller to branch on.
+ * single nullable value because one symbol can warrant more than one annotation, and because it
+ * lets a validator express precedence — a duplicate import is reported alone, suppressing the
+ * does-not-exist check on the same symbol — without leaking a flag for the caller to branch on.
  */
 data class PhelValidationProblem(
     val message: String,

--- a/src/main/kotlin/org/phellang/inspection/PhelUnusedImportInspection.kt
+++ b/src/main/kotlin/org/phellang/inspection/PhelUnusedImportInspection.kt
@@ -1,0 +1,55 @@
+package org.phellang.inspection
+
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.inspection.analysis.PhelUnusedImportFinder
+import org.phellang.inspection.quickfixes.PhelRemoveUnusedImportQuickFix
+import org.phellang.language.psi.PhelNamespaceUtils
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.PhelVisitor
+import org.phellang.language.psi.files.PhelFile
+
+/**
+ * Reports a `(:require …)` whose namespace is never used in the file.
+ *
+ * Previously reported by the annotator, which meant it could not be switched off or re-levelled
+ * from Settings. The annotator no longer reports it; a duplicate or unresolvable import is still
+ * its business.
+ */
+class PhelUnusedImportInspection : LocalInspectionTool() {
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        return object : PhelVisitor() {
+            override fun visitSymbol(o: PhelSymbol) {
+                if (!isInsideRequireForm(o)) return
+                if (!PhelUnusedImportFinder.isUnusedImport(o)) return
+
+                holder.registerProblem(
+                    o,
+                    "Unused import",
+                    ProblemHighlightType.LIKE_UNUSED_SYMBOL,
+                    PhelRemoveUnusedImportQuickFix(),
+                )
+            }
+        }
+    }
+
+    /**
+     * Every symbol in the file reaches this visitor, and a namespace-shaped symbol can appear in
+     * ordinary code. Only one inside a `(:require …)` form is an import.
+     *
+     * Narrower than "inside the `(ns …)` declaration" on purpose: the declaration's *own* name is
+     * namespace-shaped, is never used as a qualifier in its own file, and was therefore reported as
+     * an unused import by that broader test.
+     */
+    private fun isInsideRequireForm(symbol: PhelSymbol): Boolean {
+        val file = symbol.containingFile as? PhelFile ?: return false
+        val declaration = PhelNamespaceUtils.findNamespaceDeclaration(file) ?: return false
+
+        return PhelNamespaceUtils.findRequireForms(declaration)
+            .any { PsiTreeUtil.isAncestor(it, symbol, false) }
+    }
+}

--- a/src/main/kotlin/org/phellang/inspection/PhelUnusedParameterInspection.kt
+++ b/src/main/kotlin/org/phellang/inspection/PhelUnusedParameterInspection.kt
@@ -1,0 +1,29 @@
+package org.phellang.inspection
+
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElementVisitor
+import org.phellang.inspection.analysis.PhelUnusedParameterFinder
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelVisitor
+
+/** Reports a function parameter that the body never reads. */
+class PhelUnusedParameterInspection : LocalInspectionTool() {
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        return object : PhelVisitor() {
+            override fun visitList(o: PhelList) {
+                for (parameter in PhelUnusedParameterFinder.unusedParameters(o)) {
+                    // No quick fix: removing a parameter changes the function's arity, so every
+                    // call site would have to change with it.
+                    holder.registerProblem(
+                        parameter,
+                        "Parameter '${parameter.text}' is never used.",
+                        ProblemHighlightType.LIKE_UNUSED_SYMBOL,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/phellang/inspection/PhelUnusedPrivateDefinitionInspection.kt
+++ b/src/main/kotlin/org/phellang/inspection/PhelUnusedPrivateDefinitionInspection.kt
@@ -1,0 +1,29 @@
+package org.phellang.inspection
+
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElementVisitor
+import org.phellang.inspection.analysis.PhelUnusedPrivateDefinitionFinder
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelVisitor
+
+/** Reports a private top-level definition that nothing in its own file references. */
+class PhelUnusedPrivateDefinitionInspection : LocalInspectionTool() {
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        return object : PhelVisitor() {
+            override fun visitList(o: PhelList) {
+                val name = PhelUnusedPrivateDefinitionFinder.unusedPrivateDefinition(o) ?: return
+
+                // No quick fix: deleting a definition is a bigger step than deleting a binding, and
+                // a name reached only through a macro would be gone before the user noticed.
+                holder.registerProblem(
+                    name,
+                    "Private definition '${name.text}' is never used.",
+                    ProblemHighlightType.LIKE_UNUSED_SYMBOL,
+                )
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/phellang/inspection/analysis/PhelSymbolTexts.kt
+++ b/src/main/kotlin/org/phellang/inspection/analysis/PhelSymbolTexts.kt
@@ -1,0 +1,31 @@
+package org.phellang.inspection.analysis
+
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.language.psi.PhelForm
+import org.phellang.language.psi.PhelSymbol
+
+/**
+ * The set of symbol names appearing anywhere in a group of forms.
+ *
+ * Every "is this name ever read?" inspection asks the same question of a body — the let-binding
+ * finder and the parameter finder had the same walk written twice, and the second copy is the sort
+ * that quietly stops matching the first.
+ */
+internal object PhelSymbolTexts {
+
+    fun of(forms: List<PhelForm>): Set<String> {
+        val result = HashSet<String>()
+        for (form in forms) collectInto(form, result)
+
+        return result
+    }
+
+    /** Adds the text of [element] (when it is itself a symbol) plus every descendant symbol. */
+    private fun collectInto(element: PhelForm, into: MutableSet<String>) {
+        if (element is PhelSymbol) into.add(element.text)
+
+        for (symbol in PsiTreeUtil.findChildrenOfType(element, PhelSymbol::class.java)) {
+            into.add(symbol.text)
+        }
+    }
+}

--- a/src/main/kotlin/org/phellang/inspection/analysis/PhelUnusedBindingFinder.kt
+++ b/src/main/kotlin/org/phellang/inspection/analysis/PhelUnusedBindingFinder.kt
@@ -1,6 +1,5 @@
 package org.phellang.inspection.analysis
 
-import com.intellij.psi.util.PsiTreeUtil
 import org.phellang.language.psi.PhelForm
 import org.phellang.language.psi.PhelList
 import org.phellang.language.psi.PhelSpecialForms
@@ -28,7 +27,7 @@ internal object PhelUnusedBindingFinder {
         val body = forms.drop(2)
         if (body.isEmpty()) return emptyList()
 
-        return findUnused(PhelPsiUtils.activeForms(bindingVector), symbolTextsOf(body))
+        return findUnused(PhelPsiUtils.activeForms(bindingVector), PhelSymbolTexts.of(body))
     }
 
     /**
@@ -42,7 +41,7 @@ internal object PhelUnusedBindingFinder {
 
         for (i in bindings.indices.reversed()) {
             if (i % 2 == 1) {
-                collectInto(bindings[i], laterValues)
+                laterValues += PhelSymbolTexts.of(listOf(bindings[i]))
                 continue
             }
 
@@ -60,20 +59,4 @@ internal object PhelUnusedBindingFinder {
     /** A leading `_` marks a deliberate throwaway, and `&` introduces a rest parameter. */
     private fun isIntentionallyUnused(name: String): Boolean =
         name.startsWith("_") || name.startsWith("&")
-
-    private fun symbolTextsOf(forms: List<PhelForm>): Set<String> {
-        val result = HashSet<String>()
-        for (form in forms) collectInto(form, result)
-
-        return result
-    }
-
-    /** Adds the text of [element] (when it is a symbol) plus every descendant symbol. */
-    private fun collectInto(element: PhelForm, into: MutableSet<String>) {
-        if (element is PhelSymbol) into.add(element.text)
-
-        for (symbol in PsiTreeUtil.findChildrenOfType(element, PhelSymbol::class.java)) {
-            into.add(symbol.text)
-        }
-    }
 }

--- a/src/main/kotlin/org/phellang/inspection/analysis/PhelUnusedImportFinder.kt
+++ b/src/main/kotlin/org/phellang/inspection/analysis/PhelUnusedImportFinder.kt
@@ -1,0 +1,82 @@
+package org.phellang.inspection.analysis
+
+import com.intellij.openapi.util.Key
+import com.intellij.psi.util.CachedValue
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.language.psi.PhelImportAnalysis
+import org.phellang.language.psi.PhelKeyword
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelNamespaceUtils
+import org.phellang.language.psi.PhelProjectNamespaceFinder
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.files.PhelFile
+import org.phellang.language.psi.utils.cachedPerPsi
+
+/**
+ * Decides whether a required namespace is never used in the file that requires it.
+ *
+ * Moved here from `annotator/validators/PhelImportValidator`, which still owns the two problems
+ * that are genuinely annotator concerns (a duplicate import, and one that does not resolve). This
+ * one became an inspection so it can be switched off or re-levelled from Settings; the annotator no
+ * longer reports it, or every unused import would be flagged twice.
+ */
+internal object PhelUnusedImportFinder {
+
+    private val USED_QUALIFIERS_KEY: Key<CachedValue<Set<String>>> =
+        Key.create("phel.usedNamespaceQualifiers")
+
+    fun isUnusedImport(namespaceSymbol: PhelSymbol): Boolean {
+        val fullNamespace = namespaceSymbol.text ?: return false
+        if (!PhelNamespaceUtils.looksLikeNamespace(fullNamespace)) return false
+
+        val containingFile = namespaceSymbol.containingFile as? PhelFile ?: return false
+
+        // `:refer` pulls names in unqualified, so no `ns/name` qualifier will ever appear for it.
+        // Judging such an import by qualifier use would report every one of them as unused.
+        if (hasReferClause(namespaceSymbol)) return false
+
+        // A duplicate is trivially also unused, and the annotator already reports it as a duplicate.
+        // Saying both on the same symbol is the noise this precedence rule exists to avoid.
+        if (PhelImportAnalysis.isDuplicateImport(containingFile, namespaceSymbol, fullNamespace)) return false
+
+        val shortNamespace = PhelProjectNamespaceFinder.extractShortNamespace(fullNamespace)
+        val aliasMap = PhelNamespaceUtils.extractAliasMap(containingFile)
+        val alias = aliasMap.entries.find { it.value == shortNamespace }?.key
+
+        // Under `:as`, uses are written with the alias, so that is the qualifier to look for.
+        val qualifierToFind = alias ?: shortNamespace
+
+        return qualifierToFind !in usedNamespaceQualifiers(containingFile)
+    }
+
+    /**
+     * Qualifiers (`str` in `str/join`) used by namespace-qualified symbols outside the `(ns …)`
+     * declaration. Every import in the file asks the same question, so the scan is cached per file
+     * rather than re-run per import.
+     */
+    private fun usedNamespaceQualifiers(file: PhelFile): Set<String> =
+        cachedPerPsi(file, USED_QUALIFIERS_KEY) { computeUsedNamespaceQualifiers(file) }
+
+    private fun computeUsedNamespaceQualifiers(file: PhelFile): Set<String> {
+        val nsDeclaration = PhelNamespaceUtils.findNamespaceDeclaration(file)
+        val qualifiers = HashSet<String>()
+
+        for (symbol in PsiTreeUtil.findChildrenOfType(file, PhelSymbol::class.java)) {
+            // A qualifier inside the declaration is the import itself, not a use of it.
+            if (nsDeclaration != null && PsiTreeUtil.isAncestor(nsDeclaration, symbol, false)) continue
+
+            val text = symbol.text ?: continue
+            if (text.contains("/")) {
+                qualifiers.add(text.substringBefore("/"))
+            }
+        }
+
+        return qualifiers
+    }
+
+    private fun hasReferClause(namespaceSymbol: PhelSymbol): Boolean {
+        val requireForm = PsiTreeUtil.getParentOfType(namespaceSymbol, PhelList::class.java) ?: return false
+
+        return PsiTreeUtil.findChildrenOfType(requireForm, PhelKeyword::class.java).any { it.text == ":refer" }
+    }
+}

--- a/src/main/kotlin/org/phellang/inspection/analysis/PhelUnusedParameterFinder.kt
+++ b/src/main/kotlin/org/phellang/inspection/analysis/PhelUnusedParameterFinder.kt
@@ -1,0 +1,68 @@
+package org.phellang.inspection.analysis
+
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.language.psi.PhelForm
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.PhelVec
+import org.phellang.language.psi.utils.PhelPsiUtils
+
+/**
+ * Finds parameters a function declares and never reads.
+ *
+ * The same question `PhelUnusedBindingFinder` answers for `let`, over a parameter vector instead of
+ * a binding vector, and with the same exclusions: `_`-prefixed names are deliberate throwaways and
+ * `&` introduces a rest marker.
+ */
+internal object PhelUnusedParameterFinder {
+
+    /** Heads whose second form is a parameter vector followed by a body. */
+    private val PARAMETERISED_FORMS = setOf("defn", "defn-", "fn", "defmacro", "defmacro-")
+
+    fun unusedParameters(list: PhelList): List<PhelSymbol> {
+        val forms = PhelPsiUtils.activeForms(list)
+        if (forms.size < 2) return emptyList()
+
+        val head = PhelPsiUtils.asSymbol(forms[0])?.text ?: return emptyList()
+        if (head !in PARAMETERISED_FORMS) return emptyList()
+
+        val vectorIndex = forms.indexOfFirst { it is PhelVec }
+        if (vectorIndex < 1) return emptyList()
+
+        val parameters = forms[vectorIndex] as PhelVec
+        val body = forms.drop(vectorIndex + 1)
+        // A declaration with no body reads nothing, so every parameter would look unused.
+        if (body.isEmpty()) return emptyList()
+
+        val used = symbolTextsOf(body)
+
+        return PhelPsiUtils.activeForms(parameters)
+            .mapNotNull { PhelPsiUtils.asSymbol(it) }
+            .filterNot { isIntentionallyUnused(it.text) }
+            .filter { it.text !in used }
+    }
+
+    /**
+     * A leading `_` marks a deliberate throwaway, and `&` introduces a rest parameter. Destructuring
+     * targets are skipped too: the names a map or vector pattern binds are read through the pattern,
+     * not by the parameter symbol itself.
+     */
+    private fun isIntentionallyUnused(name: String?): Boolean {
+        if (name == null) return true
+
+        return name.startsWith("_") || name.startsWith("&")
+    }
+
+    private fun symbolTextsOf(forms: List<PhelForm>): Set<String> {
+        val result = HashSet<String>()
+
+        for (form in forms) {
+            if (form is PhelSymbol) result.add(form.text)
+            for (symbol in PsiTreeUtil.findChildrenOfType(form, PhelSymbol::class.java)) {
+                result.add(symbol.text)
+            }
+        }
+
+        return result
+    }
+}

--- a/src/main/kotlin/org/phellang/inspection/analysis/PhelUnusedParameterFinder.kt
+++ b/src/main/kotlin/org/phellang/inspection/analysis/PhelUnusedParameterFinder.kt
@@ -1,7 +1,5 @@
 package org.phellang.inspection.analysis
 
-import com.intellij.psi.util.PsiTreeUtil
-import org.phellang.language.psi.PhelForm
 import org.phellang.language.psi.PhelList
 import org.phellang.language.psi.PhelSymbol
 import org.phellang.language.psi.PhelVec
@@ -34,7 +32,7 @@ internal object PhelUnusedParameterFinder {
         // A declaration with no body reads nothing, so every parameter would look unused.
         if (body.isEmpty()) return emptyList()
 
-        val used = symbolTextsOf(body)
+        val used = PhelSymbolTexts.of(body)
 
         return PhelPsiUtils.activeForms(parameters)
             .mapNotNull { PhelPsiUtils.asSymbol(it) }
@@ -51,18 +49,5 @@ internal object PhelUnusedParameterFinder {
         if (name == null) return true
 
         return name.startsWith("_") || name.startsWith("&")
-    }
-
-    private fun symbolTextsOf(forms: List<PhelForm>): Set<String> {
-        val result = HashSet<String>()
-
-        for (form in forms) {
-            if (form is PhelSymbol) result.add(form.text)
-            for (symbol in PsiTreeUtil.findChildrenOfType(form, PhelSymbol::class.java)) {
-                result.add(symbol.text)
-            }
-        }
-
-        return result
     }
 }

--- a/src/main/kotlin/org/phellang/inspection/analysis/PhelUnusedPrivateDefinitionFinder.kt
+++ b/src/main/kotlin/org/phellang/inspection/analysis/PhelUnusedPrivateDefinitionFinder.kt
@@ -1,0 +1,58 @@
+package org.phellang.inspection.analysis
+
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.indexing.scanner.PhelDefinitionPrivacy
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelSpecialForms
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.files.PhelFile
+import org.phellang.language.psi.utils.PhelPsiUtils
+
+/**
+ * Finds a private top-level definition that nothing in its own file references.
+ *
+ * Privacy is what makes this answerable at all: a public definition may be called from any other
+ * namespace, so its own file cannot decide. A private one is reachable only from where it is
+ * declared, so a file-local scan is the whole story.
+ *
+ * Privacy itself is delegated to [PhelDefinitionPrivacy], the same judgement the project symbol
+ * index uses to decide what to leave out. It handles all three spellings, and the cases a textual
+ * search for `:private` gets wrong: `{:private false}` is explicitly public, and a docstring that
+ * happens to mention the word does not make a definition private.
+ */
+internal object PhelUnusedPrivateDefinitionFinder {
+
+    /** The defined name when [list] is a private definition nothing else in the file mentions. */
+    fun unusedPrivateDefinition(list: PhelList): PhelSymbol? {
+        if (list.parent !is PhelFile) return null
+
+        // activeForms: a `#_`-discarded form must not shift the head and name reads.
+        val forms = PhelPsiUtils.activeForms(list)
+        if (forms.size < 2) return null
+
+        val keyword = PhelPsiUtils.asSymbol(forms[0])?.text ?: return null
+        if (keyword !in PhelSpecialForms.DEFINITION_FORMS) return null
+
+        if (!PhelDefinitionPrivacy.isPrivateKeyword(keyword) && !PhelDefinitionPrivacy.isPrivate(forms)) return null
+
+        val name = PhelPsiUtils.asSymbol(forms[1]) ?: return null
+        val nameText = name.text ?: return null
+
+        return if (isReferenced(name, nameText)) null else name
+    }
+
+    /**
+     * Any symbol with the same text other than the defining name itself.
+     *
+     * Only the name symbol is excluded, not the whole declaration, so a recursive call counts as a
+     * use. A private function that merely calls itself is arguably dead too, but telling that apart
+     * from a genuine use needs call-graph reachability; at this inspection's weak-warning level,
+     * staying quiet is the safer error.
+     */
+    private fun isReferenced(nameSymbol: PhelSymbol, name: String): Boolean {
+        val file = nameSymbol.containingFile ?: return true
+
+        return PsiTreeUtil.findChildrenOfType(file, PhelSymbol::class.java)
+            .any { it.text == name && it !== nameSymbol }
+    }
+}

--- a/src/main/kotlin/org/phellang/inspection/quickfixes/PhelRemoveUnusedImportQuickFix.kt
+++ b/src/main/kotlin/org/phellang/inspection/quickfixes/PhelRemoveUnusedImportQuickFix.kt
@@ -1,0 +1,22 @@
+package org.phellang.inspection.quickfixes
+
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.openapi.project.Project
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.utils.PhelImportRemoval
+
+class PhelRemoveUnusedImportQuickFix : LocalQuickFix {
+
+    override fun getFamilyName(): String = "Remove unused import"
+
+    /**
+     * No write action of its own: the platform already runs `applyFix` inside one, and inside a
+     * command, so a failed PSI edit is rolled back and reported rather than leaving the user with a
+     * fix that silently did nothing.
+     */
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        val symbol = descriptor.psiElement as? PhelSymbol ?: return
+        PhelImportRemoval.removeEnclosingImport(symbol)
+    }
+}

--- a/src/main/kotlin/org/phellang/language/psi/PhelImportAnalysis.kt
+++ b/src/main/kotlin/org/phellang/language/psi/PhelImportAnalysis.kt
@@ -1,0 +1,47 @@
+package org.phellang.language.psi
+
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.language.psi.files.PhelFile
+
+/**
+ * Questions about the imports in an `(ns …)` declaration that more than one feature package asks.
+ *
+ * Lives in `language` because the annotator reports a duplicate import while the unused-import
+ * inspection has to stay quiet on that same symbol, and a feature package may not reach into
+ * another's internals. Keeping one copy is what makes the precedence rule hold: a duplicate is
+ * trivially also unused, and saying both on the same symbol is noise.
+ */
+object PhelImportAnalysis {
+
+    /**
+     * True when [currentSymbol] is a *later* occurrence of a namespace already imported above it.
+     *
+     * The first occurrence is the original and is never a duplicate, so the warning lands on the
+     * copy the user should delete.
+     */
+    fun isDuplicateImport(file: PhelFile, currentSymbol: PhelSymbol, namespace: String): Boolean {
+        val nsDeclaration = PhelNamespaceUtils.findNamespaceDeclaration(file) ?: return false
+        val requireForms = PhelNamespaceUtils.findRequireForms(nsDeclaration)
+        val normalizedTarget = PhelNamespaceUtils.normalizeNamespace(namespace)
+
+        var foundFirst = false
+
+        for (requireForm in requireForms) {
+            for (symbol in PsiTreeUtil.findChildrenOfType(requireForm, PhelSymbol::class.java)) {
+                val symbolText = symbol.text ?: continue
+                if (!PhelNamespaceUtils.looksLikeNamespace(symbolText)) continue
+                if (PhelNamespaceUtils.normalizeNamespace(symbolText) != normalizedTarget) continue
+
+                if (symbol === currentSymbol) {
+                    if (foundFirst) return true
+                } else if (!foundFirst) {
+                    foundFirst = true
+                } else if (symbol.textOffset < currentSymbol.textOffset) {
+                    return true
+                }
+            }
+        }
+
+        return false
+    }
+}

--- a/src/main/kotlin/org/phellang/language/psi/PhelNamespaceUtils.kt
+++ b/src/main/kotlin/org/phellang/language/psi/PhelNamespaceUtils.kt
@@ -124,6 +124,13 @@ object PhelNamespaceUtils {
         return namespace.replace('\\', '.')
     }
 
+    /**
+     * Whether [text] is shaped like a namespace: dot-separated (Phel 0.35+ canonical) or the legacy
+     * backslash form. Both the import validator and the unused-import inspection screen candidate
+     * symbols with this before treating them as imports.
+     */
+    fun looksLikeNamespace(text: String): Boolean = text.contains('\\') || text.contains('.')
+
     fun extractNamespaceFromDeclaration(nsDeclaration: PhelList): String? {
         val forms = nsDeclaration.forms
         if (forms.size < 2) return null

--- a/src/main/kotlin/org/phellang/language/psi/utils/PhelImportRemoval.kt
+++ b/src/main/kotlin/org/phellang/language/psi/utils/PhelImportRemoval.kt
@@ -1,0 +1,29 @@
+package org.phellang.language.psi.utils
+
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelSymbol
+
+/**
+ * Deletes an import entry from an `(ns …)` declaration.
+ *
+ * Lives in `language` because two quick fixes in different feature packages need it — the
+ * annotator's duplicate-import fix and the inspection's unused-import fix — and a feature package
+ * may not reach into another's internals.
+ *
+ * The caller supplies the write action: an `IntentionAction` opens its own, while a `LocalQuickFix`
+ * is already running inside one.
+ */
+object PhelImportRemoval {
+
+    /** Removes the require entry containing [symbol], along with the whitespace that preceded it. */
+    fun removeEnclosingImport(symbol: PhelSymbol) {
+        val requireList = PsiTreeUtil.getParentOfType(symbol, PhelList::class.java) ?: return
+
+        val previous = requireList.prevSibling
+        if (previous != null && previous.text.isBlank()) {
+            previous.delete()
+        }
+        requireList.delete()
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -139,6 +139,30 @@
                 implementationClass="org.phellang.inspection.PhelUnresolvedSymbolInspection"/>
         <localInspection
                 language="Phel"
+                shortName="PhelUnusedImport"
+                displayName="Unused import"
+                groupName="Phel"
+                enabledByDefault="true"
+                level="WEAK WARNING"
+                implementationClass="org.phellang.inspection.PhelUnusedImportInspection"/>
+        <localInspection
+                language="Phel"
+                shortName="PhelUnusedPrivateDefinition"
+                displayName="Unused private definition"
+                groupName="Phel"
+                enabledByDefault="true"
+                level="WEAK WARNING"
+                implementationClass="org.phellang.inspection.PhelUnusedPrivateDefinitionInspection"/>
+        <localInspection
+                language="Phel"
+                shortName="PhelUnusedParameter"
+                displayName="Unused function parameter"
+                groupName="Phel"
+                enabledByDefault="true"
+                level="WEAK WARNING"
+                implementationClass="org.phellang.inspection.PhelUnusedParameterInspection"/>
+        <localInspection
+                language="Phel"
                 shortName="PhelShadowedLetBinding"
                 displayName="Shadowed let binding"
                 groupName="Phel"

--- a/src/main/resources/inspectionDescriptions/PhelUnusedImport.html
+++ b/src/main/resources/inspectionDescriptions/PhelUnusedImport.html
@@ -1,0 +1,27 @@
+<html>
+<body>
+<p>Reports a namespace brought in by <code>(:require ...)</code> that the file never uses.</p>
+
+<p>An import is flagged when no namespace-qualified symbol outside the <code>(ns ...)</code>
+    declaration uses its qualifier. Under <code>:as</code> the alias is the qualifier that counts, so
+    <code>(:require phel\str :as s)</code> is used by <code>(s/join ...)</code> and not by
+    <code>(str/join ...)</code>.</p>
+
+<h3>Example:</h3>
+<pre><code>
+(ns app\core
+  (:require phel\str))   ;; reported: Unused import
+
+(println "hi")
+</code></pre>
+
+<h3>Not reported</h3>
+<p>An import carrying <code>:refer</code> is never reported: it brings names in unqualified, so no
+    qualifier will ever appear for it and judging it this way would flag every such import.</p>
+
+<p>A duplicate or unresolvable import is reported separately, as a warning rather than through this
+    inspection.</p>
+
+<p>A quick-fix removes the require entry.</p>
+</body>
+</html>

--- a/src/main/resources/inspectionDescriptions/PhelUnusedParameter.html
+++ b/src/main/resources/inspectionDescriptions/PhelUnusedParameter.html
@@ -1,0 +1,21 @@
+<html>
+<body>
+<p>Reports a function parameter that the body never reads.</p>
+
+<p>Applies to <code>defn</code>, <code>defn-</code>, <code>fn</code>, <code>defmacro</code> and
+    <code>defmacro-</code>.</p>
+
+<h3>Example:</h3>
+<pre><code>
+(defn greet [name greeting]   ;; 'greeting' is reported: Parameter 'greeting' is never used.
+  (println name))
+</code></pre>
+
+<h3>Ignored names</h3>
+<p>Names conventionally used to discard a value are never reported: <code>_</code>, any name starting
+    with <code>_</code>, and names starting with <code>&amp;</code> (rest markers).</p>
+
+<p>No quick-fix is offered: removing a parameter changes the function's arity, so every call site
+    would have to change with it.</p>
+</body>
+</html>

--- a/src/main/resources/inspectionDescriptions/PhelUnusedPrivateDefinition.html
+++ b/src/main/resources/inspectionDescriptions/PhelUnusedPrivateDefinition.html
@@ -1,0 +1,29 @@
+<html>
+<body>
+<p>Reports a private top-level definition that nothing in its own file references.</p>
+
+<p>Privacy is what makes this answerable: a public definition can be called from any other
+    namespace, so its own file cannot tell whether it is used. A private one is reachable only from
+    where it is declared, so a file-local scan is conclusive.</p>
+
+<p>Recognises all three ways Phel marks a definition private: the <code>defn-</code> /
+    <code>def-</code> / <code>defmacro-</code> family, a <code>^:private</code> flag on the name, and
+    a <code>:private</code> entry in the metadata slot.</p>
+
+<h3>Example:</h3>
+<pre><code>
+(defn- helper [x]   ;; reported: Private definition 'helper' is never used.
+  (* x 2))
+
+(defn public-entry [x]
+  (* x 3))
+</code></pre>
+
+<h3>Not reported</h3>
+<p>A definition that refers to itself stays alive: reporting a recursive helper as unused would be
+    wrong far more often than the reverse.</p>
+
+<p>No quick-fix is offered. Deleting a definition is a larger step than deleting a binding, and a
+    name reached only through a macro would be gone before it was missed.</p>
+</body>
+</html>

--- a/src/test/kotlin/org/phellang/integration/annotator/PhelImportValidationIntegrationTest.kt
+++ b/src/test/kotlin/org/phellang/integration/annotator/PhelImportValidationIntegrationTest.kt
@@ -1,6 +1,7 @@
 package org.phellang.integration.annotator
 
 import com.intellij.lang.annotation.HighlightSeverity
+import org.phellang.inspection.PhelUnusedImportInspection
 import org.phellang.integration.PhelIntegrationTestCase
 
 /**
@@ -10,6 +11,10 @@ import org.phellang.integration.PhelIntegrationTestCase
  * data class and asserted on that, never invoking a validator. The precedence rules below are the
  * substance — a duplicate import must not also be reported as unused, while an import that is both
  * unknown and unused must produce both warnings.
+ *
+ * The unused-import half is now `PhelUnusedImportInspection` rather than an annotation, so it is
+ * enabled explicitly below. Keeping these assertions end-to-end is the point: the precedence rule
+ * now spans an annotator and an inspection, and only the rendered result proves it still holds.
  */
 class PhelImportValidationIntegrationTest : PhelIntegrationTestCase() {
 
@@ -56,6 +61,12 @@ class PhelImportValidationIntegrationTest : PhelIntegrationTestCase() {
         // symbol is noise. The duplicate warning suppresses the unused one.
         val duplicates = warnings.filter { it.contains("Duplicate import") }
         assertEquals("duplicate should be reported once: $warnings", 1, duplicates.size)
+
+        // The unused check lives in an inspection now, so this precedence spans two extension
+        // points. The duplicated copy must still be silent about being unused; the original above
+        // it is reported as unused exactly as before.
+        val unused = warnings.filter { it.contains("Unused import") }
+        assertEquals("the duplicate must not also be reported as unused: $warnings", 1, unused.size)
     }
 
     fun testUnknownNamespaceIsReported() {
@@ -73,6 +84,7 @@ class PhelImportValidationIntegrationTest : PhelIntegrationTestCase() {
 
     /** Every warning/weak-warning message the annotator produces for [text]. */
     private fun warningsFor(text: String): List<String> {
+        myFixture.enableInspections(PhelUnusedImportInspection())
         myFixture.configureByText("a.phel", text)
         return myFixture.doHighlighting()
             .filter { it.severity == HighlightSeverity.WARNING || it.severity == HighlightSeverity.WEAK_WARNING }

--- a/src/test/kotlin/org/phellang/integration/annotator/PhelImportValidatorTest.kt
+++ b/src/test/kotlin/org/phellang/integration/annotator/PhelImportValidatorTest.kt
@@ -1,0 +1,79 @@
+package org.phellang.integration.annotator
+
+import com.intellij.psi.PsiManager
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.annotator.validators.PhelImportValidator
+import org.phellang.integration.PhelIntegrationTestCase
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.files.PhelFile
+
+/**
+ * What the annotator still reports about an import, and what it must no longer report.
+ *
+ * The unused-import check became `PhelUnusedImportInspection` so it could be switched off from
+ * Settings. If the annotator kept reporting it too, every unused import would be flagged twice, on
+ * the same symbol, with only one of the two responding to the setting.
+ */
+class PhelImportValidatorTest : PhelIntegrationTestCase() {
+
+    private var fileIndex = 0
+
+    private fun problemsFor(text: String, namespace: String, occurrence: Int = 0): List<String> {
+        val file = myFixture.configureByText("v${fileIndex++}.phel", text) as PhelFile
+        val symbol = PsiTreeUtil.findChildrenOfType(file, PhelSymbol::class.java)
+            .filter { it.text == namespace && PsiTreeUtil.getParentOfType(it, PhelList::class.java) != null }[occurrence]
+
+        return PhelImportValidator.validateImport(symbol).map { it.message }
+    }
+
+    fun testDoesNotReportAnUnusedImport() {
+        val problems = problemsFor("(ns app\\a\n  (:require phel\\string))\n(println \"hi\")\n", "phel\\string")
+
+        assertEmpty("the unused-import check belongs to PhelUnusedImportInspection now", problems)
+    }
+
+    /** Reported on the second occurrence: the first one is the original, not the duplicate. */
+    fun testStillReportsADuplicateImport() {
+        val source = "(ns app\\a\n  (:require phel\\string)\n  (:require phel\\string))\n(string/join \"\" [])\n"
+
+        val duplicate = problemsFor(source, "phel\\string", occurrence = 1)
+
+        assertTrue(duplicate.toString(), duplicate.any { it.startsWith("Duplicate import") })
+    }
+
+    fun testDoesNotReportTheOriginalAsADuplicate() {
+        val source = "(ns app\\a\n  (:require phel\\string)\n  (:require phel\\string))\n(string/join \"\" [])\n"
+
+        val original = problemsFor(source, "phel\\string", occurrence = 0)
+
+        assertEmpty(original)
+    }
+
+    fun testStillReportsANamespaceThatDoesNotExist() {
+        val problems = problemsFor("(ns app\\a\n  (:require totally\\missing))\n(missing/go)\n", "totally\\missing")
+
+        assertTrue(problems.toString(), problems.any { it.contains("does not exist") })
+    }
+
+    fun testSaysNothingAboutAUsedStandardLibraryImport() {
+        val problems = problemsFor(
+            "(ns app\\a\n  (:require phel\\string))\n(string/join \", \" [1 2])\n",
+            "phel\\string",
+        )
+
+        assertEmpty(problems)
+    }
+
+    /** Regression guard: the file used to also be reachable through PsiManager in this shape. */
+    fun testWorksOnAFileOpenedThroughPsiManager() {
+        val vf = myFixture.addFileToProject(
+            "src/validator_probe.phel",
+            "(ns app\\probe\n  (:require phel\\string))\n(println \"hi\")\n",
+        ).virtualFile
+        val file = PsiManager.getInstance(project).findFile(vf) as PhelFile
+        val symbol = PsiTreeUtil.findChildrenOfType(file, PhelSymbol::class.java).first { it.text == "phel\\string" }
+
+        assertEmpty(PhelImportValidator.validateImport(symbol).map { it.message })
+    }
+}

--- a/src/test/kotlin/org/phellang/integration/inspection/PhelUnusedDefinitionInspectionsTest.kt
+++ b/src/test/kotlin/org/phellang/integration/inspection/PhelUnusedDefinitionInspectionsTest.kt
@@ -1,0 +1,135 @@
+package org.phellang.integration.inspection
+
+import com.intellij.codeInspection.InspectionManager
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiRecursiveElementVisitor
+import org.phellang.inspection.PhelUnusedImportInspection
+import org.phellang.inspection.PhelUnusedParameterInspection
+import org.phellang.inspection.PhelUnusedPrivateDefinitionInspection
+import org.phellang.integration.PhelIntegrationTestCase
+import org.phellang.language.psi.files.PhelFile
+
+/**
+ * The three "never used" inspections.
+ *
+ * All three ship at WEAK WARNING because a false report here is worse than a missed one: it teaches
+ * the user to ignore the plugin. The silent cases below outnumber the reported ones for that reason.
+ */
+class PhelUnusedDefinitionInspectionsTest : PhelIntegrationTestCase() {
+
+    private var fileIndex = 0
+
+    private fun inspect(tool: LocalInspectionTool, source: String): List<String> {
+        // Deliberately does not prime the project index: doing so leaks this file's definitions into
+        // the shared light project (see #271). Everything here resolves from the file's own PSI.
+        val file = myFixture.configureByText("u${fileIndex++}.phel", source) as PhelFile
+
+        val holder = ProblemsHolder(InspectionManager.getInstance(project), file, true)
+        val visitor = tool.buildVisitor(holder, true)
+        file.accept(object : PsiRecursiveElementVisitor() {
+            override fun visitElement(element: PsiElement) {
+                element.accept(visitor)
+                super.visitElement(element)
+            }
+        })
+
+        return holder.results.map { it.descriptionTemplate }
+    }
+
+    // ---- unused private definitions ----
+
+    private fun privateDefinitions(source: String) = inspect(PhelUnusedPrivateDefinitionInspection(), source)
+
+    fun testReportsAPrivateDefinitionNothingCalls() {
+        val problems = privateDefinitions("(ns app\\a)\n(defn- helper [x] (* x 2))\n")
+
+        assertEquals(listOf("Private definition 'helper' is never used."), problems)
+    }
+
+    fun testDoesNotReportAPrivateDefinitionThatIsCalled() {
+        assertEmpty(privateDefinitions("(ns app\\a)\n(defn- helper [x] (* x 2))\n(defn run [] (helper 1))\n"))
+    }
+
+    /** A public definition may be called from another namespace, so its own file cannot judge it. */
+    fun testDoesNotReportAPublicDefinition() {
+        assertEmpty(privateDefinitions("(ns app\\a)\n(defn helper [x] (* x 2))\n"))
+    }
+
+    fun testRecognisesThePrivateMetadataFlag() {
+        val problems = privateDefinitions("(ns app\\a)\n(def ^:private limit 10)\n")
+
+        assertEquals(listOf("Private definition 'limit' is never used."), problems)
+    }
+
+    /** Reporting a recursive helper as unused would be wrong more often than the reverse. */
+    fun testDoesNotReportARecursivePrivateDefinition() {
+        assertEmpty(privateDefinitions("(ns app\\a)\n(defn- countdown [n] (if (zero? n) 0 (countdown (dec n))))\n"))
+    }
+
+    fun testDoesNotReportANestedDefinition() {
+        assertEmpty(privateDefinitions("(ns app\\a)\n(defn run [] (let [helper 1] helper))\n"))
+    }
+
+    // ---- unused parameters ----
+
+    private fun parameters(source: String) = inspect(PhelUnusedParameterInspection(), source)
+
+    fun testReportsAParameterTheBodyNeverReads() {
+        val problems = parameters("(defn greet [name greeting] (println name))\n")
+
+        assertEquals(listOf("Parameter 'greeting' is never used."), problems)
+    }
+
+    fun testDoesNotReportAParameterTheBodyReads() {
+        assertEmpty(parameters("(defn greet [name] (println name))\n"))
+    }
+
+    fun testDoesNotReportAnUnderscoreParameter() {
+        assertEmpty(parameters("(defn greet [_ignored name] (println name))\n"))
+    }
+
+    fun testDoesNotReportARestMarker() {
+        assertEmpty(parameters("(defn greet [name & rest] (println name rest))\n"))
+    }
+
+    fun testReportsInsideAnAnonymousFunction() {
+        val problems = parameters("(defn run [] (map (fn [x y] x) []))\n")
+
+        assertEquals(listOf("Parameter 'y' is never used."), problems)
+    }
+
+    /** No body means nothing reads anything; every parameter would otherwise look unused. */
+    fun testDoesNotReportWhenThereIsNoBody() {
+        assertEmpty(parameters("(defn greet [name])\n"))
+    }
+
+    fun testReportsEveryUnusedParameterInOrder() {
+        val problems = parameters("(defn greet [a b c] (println b))\n")
+
+        assertEquals(
+            listOf("Parameter 'a' is never used.", "Parameter 'c' is never used."),
+            problems,
+        )
+    }
+
+    // ---- unused imports, now an inspection rather than an annotation ----
+
+    private fun imports(source: String) = inspect(PhelUnusedImportInspection(), source)
+
+    fun testReportsAnUnusedImport() {
+        val problems = imports("(ns app\\a\n  (:require phel\\str))\n(println \"hi\")\n")
+
+        assertEquals(listOf("Unused import"), problems)
+    }
+
+    fun testDoesNotReportAUsedImport() {
+        assertEmpty(imports("(ns app\\a\n  (:require phel\\str))\n(str/join \", \" [1 2])\n"))
+    }
+
+    /** A namespace-shaped symbol in ordinary code is not an import. */
+    fun testDoesNotReportOutsideTheNamespaceDeclaration() {
+        assertEmpty(imports("(ns app\\a)\n(println \"phel\\str\")\n"))
+    }
+}

--- a/src/test/kotlin/org/phellang/integration/inspection/PhelUnusedImportTest.kt
+++ b/src/test/kotlin/org/phellang/integration/inspection/PhelUnusedImportTest.kt
@@ -1,16 +1,18 @@
 package org.phellang.integration.inspection
 
 import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.inspection.analysis.PhelUnusedImportFinder
 import org.phellang.integration.PhelIntegrationTestCase
-import org.phellang.annotator.validators.PhelImportValidator
 import org.phellang.language.psi.PhelList
 import org.phellang.language.psi.PhelSymbol
 import org.phellang.language.psi.files.PhelFile
 
 /**
- * Behavioural coverage for [PhelImportValidator.isUnusedImport], guarding the cached
+ * Behavioural coverage for [PhelUnusedImportFinder.isUnusedImport], guarding the cached
  * used-qualifier scan: a required namespace is "unused" only when no `ns/...` call in the
  * file body references it.
+ *
+ * The detection moved here from `PhelImportValidator` when it became a switchable inspection.
  */
 class PhelUnusedImportTest : PhelIntegrationTestCase() {
 
@@ -22,13 +24,27 @@ class PhelUnusedImportTest : PhelIntegrationTestCase() {
         assertTrue(isUnused("(ns app\\m\n  (:require phel\\str))\n(println \"hi\")\n", "phel\\str"))
     }
 
+    /** Under `:as` the alias is the qualifier that counts, not the short namespace. */
+    fun testImportUsedThroughItsAliasIsNotUnused() {
+        assertFalse(isUnused("(ns app\\m\n  (:require phel\\str :as s))\n(s/join \", \" [1 2])\n", "phel\\str"))
+    }
+
+    fun testAliasedImportNeverUsedIsUnused() {
+        assertTrue(isUnused("(ns app\\m\n  (:require phel\\str :as s))\n(println \"hi\")\n", "phel\\str"))
+    }
+
+    /** `:refer` brings names in unqualified, so no qualifier will ever appear for it. */
+    fun testReferredImportIsNeverUnused() {
+        assertFalse(isUnused("(ns app\\m\n  (:require phel\\str :refer [join]))\n(println \"hi\")\n", "phel\\str"))
+    }
+
     private fun isUnused(text: String, requiredNamespace: String): Boolean {
         // Unique path per class — the shared test project does not reliably clean files
-        // between classes, so a shared path would risk cross-test interference.
+        // between classes, so a shared path would risk cross-test interference (see #271).
         val vf = myFixture.addFileToProject("src/unused_import_test.phel", text).virtualFile
         val phelFile = com.intellij.psi.PsiManager.getInstance(project).findFile(vf) as PhelFile
         val symbol = PsiTreeUtil.findChildrenOfType(phelFile, PhelSymbol::class.java)
             .first { it.text == requiredNamespace && PsiTreeUtil.getParentOfType(it, PhelList::class.java) != null }
-        return PhelImportValidator.isUnusedImport(symbol)
+        return PhelUnusedImportFinder.isUnusedImport(symbol)
     }
 }


### PR DESCRIPTION
Adds the two missing "never used" inspections, and converts the existing unused-import warning into a
third so it can be switched off.

All three ship at **WEAK WARNING**. A false report here is worse than a missed one: it teaches the
user to ignore the plugin's warnings.

## Unused private definition

Reports a private top-level definition that nothing in its own file references. Only private ones:
a public definition may be called from any namespace, so its own file cannot judge it.

Privacy is delegated to `PhelDefinitionPrivacy`, the same judgement the symbol index already uses to
decide what to leave out. It handles all three spellings and the cases a textual search for
`:private` gets wrong — `{:private false}` is explicitly public, and a docstring mentioning the word
does not make a definition private.

A recursive call counts as a use. A private function that only calls itself is arguably dead too,
but telling that apart from a genuine use needs call-graph reachability, and at this level staying
quiet is the safer error.

## Unused function parameter

Covers `defn`, `defn-`, `fn`, `defmacro`, `defmacro-`, mirroring `PhelUnusedBindingFinder` including
its `_` and `&` exclusions.

Neither new inspection offers a quick fix: deleting a definition, or changing a function's arity, is
a much larger step than deleting a `let` binding.

## Converting the unused-import check

Worth reading this part. The check already existed and worked — my own issue text claiming otherwise
was wrong, and is [corrected on the issue](https://github.com/phel-lang/phel-intellij-plugin/issues/266#issuecomment-5080092715).
It simply lived in the annotator, so it could not be disabled or re-levelled from Settings.

Splitting it out ran into the architecture boundary: a feature package may not reach into another's
internals, and both halves lived past `annotator`'s root. Two things therefore move **down into
leaves** rather than sideways:

- `language/psi/PhelImportAnalysis` — duplicate detection, now shared.
- `language/psi/utils/PhelImportRemoval` — the PSI removal, shared by both quick fixes.

The first of those is not cosmetic. The existing design deliberately suppresses "unused" on an
import already reported as a duplicate, because a duplicate is trivially also unused and saying both
on one symbol is noise. Splitting the two checks across an annotator and an inspection broke that
rule, and `PhelImportValidationIntegrationTest` caught it — the inspection now consults the same
duplicate check and stays silent on that symbol. That test keeps asserting end-to-end through
`doHighlighting`, since the precedence now spans two extension points and only the rendered result
proves it holds.

The annotator no longer reports unused imports at all, or every one would be flagged twice with only
one copy responding to the setting.

## Also

`PhelValidationProblem`'s doc comment described the unused-import precedence it no longer implements;
updated to match. Its `Severity.WEAK_WARNING` now has no producer, but removing the severity concept
would touch the annotator's rendering path for no user-visible gain, so it stays.

## Test plan

- `./gradlew test` — 1446 tests, 0 failures, confirmed over three consecutive full runs.
- 19 new tests across the three inspections: private definition reported / called / public /
  metadata-flag / recursive / nested; parameter reported / read / `_`-prefixed / rest marker /
  anonymous `fn` / no body / multiple in order; import reported / used / outside the declaration.
- 6 new annotator tests pinning what it must *no longer* say, and what it still must: no unused
  report, duplicate still reported on the second occurrence and not the first, missing namespace
  still reported.
- Existing `PhelUnusedImportTest` retargeted at the moved finder, plus new alias and `:refer` cases.

Not verified in a sandbox IDE: the inspections were driven through `buildVisitor` and
`doHighlighting` rather than by toggling them in Settings.

Closes #266
