### PR TITLE
Bundle live templates and spellcheck prose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ refreshed, since completion, hover and arity checking are all driven by it.
 
 ### Added
 
+- **Live templates** for eleven forms: `defn-`, `defmacro`, `ns`, `deftest`, `when`, `when-let`, `loop`, `cond`,
+  `case`, `try` and `foreach`. They appear under Settings > Editor > Live Templates > Phel, expand with Tab, and can
+  be edited or extended. The six abbreviations completion already offers (`()`, `defn`, `def`, `let`, `if`, `fn`) are
+  deliberately not redefined, so no name produces two differently-behaving entries (#268).
+- **Spellchecking** of string literals, including docstrings, and line comments. Symbols are not checked: in a Lisp
+  nearly every token is one, and checking them would underline most of a file (#268).
 - **Default keyboard shortcuts for the nine paredit actions**, which previously shipped reachable only through the
   menu. All are two-stroke, under a shared `Ctrl+Alt+Shift+P` prefix: `S` / `B` slurp and barf forward, `Shift+S` /
   `Shift+B` backward, `W` / `V` / `M` wrap in `( )` / `[ ]` / `{ }`, `U` splice, `R` raise (#267).

--- a/src/main/kotlin/org/phellang/editor/spellchecking/PhelSpellcheckingStrategy.kt
+++ b/src/main/kotlin/org/phellang/editor/spellchecking/PhelSpellcheckingStrategy.kt
@@ -1,0 +1,23 @@
+package org.phellang.editor.spellchecking
+
+import com.intellij.psi.PsiElement
+import com.intellij.spellchecker.tokenizer.SpellcheckingStrategy
+import com.intellij.spellchecker.tokenizer.Tokenizer
+import org.phellang.language.psi.PhelTypes
+
+/**
+ * Spellchecks the prose in a Phel file: string literals, which includes docstrings, and comments.
+ *
+ * Symbols are deliberately left alone. In a Lisp almost every token is a symbol — `defn`, `pos?`,
+ * `str/join`, plus the 900-odd names in the registry — and checking them would underline most of a
+ * file. Docstrings are where a typo actually escapes, since the plugin renders them in hover
+ * documentation and the completion popup, and `phel doc` publishes them.
+ */
+class PhelSpellcheckingStrategy : SpellcheckingStrategy() {
+
+    override fun getTokenizer(element: PsiElement): Tokenizer<*> = when (element.node?.elementType) {
+        PhelTypes.STRING -> TEXT_TOKENIZER
+        PhelTypes.LINE_COMMENT -> TEXT_TOKENIZER
+        else -> EMPTY_TOKENIZER
+    }
+}

--- a/src/main/kotlin/org/phellang/editor/templates/PhelTemplateContextType.kt
+++ b/src/main/kotlin/org/phellang/editor/templates/PhelTemplateContextType.kt
@@ -1,0 +1,12 @@
+package org.phellang.editor.templates
+
+import com.intellij.codeInsight.template.TemplateActionContext
+import com.intellij.codeInsight.template.TemplateContextType
+import org.phellang.language.psi.files.PhelFile
+
+/** Scopes the bundled live templates to Phel files, so they are not offered everywhere else. */
+class PhelTemplateContextType : TemplateContextType("Phel") {
+
+    override fun isInContext(templateActionContext: TemplateActionContext): Boolean =
+        templateActionContext.file is PhelFile
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -103,6 +103,13 @@
                 language="Phel"
                 implementationClass="org.phellang.editor.paredit.PhelSurroundDescriptor"/>
         <internalFileTemplate name="Phel File.phel"/>
+        <defaultLiveTemplates file="/liveTemplates/Phel.xml"/>
+        <liveTemplateContext
+                contextId="Phel"
+                implementation="org.phellang.editor.templates.PhelTemplateContextType"/>
+        <spellchecker.support
+                language="Phel"
+                implementationClass="org.phellang.editor.spellchecking.PhelSpellcheckingStrategy"/>
         <localInspection
                 language="Phel"
                 shortName="PhelDeprecatedFunction"

--- a/src/main/resources/liveTemplates/Phel.xml
+++ b/src/main/resources/liveTemplates/Phel.xml
@@ -1,0 +1,103 @@
+<templateSet group="Phel">
+  <!--
+    Deliberately does not redefine (), defn, def, let, if or fn. Those six are already offered by
+    PhelMainCompletionProvider's FORM_TEMPLATES, and a live template sharing an abbreviation would
+    put two differently-behaving entries under one name in the completion popup.
+  -->
+  <template name="defn-" value="(defn- $NAME$ [$ARGS$]&#10;  $END$)" description="Private function"
+            toReformat="false" toShortenFQNames="false">
+    <variable name="NAME" expression="" defaultValue="&quot;name&quot;" alwaysStopAt="true"/>
+    <variable name="ARGS" expression="" defaultValue="" alwaysStopAt="true"/>
+    <context>
+      <option name="Phel" value="true"/>
+    </context>
+  </template>
+
+  <template name="defmacro" value="(defmacro $NAME$ [$ARGS$]&#10;  $END$)" description="Macro"
+            toReformat="false" toShortenFQNames="false">
+    <variable name="NAME" expression="" defaultValue="&quot;name&quot;" alwaysStopAt="true"/>
+    <variable name="ARGS" expression="" defaultValue="" alwaysStopAt="true"/>
+    <context>
+      <option name="Phel" value="true"/>
+    </context>
+  </template>
+
+  <template name="ns" value="(ns $NAME$)&#10;$END$" description="Namespace declaration"
+            toReformat="false" toShortenFQNames="false">
+    <variable name="NAME" expression="" defaultValue="&quot;namespace&quot;" alwaysStopAt="true"/>
+    <context>
+      <option name="Phel" value="true"/>
+    </context>
+  </template>
+
+  <template name="deftest" value="(deftest $NAME$&#10;  $END$)" description="Test"
+            toReformat="false" toShortenFQNames="false">
+    <variable name="NAME" expression="" defaultValue="&quot;test-name&quot;" alwaysStopAt="true"/>
+    <context>
+      <option name="Phel" value="true"/>
+    </context>
+  </template>
+
+  <template name="when" value="(when $COND$&#10;  $END$)" description="when"
+            toReformat="false" toShortenFQNames="false">
+    <variable name="COND" expression="" defaultValue="&quot;condition&quot;" alwaysStopAt="true"/>
+    <context>
+      <option name="Phel" value="true"/>
+    </context>
+  </template>
+
+  <template name="when-let" value="(when-let [$BINDING$ $VALUE$]&#10;  $END$)" description="when-let"
+            toReformat="false" toShortenFQNames="false">
+    <variable name="BINDING" expression="" defaultValue="&quot;binding&quot;" alwaysStopAt="true"/>
+    <variable name="VALUE" expression="" defaultValue="" alwaysStopAt="true"/>
+    <context>
+      <option name="Phel" value="true"/>
+    </context>
+  </template>
+
+  <template name="loop" value="(loop [$BINDING$ $VALUE$]&#10;  $END$)" description="loop"
+            toReformat="false" toShortenFQNames="false">
+    <variable name="BINDING" expression="" defaultValue="&quot;binding&quot;" alwaysStopAt="true"/>
+    <variable name="VALUE" expression="" defaultValue="" alwaysStopAt="true"/>
+    <context>
+      <option name="Phel" value="true"/>
+    </context>
+  </template>
+
+  <template name="cond" value="(cond&#10;  $COND$ $RESULT$&#10;  $END$)" description="cond"
+            toReformat="false" toShortenFQNames="false">
+    <variable name="COND" expression="" defaultValue="&quot;condition&quot;" alwaysStopAt="true"/>
+    <variable name="RESULT" expression="" defaultValue="" alwaysStopAt="true"/>
+    <context>
+      <option name="Phel" value="true"/>
+    </context>
+  </template>
+
+  <template name="case" value="(case $EXPR$&#10;  $VALUE$ $RESULT$&#10;  $END$)" description="case"
+            toReformat="false" toShortenFQNames="false">
+    <variable name="EXPR" expression="" defaultValue="&quot;expr&quot;" alwaysStopAt="true"/>
+    <variable name="VALUE" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="RESULT" expression="" defaultValue="" alwaysStopAt="true"/>
+    <context>
+      <option name="Phel" value="true"/>
+    </context>
+  </template>
+
+  <template name="try" value="(try&#10;  $BODY$&#10;  (catch $EXCEPTION$ e&#10;    $END$))" description="try/catch"
+            toReformat="false" toShortenFQNames="false">
+    <variable name="BODY" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="EXCEPTION" expression="" defaultValue="&quot;\\Exception&quot;" alwaysStopAt="true"/>
+    <context>
+      <option name="Phel" value="true"/>
+    </context>
+  </template>
+
+  <template name="foreach" value="(foreach [$BINDING$ $COLL$]&#10;  $END$)" description="foreach"
+            toReformat="false" toShortenFQNames="false">
+    <variable name="BINDING" expression="" defaultValue="&quot;item&quot;" alwaysStopAt="true"/>
+    <variable name="COLL" expression="" defaultValue="&quot;coll&quot;" alwaysStopAt="true"/>
+    <context>
+      <option name="Phel" value="true"/>
+    </context>
+  </template>
+</templateSet>

--- a/src/test/kotlin/org/phellang/integration/editor/PhelLiveTemplatesTest.kt
+++ b/src/test/kotlin/org/phellang/integration/editor/PhelLiveTemplatesTest.kt
@@ -1,0 +1,89 @@
+package org.phellang.integration.editor
+
+import com.intellij.codeInsight.template.TemplateActionContext
+import com.intellij.codeInsight.template.impl.TemplateSettings
+import org.phellang.editor.templates.PhelTemplateContextType
+import org.phellang.integration.PhelIntegrationTestCase
+
+/**
+ * The bundled live templates and the context that scopes them.
+ *
+ * The abbreviation set matters as much as the templates: `PhelMainCompletionProvider.FORM_TEMPLATES`
+ * already offers `()`, `defn`, `def`, `let`, `if` and `fn` through completion, and a live template
+ * sharing one of those names would put two differently-behaving entries under it.
+ */
+class PhelLiveTemplatesTest : PhelIntegrationTestCase() {
+
+    private val contextType = PhelTemplateContextType()
+
+    private fun bundledAbbreviations(): List<String> =
+        TemplateSettings.getInstance().templates
+            .filter { it.groupName == "Phel" }
+            .map { it.key }
+
+    fun testBundlesThePhelTemplateGroup() {
+        assertTrue("expected the Phel live template group to be registered", bundledAbbreviations().isNotEmpty())
+    }
+
+    fun testOffersTemplatesForFormsCompletionDoesNotCover() {
+        val abbreviations = bundledAbbreviations()
+
+        for (expected in listOf("defn-", "defmacro", "ns", "deftest", "when", "loop", "cond", "try")) {
+            assertTrue("expected a '$expected' live template, got $abbreviations", expected in abbreviations)
+        }
+    }
+
+    /** The six the completion contributor already provides; duplicating them would be confusing. */
+    fun testDoesNotRedefineTheCompletionTemplates() {
+        val abbreviations = bundledAbbreviations()
+
+        for (owned in listOf("()", "defn", "def", "let", "if", "fn")) {
+            assertFalse("'$owned' is already a completion template, so it must not also be a live template",
+                owned in abbreviations)
+        }
+    }
+
+    fun testTemplatesApplyInsidePhelFiles() {
+        val file = myFixture.configureByText("t.phel", "\n")
+
+        assertTrue(contextType.isInContext(TemplateActionContext.expanding(file, 0)))
+    }
+
+    fun testTemplatesDoNotApplyOutsidePhelFiles() {
+        val file = myFixture.configureByText("t.txt", "\n")
+
+        assertFalse(contextType.isInContext(TemplateActionContext.expanding(file, 0)))
+    }
+
+    /**
+     * Every bundled template must declare the Phel context, or it is offered in every file type.
+     *
+     * Asserted against the shipped XML rather than the loaded `TemplateContext`: reaching the
+     * registered context instance needs `contextId`, which the extension-point registration supplies
+     * and a locally constructed instance lacks, and the platform asserts on its absence.
+     */
+    fun testEveryBundledTemplateDeclaresThePhelContext() {
+        val xml = javaClass.getResourceAsStream("/liveTemplates/Phel.xml")
+            ?.bufferedReader()?.readText()
+            ?: fail("the bundled live template set must be on the classpath")
+
+        val declarations = xml.toString().split("<template ").drop(1)
+        assertTrue("expected bundled templates, found none", declarations.isNotEmpty())
+
+        for (declaration in declarations) {
+            val name = declaration.substringAfter("name=\"").substringBefore("\"")
+            assertTrue(
+                "template '$name' must declare <option name=\"Phel\" value=\"true\"/>",
+                declaration.contains("<option name=\"Phel\" value=\"true\"/>"),
+            )
+        }
+    }
+
+    fun testBundlesEveryTemplateFromTheXml() {
+        val xml = javaClass.getResourceAsStream("/liveTemplates/Phel.xml")!!.bufferedReader().readText()
+        val declared = xml.split("<template ").drop(1)
+            .map { it.substringAfter("name=\"").substringBefore("\"") }
+
+        assertEquals(declared.sorted(), bundledAbbreviations().sorted())
+    }
+}

--- a/src/test/kotlin/org/phellang/integration/editor/PhelLiveTemplatesTest.kt
+++ b/src/test/kotlin/org/phellang/integration/editor/PhelLiveTemplatesTest.kt
@@ -16,6 +16,18 @@ class PhelLiveTemplatesTest : PhelIntegrationTestCase() {
 
     private val contextType = PhelTemplateContextType()
 
+    /** The raw `<template …>` declarations from the shipped XML, one string each. */
+    private fun declarations(): List<String> {
+        val xml = javaClass.getResourceAsStream(TEMPLATE_RESOURCE)
+            ?.bufferedReader()?.readText()
+            ?: fail("$TEMPLATE_RESOURCE must be on the classpath")
+
+        return xml.toString().split("<template ").drop(1)
+    }
+
+    private fun declaredAbbreviations(): List<String> =
+        declarations().map { it.substringAfter("name=\"").substringBefore("\"") }
+
     private fun bundledAbbreviations(): List<String> =
         TemplateSettings.getInstance().templates
             .filter { it.groupName == "Phel" }
@@ -63,11 +75,7 @@ class PhelLiveTemplatesTest : PhelIntegrationTestCase() {
      * and a locally constructed instance lacks, and the platform asserts on its absence.
      */
     fun testEveryBundledTemplateDeclaresThePhelContext() {
-        val xml = javaClass.getResourceAsStream("/liveTemplates/Phel.xml")
-            ?.bufferedReader()?.readText()
-            ?: fail("the bundled live template set must be on the classpath")
-
-        val declarations = xml.toString().split("<template ").drop(1)
+        val declarations = declarations()
         assertTrue("expected bundled templates, found none", declarations.isNotEmpty())
 
         for (declaration in declarations) {
@@ -79,11 +87,12 @@ class PhelLiveTemplatesTest : PhelIntegrationTestCase() {
         }
     }
 
+    /** Guards the registration itself: a template in the XML that the IDE never loaded. */
     fun testBundlesEveryTemplateFromTheXml() {
-        val xml = javaClass.getResourceAsStream("/liveTemplates/Phel.xml")!!.bufferedReader().readText()
-        val declared = xml.split("<template ").drop(1)
-            .map { it.substringAfter("name=\"").substringBefore("\"") }
+        assertEquals(declaredAbbreviations().sorted(), bundledAbbreviations().sorted())
+    }
 
-        assertEquals(declared.sorted(), bundledAbbreviations().sorted())
+    private companion object {
+        const val TEMPLATE_RESOURCE = "/liveTemplates/Phel.xml"
     }
 }

--- a/src/test/kotlin/org/phellang/integration/editor/PhelSpellcheckingStrategyTest.kt
+++ b/src/test/kotlin/org/phellang/integration/editor/PhelSpellcheckingStrategyTest.kt
@@ -1,0 +1,55 @@
+package org.phellang.integration.editor
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.spellchecker.tokenizer.SpellcheckingStrategy
+import org.phellang.editor.spellchecking.PhelSpellcheckingStrategy
+import org.phellang.integration.PhelIntegrationTestCase
+import org.phellang.language.psi.PhelTypes
+
+class PhelSpellcheckingStrategyTest : PhelIntegrationTestCase() {
+
+    private val strategy = PhelSpellcheckingStrategy()
+
+    private var fileIndex = 0
+
+    /** The leaf carrying [elementType], as the spellchecker would encounter it. */
+    private fun leafOfType(text: String, elementType: Any): PsiElement? {
+        val file = myFixture.configureByText("sp${fileIndex++}.phel", text)
+        return PsiTreeUtil.collectElements(file) { it.firstChild == null && it.node?.elementType == elementType }
+            .firstOrNull()
+    }
+
+    private fun tokenizes(element: PsiElement?): Boolean =
+        element != null && strategy.getTokenizer(element) !== SpellcheckingStrategy.EMPTY_TOKENIZER
+
+    fun testChecksStringLiterals() {
+        assertTrue(tokenizes(leafOfType("(def greeting \"helo wrld\")\n", PhelTypes.STRING)))
+    }
+
+    /** Docstrings are string literals, and are the case that matters most: hover renders them. */
+    fun testChecksADocstring() {
+        val source = "(defn greet\n  \"Returns a greetng.\"\n  [name]\n  name)\n"
+
+        assertTrue(tokenizes(leafOfType(source, PhelTypes.STRING)))
+    }
+
+    fun testChecksLineComments() {
+        assertTrue(tokenizes(leafOfType("; a coment about things\n(def x 1)\n", PhelTypes.LINE_COMMENT)))
+    }
+
+    /**
+     * Almost every token in a Lisp is a symbol, so checking them would underline most of a file.
+     */
+    fun testLeavesSymbolsAlone() {
+        assertFalse(tokenizes(leafOfType("(defn greet [nme] nme)\n", PhelTypes.SYM)))
+    }
+
+    fun testLeavesKeywordsAlone() {
+        assertFalse(tokenizes(leafOfType("(def m {:naem 1})\n", PhelTypes.KEYWORD)))
+    }
+
+    fun testLeavesNumbersAlone() {
+        assertFalse(tokenizes(leafOfType("(def x 42)\n", PhelTypes.NUMBER)))
+    }
+}


### PR DESCRIPTION
The last two platform integrations from the post-1.1.0 sweep.

## Live templates

Eleven forms: `defn-`, `defmacro`, `ns`, `deftest`, `when`, `when-let`, `loop`, `cond`, `case`, `try`,
`foreach`. They appear under Settings > Editor > Live Templates > Phel, expand with Tab, offer
tab-through placeholders, and can be edited or extended — none of which the completion templates
allow, since those insert a fixed snippet.

**On the overlap question the issue raised.** `PhelMainCompletionProvider.FORM_TEMPLATES` already
offers `()`, `defn`, `def`, `let`, `if` and `fn`. Those six are deliberately *not* redefined here: a
live template sharing an abbreviation would put two differently-behaving entries under one name in
the completion popup, which is exactly the trap the issue called out.

I considered replacing the completion templates outright, which is the cleaner end state — live
templates are strictly more capable, and no test pins the completion ones. I did not, because the
completion ordering (`parens → templates → ns-qualified → locals → PHP interop`) is documented
convention in `completion-registry.md`, and removing working behaviour is a larger change than this
issue asked for. Worth doing as a follow-up if you want one mechanism rather than two; happy to file
it.

A test asserts both halves of that decision: the eleven are present, and the six are absent.

## Spellchecking

String literals, docstrings among them, and line comments.

**Symbols are deliberately not checked.** The issue proposed splitting symbol names on `-`, and I did
not implement that. In a Lisp nearly every token is a symbol — `defn`, `pos?`, `str/join`, plus the
900-odd names in the registry — so checking them would underline most of a file and train users to
ignore the squiggles. Docstrings are where a typo actually escapes, since hover documentation, the
completion popup and the published API docs all render them, and that is what the issue's own
use-case paragraph argues.

If you want symbol checking anyway, the narrower version worth considering is definition names only
(what a `defn` or `def` introduces), where the count is small and a typo is costly.

`PhelParserDefinition.getStringLiteralElements()` still returns `TokenSet.EMPTY`. Spellchecking is
driven by the strategy and does not need it, and I could not verify locally what else keys off that
value — the quote handler is the obvious candidate — so I left it alone rather than change it
speculatively.

## Test plan

- `./gradlew test` — 1475 tests, 0 failures, over three consecutive full runs.
- 7 live-template tests: the group registers; the eleven are offered; the six completion-owned
  abbreviations are absent; the context applies in `.phel` and not in `.txt`; every shipped template
  declares the Phel context; and everything in the XML actually loaded.
- 6 spellchecking tests: strings, docstrings and line comments are tokenized; symbols, keywords and
  numbers are not.

Not verified in a sandbox IDE: templates were asserted through `TemplateSettings` and the shipped
XML rather than by typing an abbreviation and pressing Tab, and spellchecking through the strategy's
tokenizer rather than by observing a squiggle.

Closes #268
