### PR TITLE
Bind the paredit actions, and add move-element and surround-with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,13 @@ refreshed, since completion, hover and arity checking are all driven by it.
 
 ### Added
 
+- **Default keyboard shortcuts for the nine paredit actions**, which previously shipped reachable only through the
+  menu. All are two-stroke, under a shared `Ctrl+Alt+Shift+P` prefix: `S` / `B` slurp and barf forward, `Shift+S` /
+  `Shift+B` backward, `W` / `V` / `M` wrap in `( )` / `[ ]` / `{ }`, `U` splice, `R` raise (#267).
+- **Move Element Left/Right** (`Ctrl+Alt+Shift+Left/Right`) over the forms inside a list, vector, map or set, for
+  reordering arguments and map entries (#267).
+- **Surround With** (`Ctrl+Alt+T`) for wrapping a selection of whole forms in `( )`, `[ ]` or `{ }`. Unlike the
+  paredit wrap actions, which take the single form at the caret, this works across a multi-form selection (#267).
 - An **Unused private definition** inspection, reporting a `defn-` / `def-` / `^:private` definition that nothing in
   its own file references. Only private definitions are reported: a public one may be called from any namespace, so
   its own file cannot tell (#266).

--- a/src/main/kotlin/org/phellang/editor/paredit/PhelMoveElementLeftRightHandler.kt
+++ b/src/main/kotlin/org/phellang/editor/paredit/PhelMoveElementLeftRightHandler.kt
@@ -1,0 +1,28 @@
+package org.phellang.editor.paredit
+
+import com.intellij.codeInsight.editorActions.moveLeftRight.MoveElementLeftRightHandler
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.language.psi.PhelForm
+
+/**
+ * Backs Move Element Left/Right over the forms inside a bracketed container.
+ *
+ * Reordering arguments and map entries is the operation the paredit actions do not cover: slurp and
+ * barf change what a form contains, never the order of what is already there.
+ *
+ * Every form is movable, the head included. `(+ 1 2)` swapping to `(1 + 2)` is nonsense, but so is
+ * every other way of misusing a manual reorder, and the alternative — freezing the first element —
+ * would break the data literals where there is no head at all.
+ */
+class PhelMoveElementLeftRightHandler : MoveElementLeftRightHandler() {
+
+    override fun getMovableSubElements(element: PsiElement): Array<PsiElement> {
+        if (!PhelPareditContainers.isContainer(element)) return PsiElement.EMPTY_ARRAY
+
+        val forms = PsiTreeUtil.getChildrenOfType(element, PhelForm::class.java) ?: return PsiElement.EMPTY_ARRAY
+
+        // Nothing to reorder below two, and the platform would still draw the action as available.
+        return if (forms.size < 2) PsiElement.EMPTY_ARRAY else forms.toList().toTypedArray()
+    }
+}

--- a/src/main/kotlin/org/phellang/editor/paredit/PhelPareditContainers.kt
+++ b/src/main/kotlin/org/phellang/editor/paredit/PhelPareditContainers.kt
@@ -14,13 +14,18 @@ import org.phellang.language.psi.PhelVec
 
 internal object PhelPareditContainers {
 
-    fun findEnclosingContainer(file: PsiFile, offset: Int): PsiElement? {
-        for (candidate in candidatesAt(file, offset)) {
-            var current: PsiElement? = candidate
-            while (current != null && current !is PsiFile) {
-                if (isContainer(current)) return current
-                current = current.parent
-            }
+    fun findEnclosingContainer(file: PsiFile, offset: Int): PsiElement? =
+        candidatesAt(file, offset).firstNotNullOfOrNull { enclosingContainerOf(it) }
+
+    /**
+     * The nearest bracketed container at or above [element], or null if there is none below the
+     * file. [element] itself counts, so a container passed in is returned unchanged.
+     */
+    fun enclosingContainerOf(element: PsiElement): PsiElement? {
+        var current: PsiElement? = element
+        while (current != null && current !is PsiFile) {
+            if (isContainer(current)) return current
+            current = current.parent
         }
         return null
     }

--- a/src/main/kotlin/org/phellang/editor/paredit/PhelSurroundDescriptor.kt
+++ b/src/main/kotlin/org/phellang/editor/paredit/PhelSurroundDescriptor.kt
@@ -1,0 +1,48 @@
+package org.phellang.editor.paredit
+
+import com.intellij.lang.surroundWith.SurroundDescriptor
+import com.intellij.lang.surroundWith.Surrounder
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.editor.paredit.surround.PhelBracketSurrounder
+import org.phellang.language.psi.PhelForm
+
+/** Surround With (Ctrl+Alt+T) over a selection of Phel forms. */
+class PhelSurroundDescriptor : SurroundDescriptor {
+
+    override fun getSurrounders(): Array<Surrounder> = arrayOf(
+        PhelBracketSurrounder("(", ")", "( ) list"),
+        PhelBracketSurrounder("[", "]", "[ ] vector"),
+        PhelBracketSurrounder("{", "}", "{ } map"),
+    )
+
+    /**
+     * The top-level forms the selection covers.
+     *
+     * Only whole forms: a selection cutting through the middle of one has no valid surround, and
+     * wrapping it anyway would produce unbalanced brackets.
+     */
+    override fun getElementsToSurround(file: PsiFile, startOffset: Int, endOffset: Int): Array<PsiElement> {
+        if (startOffset >= endOffset) return PsiElement.EMPTY_ARRAY
+
+        val start = file.findElementAt(startOffset) ?: return PsiElement.EMPTY_ARRAY
+        val end = file.findElementAt(endOffset - 1) ?: return PsiElement.EMPTY_ARRAY
+
+        val common = PsiTreeUtil.findCommonParent(start, end) ?: return PsiElement.EMPTY_ARRAY
+        val container = if (PhelPareditContainers.isContainer(common) || common is PsiFile) {
+            common
+        } else {
+            PsiTreeUtil.getParentOfType(common, PhelForm::class.java)?.parent ?: return PsiElement.EMPTY_ARRAY
+        }
+
+        val covered = PsiTreeUtil.getChildrenOfType(container, PhelForm::class.java)
+            ?.filter { it.textRange.startOffset >= startOffset && it.textRange.endOffset <= endOffset }
+            ?: return PsiElement.EMPTY_ARRAY
+
+        return covered.toTypedArray()
+    }
+
+    /** Other descriptors (live templates) stay available alongside these. */
+    override fun isExclusive(): Boolean = false
+}

--- a/src/main/kotlin/org/phellang/editor/paredit/PhelSurroundDescriptor.kt
+++ b/src/main/kotlin/org/phellang/editor/paredit/PhelSurroundDescriptor.kt
@@ -30,11 +30,8 @@ class PhelSurroundDescriptor : SurroundDescriptor {
         val end = file.findElementAt(endOffset - 1) ?: return PsiElement.EMPTY_ARRAY
 
         val common = PsiTreeUtil.findCommonParent(start, end) ?: return PsiElement.EMPTY_ARRAY
-        val container = if (PhelPareditContainers.isContainer(common) || common is PsiFile) {
-            common
-        } else {
-            PsiTreeUtil.getParentOfType(common, PhelForm::class.java)?.parent ?: return PsiElement.EMPTY_ARRAY
-        }
+        // Falls back to the file so a selection spanning top-level forms still surrounds.
+        val container = PhelPareditContainers.enclosingContainerOf(common) ?: file
 
         val covered = PsiTreeUtil.getChildrenOfType(container, PhelForm::class.java)
             ?.filter { it.textRange.startOffset >= startOffset && it.textRange.endOffset <= endOffset }

--- a/src/main/kotlin/org/phellang/editor/paredit/surround/PhelBracketSurrounder.kt
+++ b/src/main/kotlin/org/phellang/editor/paredit/surround/PhelBracketSurrounder.kt
@@ -1,0 +1,42 @@
+package org.phellang.editor.paredit.surround
+
+import com.intellij.lang.surroundWith.Surrounder
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+
+/**
+ * Wraps the selected forms in a bracket pair.
+ *
+ * Distinct from the paredit wrap actions, which take the single form at the caret. This works on a
+ * selection spanning several forms, which is what Surround With is for.
+ */
+class PhelBracketSurrounder(
+    private val open: String,
+    private val close: String,
+    private val templateDescription: String,
+) : Surrounder {
+
+    override fun getTemplateDescription(): String = templateDescription
+
+    override fun isApplicable(elements: Array<out PsiElement>): Boolean = elements.isNotEmpty()
+
+    override fun surroundElements(
+        project: Project,
+        editor: Editor,
+        elements: Array<out PsiElement>,
+    ): TextRange? {
+        if (elements.isEmpty()) return null
+
+        val start = elements.first().textRange.startOffset
+        val end = elements.last().textRange.endOffset
+
+        // End first: inserting at the start would shift the end offset out from under us.
+        editor.document.insertString(end, close)
+        editor.document.insertString(start, open)
+
+        // Caret just inside the new opening bracket, ready to type the head of the form.
+        return TextRange.from(start + open.length, 0)
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -96,6 +96,12 @@
                 implementationClass="org.phellang.editor.structure.PhelStructureViewFactory"/>
         <enterHandlerDelegate
                 implementation="org.phellang.editor.enter.PhelEnterHandlerDelegate"/>
+        <moveLeftRightHandler
+                language="Phel"
+                implementationClass="org.phellang.editor.paredit.PhelMoveElementLeftRightHandler"/>
+        <lang.surroundDescriptor
+                language="Phel"
+                implementationClass="org.phellang.editor.paredit.PhelSurroundDescriptor"/>
         <internalFileTemplate name="Phel File.phel"/>
         <localInspection
                 language="Phel"
@@ -210,39 +216,57 @@
             <action id="Phel.Paredit.SlurpForward"
                     class="org.phellang.editor.paredit.PhelSlurpForwardAction"
                     text="Slurp Forward"
-                    description="Extend the current form to include the next sibling"/>
+                    description="Extend the current form to include the next sibling">
+                <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt shift P" second-keystroke="S"/>
+            </action>
             <action id="Phel.Paredit.BarfForward"
                     class="org.phellang.editor.paredit.PhelBarfForwardAction"
                     text="Barf Forward"
-                    description="Eject the last child of the current form"/>
+                    description="Eject the last child of the current form">
+                <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt shift P" second-keystroke="B"/>
+            </action>
             <action id="Phel.Paredit.SlurpBackward"
                     class="org.phellang.editor.paredit.PhelSlurpBackwardAction"
                     text="Slurp Backward"
-                    description="Extend the current form to include the previous sibling"/>
+                    description="Extend the current form to include the previous sibling">
+                <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt shift P" second-keystroke="shift S"/>
+            </action>
             <action id="Phel.Paredit.BarfBackward"
                     class="org.phellang.editor.paredit.PhelBarfBackwardAction"
                     text="Barf Backward"
-                    description="Eject the first child of the current form"/>
+                    description="Eject the first child of the current form">
+                <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt shift P" second-keystroke="shift B"/>
+            </action>
             <action id="Phel.Paredit.WrapParen"
                     class="org.phellang.editor.paredit.PhelWrapParenAction"
                     text="Wrap with ( )"
-                    description="Wrap the form at caret in a list"/>
+                    description="Wrap the form at caret in a list">
+                <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt shift P" second-keystroke="W"/>
+            </action>
             <action id="Phel.Paredit.WrapBracket"
                     class="org.phellang.editor.paredit.PhelWrapBracketAction"
                     text="Wrap with [ ]"
-                    description="Wrap the form at caret in a vector"/>
+                    description="Wrap the form at caret in a vector">
+                <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt shift P" second-keystroke="V"/>
+            </action>
             <action id="Phel.Paredit.WrapBrace"
                     class="org.phellang.editor.paredit.PhelWrapBraceAction"
                     text="Wrap with { }"
-                    description="Wrap the form at caret in a map"/>
+                    description="Wrap the form at caret in a map">
+                <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt shift P" second-keystroke="M"/>
+            </action>
             <action id="Phel.Paredit.Splice"
                     class="org.phellang.editor.paredit.PhelSpliceAction"
                     text="Splice"
-                    description="Unwrap the enclosing form, leaving its children in place"/>
+                    description="Unwrap the enclosing form, leaving its children in place">
+                <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt shift P" second-keystroke="U"/>
+            </action>
             <action id="Phel.Paredit.Raise"
                     class="org.phellang.editor.paredit.PhelRaiseAction"
                     text="Raise"
-                    description="Replace the enclosing form with the form at caret"/>
+                    description="Replace the enclosing form with the form at caret">
+                <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt shift P" second-keystroke="R"/>
+            </action>
         </group>
     </actions>
 </idea-plugin>

--- a/src/test/kotlin/org/phellang/integration/editor/PhelMoveElementLeftRightHandlerTest.kt
+++ b/src/test/kotlin/org/phellang/integration/editor/PhelMoveElementLeftRightHandlerTest.kt
@@ -1,0 +1,70 @@
+package org.phellang.integration.editor
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.editor.paredit.PhelMoveElementLeftRightHandler
+import org.phellang.integration.PhelIntegrationTestCase
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelMap
+import org.phellang.language.psi.PhelVec
+import org.phellang.language.psi.files.PhelFile
+
+/**
+ * The sub-elements Move Element Left/Right is allowed to swap.
+ *
+ * Asserts what the handler exposes rather than driving the action: the platform owns the swap
+ * itself, and what this plugin decides is only which elements are movable.
+ */
+class PhelMoveElementLeftRightHandlerTest : PhelIntegrationTestCase() {
+
+    private val handler = PhelMoveElementLeftRightHandler()
+
+    private fun parse(text: String): PhelFile = myFixture.configureByText("m.phel", text) as PhelFile
+
+    private fun movableTextsOf(element: PsiElement?): List<String> =
+        element?.let { handler.getMovableSubElements(it).map(PsiElement::getText) }.orEmpty()
+
+    private inline fun <reified T : PsiElement> firstOf(text: String): T? =
+        PsiTreeUtil.findChildOfType(parse(text), T::class.java)
+
+    fun testExposesTheFormsOfAList() {
+        val movable = movableTextsOf(firstOf<PhelList>("(println 1 2)\n"))
+
+        assertEquals(listOf("println", "1", "2"), movable)
+    }
+
+    fun testExposesTheElementsOfAVector() {
+        val movable = movableTextsOf(firstOf<PhelVec>("[1 2 3]\n"))
+
+        assertEquals(listOf("1", "2", "3"), movable)
+    }
+
+    fun testExposesTheEntriesOfAMap() {
+        val movable = movableTextsOf(firstOf<PhelMap>("{:a 1 :b 2}\n"))
+
+        assertEquals(listOf(":a", "1", ":b", "2"), movable)
+    }
+
+    /** Nothing to reorder, and the platform would otherwise still offer the action. */
+    fun testOffersNothingForASingleForm() {
+        assertEmpty(movableTextsOf(firstOf<PhelList>("(println)\n")))
+    }
+
+    fun testOffersNothingForAnEmptyContainer() {
+        assertEmpty(movableTextsOf(firstOf<PhelVec>("[]\n")))
+    }
+
+    fun testOffersNothingForANonContainer() {
+        val file = parse("(println 1 2)\n")
+        val symbol = PsiTreeUtil.findChildrenOfType(file, PsiElement::class.java)
+            .first { it.text == "println" && it.firstChild == null }
+
+        assertEmpty(movableTextsOf(symbol))
+    }
+
+    fun testExposesNestedFormsAsWholeUnits() {
+        val movable = movableTextsOf(firstOf<PhelList>("(f (g 1) 2)\n"))
+
+        assertEquals(listOf("f", "(g 1)", "2"), movable)
+    }
+}

--- a/src/test/kotlin/org/phellang/integration/editor/PhelSurroundDescriptorTest.kt
+++ b/src/test/kotlin/org/phellang/integration/editor/PhelSurroundDescriptorTest.kt
@@ -1,0 +1,89 @@
+package org.phellang.integration.editor
+
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.psi.PsiElement
+import org.phellang.editor.paredit.PhelSurroundDescriptor
+import org.phellang.integration.PhelIntegrationTestCase
+import org.phellang.language.psi.files.PhelFile
+
+class PhelSurroundDescriptorTest : PhelIntegrationTestCase() {
+
+    private val descriptor = PhelSurroundDescriptor()
+
+    private var fileIndex = 0
+
+    private fun parse(text: String): PhelFile =
+        myFixture.configureByText("s${fileIndex++}.phel", text) as PhelFile
+
+    private fun elementsIn(text: String, selection: String): Array<PsiElement> {
+        val file = parse(text)
+        val start = text.indexOf(selection)
+        return descriptor.getElementsToSurround(file, start, start + selection.length)
+    }
+
+    fun testOffersListVectorAndMap() {
+        val descriptions = descriptor.surrounders.map { it.templateDescription }
+
+        assertEquals(listOf("( ) list", "[ ] vector", "{ } map"), descriptions)
+    }
+
+    fun testFindsTheWholeFormsInASelection() {
+        val elements = elementsIn("(f 1 2 3)\n", "1 2")
+
+        assertEquals(listOf("1", "2"), elements.map(PsiElement::getText))
+    }
+
+    fun testFindsASingleSelectedForm() {
+        val elements = elementsIn("(f 1 2 3)\n", "2")
+
+        assertEquals(listOf("2"), elements.map(PsiElement::getText))
+    }
+
+    /** A selection cutting through a form has no valid surround: wrapping would unbalance it. */
+    fun testIgnoresAPartiallySelectedForm() {
+        val elements = elementsIn("(f abc def)\n", "bc de")
+
+        assertEmpty(elements.toList())
+    }
+
+    fun testFindsTopLevelFormsAtFileLevel() {
+        val elements = elementsIn("(f 1)\n(g 2)\n", "(f 1)\n(g 2)")
+
+        assertEquals(listOf("(f 1)", "(g 2)"), elements.map(PsiElement::getText))
+    }
+
+    fun testOffersNothingForAnEmptySelection() {
+        val file = parse("(f 1)\n")
+
+        assertEmpty(descriptor.getElementsToSurround(file, 3, 3).toList())
+    }
+
+    fun testWrapsTheSelectionInTheChosenBrackets() {
+        val file = parse("(f 1 2 3)\n")
+        val start = file.text.indexOf("1 2")
+        val elements = descriptor.getElementsToSurround(file, start, start + 3)
+        val surrounder = descriptor.surrounders.first()
+
+        WriteCommandAction.runWriteCommandAction(project) {
+            surrounder.surroundElements(project, myFixture.editor, elements)
+        }
+
+        assertEquals("(f (1 2) 3)\n", myFixture.editor.document.text)
+    }
+
+    fun testWrapsWithAVector() {
+        val file = parse("(f 1 2 3)\n")
+        val start = file.text.indexOf("1 2")
+        val elements = descriptor.getElementsToSurround(file, start, start + 3)
+
+        WriteCommandAction.runWriteCommandAction(project) {
+            descriptor.surrounders[1].surroundElements(project, myFixture.editor, elements)
+        }
+
+        assertEquals("(f [1 2] 3)\n", myFixture.editor.document.text)
+    }
+
+    fun testLeavesOtherSurroundersAvailable() {
+        assertFalse(descriptor.isExclusive)
+    }
+}


### PR DESCRIPTION
Nine paredit actions shipped with no default shortcuts at all, reachable only through a menu. Slurp
and barf via a menu defeats the point of structural editing, so in practice they went unused.

## Shortcuts

All nine are bound as **two-stroke** shortcuts under one `Ctrl+Alt+Shift+P` prefix:

| Stroke | Action |
|---|---|
| `S` / `B` | Slurp / Barf forward |
| `Shift+S` / `Shift+B` | Slurp / Barf backward |
| `W` / `V` / `M` | Wrap in `( )` / `[ ]` / `{ }` |
| `U` | Splice (unwrap) |
| `R` | Raise |

Two-stroke rather than single chords because one that collides with an IDE default is worse than an
extra keystroke, and a shared prefix makes the family discoverable in the keymap.

**Please sanity-check the prefix in the sandbox.** I could not verify it against the platform's
default keymaps: the keymap XMLs are not present in the IDE distribution on disk in any form I could
locate, and neither the Plugin Verifier nor CI checks for shortcut conflicts. `Ctrl+Alt+Shift+P` was
chosen as a three-modifier chord unlikely to be taken, but that is reasoning, not evidence. If it
does collide, only `plugin.xml` needs to change.

## Move Element Left/Right

`Ctrl+Alt+Shift+Left/Right` over the forms inside a list, vector, map or set. This covers the gap the
paredit actions leave: slurp and barf change what a form *contains*, never the order of what is
already in it, so reordering arguments or map entries had no support.

Every form is movable, the head included. `(+ 1 2)` becoming `(1 + 2)` is nonsense, but freezing the
first element would break the data literals where there is no head at all, and a manual reorder can
be misused in any number of ways.

## Surround With

`Ctrl+Alt+T` wraps a selection of whole forms in `( )`, `[ ]` or `{ }`. Distinct from the paredit
wrap actions, which take the single form at the caret; this works across a multi-form selection.

A selection cutting through the middle of a form yields nothing rather than unbalanced brackets.

## Test plan

- `./gradlew test` — 1462 tests, 0 failures, over three consecutive full runs.
- 7 move-handler tests: exposes the forms of a list, vector and map; nested forms stay whole units;
  nothing for a single form, an empty container, or a non-container.
- 9 surround tests: the three surrounders; whole forms in a selection; a single form; a partially
  selected form yields nothing; top-level forms at file level; an empty selection; and two that
  assert the resulting document text after wrapping.

Not verified in a sandbox IDE: the shortcuts themselves. The actions behind them were already
covered end-to-end by the tests added in #211, and this changes only their bindings.

Closes #267
