### PR TITLE
Add REPL and test run configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,11 @@ refreshed, since completion, hover and arity checking are all driven by it.
   indents two spaces per level, matching what pressing Enter already does (#265).
 - A **Code Style page** for Phel (Settings > Editor > Code Style > Phel), so indentation is configurable and persists
   per project (#265).
+- A **REPL** run configuration, launching `phel repl` in the Run console, which accepts typed input and forwards it
+  to the process (#263).
+- A **test** run configuration, running `phel test` over the whole suite or over named paths. Output goes to the
+  plain console: `phel test` takes a `--reporter`, which is what an IDE test tree would need, but mapping a
+  reporter's output onto the platform's test model means pinning a format the plugin cannot verify from here (#263).
 - A **run configuration** for Phel files. Right-click a `.phel` file, or use the Run icon in the gutter beside its
   `(ns …)` form, to run it through the project's `phel` binary. The binary is found the same way the formatter finds
   it (`./bin/phel`, then `./vendor/bin/phel`) and runs with the login shell's environment, so a Homebrew, Herd, asdf

--- a/src/main/kotlin/org/phellang/run/PhelCliRunConfiguration.kt
+++ b/src/main/kotlin/org/phellang/run/PhelCliRunConfiguration.kt
@@ -1,0 +1,82 @@
+package org.phellang.run
+
+import com.intellij.execution.ExecutionException
+import com.intellij.execution.Executor
+import com.intellij.execution.configurations.CommandLineState
+import com.intellij.execution.configurations.ConfigurationFactory
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.configurations.LocatableConfigurationBase
+import com.intellij.execution.configurations.RunProfileState
+import com.intellij.execution.configurations.RuntimeConfigurationError
+import com.intellij.execution.process.KillableColoredProcessHandler
+import com.intellij.execution.process.ProcessHandler
+import com.intellij.execution.process.ProcessTerminatedListener
+import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.JDOMExternalizerUtil
+import org.jdom.Element
+import org.phellang.core.cli.PhelCliLocator
+import java.io.File
+
+/**
+ * What every `phel` invocation launched from the IDE has in common: finding the binary, choosing a
+ * working directory, and running it in a killable console.
+ *
+ * Subclasses supply only the command line. Without this the run, REPL and test configurations would
+ * each carry their own copy of the binary lookup and process wiring, and the three would drift.
+ */
+abstract class PhelCliRunConfiguration(
+    project: Project,
+    factory: ConfigurationFactory,
+    name: String,
+) : LocatableConfigurationBase<RunProfileState>(project, factory, name) {
+
+    var workingDirectory: String = ""
+
+    protected abstract fun commandLine(binary: File): GeneralCommandLine
+
+    /** Falls back to the project root, which is where `phel` resolves `phel-config.php`. */
+    fun effectiveWorkingDirectory(): String = workingDirectory.ifBlank { project.basePath.orEmpty() }
+
+    override fun checkConfiguration() {
+        val basePath = project.basePath ?: throw RuntimeConfigurationError("No project base path available")
+        if (PhelCliLocator.locate(basePath) == null) {
+            throw RuntimeConfigurationError(PhelCliLocator.NOT_FOUND_MESSAGE)
+        }
+    }
+
+    /**
+     * Resolved again at launch rather than carried over from [checkConfiguration]: a `composer
+     * install` between validating the dialog and pressing Run is exactly when this changes.
+     */
+    protected fun requireBinary(): File {
+        val basePath = project.basePath ?: throw ExecutionException("No project base path available")
+        return PhelCliLocator.locate(basePath) ?: throw ExecutionException(PhelCliLocator.NOT_FOUND_MESSAGE)
+    }
+
+    override fun getState(executor: Executor, environment: ExecutionEnvironment): RunProfileState =
+        object : CommandLineState(environment) {
+            override fun startProcess(): ProcessHandler {
+                // Killable so Stop terminates a long-running script or a REPL waiting on input,
+                // rather than detaching from it.
+                val handler = KillableColoredProcessHandler(commandLine(requireBinary()))
+                ProcessTerminatedListener.attach(handler)
+                return handler
+            }
+        }
+
+    override fun writeExternal(element: Element) {
+        super.writeExternal(element)
+        JDOMExternalizerUtil.writeField(element, WORKING_DIRECTORY_FIELD, workingDirectory)
+    }
+
+    override fun readExternal(element: Element) {
+        super.readExternal(element)
+        workingDirectory = JDOMExternalizerUtil.readField(element, WORKING_DIRECTORY_FIELD).orEmpty()
+    }
+
+    protected companion object {
+        // Field names are persisted in workspace.xml; changing one silently drops the saved value.
+        const val WORKING_DIRECTORY_FIELD = "WORKING_DIRECTORY"
+    }
+}

--- a/src/main/kotlin/org/phellang/run/PhelReplConfiguration.kt
+++ b/src/main/kotlin/org/phellang/run/PhelReplConfiguration.kt
@@ -1,0 +1,32 @@
+package org.phellang.run
+
+import com.intellij.execution.configurations.ConfigurationFactory
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.configurations.RunConfiguration
+import com.intellij.openapi.options.SettingsEditor
+import com.intellij.openapi.project.Project
+import org.phellang.run.execution.PhelRunCommandLine
+import org.phellang.run.settings.PhelWorkingDirectoryEditor
+import java.io.File
+
+/**
+ * Runs `phel repl` in the Run console.
+ *
+ * The console the platform builds for a [com.intellij.execution.configurations.CommandLineState]
+ * accepts typed input and forwards it to the process, which is what makes an interactive prompt work
+ * here without a dedicated tool window.
+ */
+class PhelReplConfiguration(
+    project: Project,
+    factory: ConfigurationFactory,
+    name: String,
+) : PhelCliRunConfiguration(project, factory, name) {
+
+    override fun getConfigurationEditor(): SettingsEditor<out RunConfiguration> =
+        PhelWorkingDirectoryEditor(project, "Directory the REPL starts in; defaults to the project root")
+
+    override fun commandLine(binary: File): GeneralCommandLine =
+        PhelRunCommandLine.repl(binary, effectiveWorkingDirectory())
+
+    override fun suggestedName(): String = "Phel REPL"
+}

--- a/src/main/kotlin/org/phellang/run/PhelRunConfiguration.kt
+++ b/src/main/kotlin/org/phellang/run/PhelRunConfiguration.kt
@@ -1,36 +1,30 @@
 package org.phellang.run
 
-import com.intellij.execution.ExecutionException
-import com.intellij.execution.Executor
-import com.intellij.execution.configurations.CommandLineState
 import com.intellij.execution.configurations.ConfigurationFactory
-import com.intellij.execution.configurations.LocatableConfigurationBase
+import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.configurations.RunConfiguration
-import com.intellij.execution.configurations.RunProfileState
 import com.intellij.execution.configurations.RuntimeConfigurationError
-import com.intellij.execution.process.KillableColoredProcessHandler
-import com.intellij.execution.process.ProcessHandler
-import com.intellij.execution.process.ProcessTerminatedListener
-import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.openapi.options.SettingsEditor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.JDOMExternalizerUtil
 import org.jdom.Element
-import org.phellang.core.cli.PhelCliLocator
 import org.phellang.run.execution.PhelRunCommandLine
 import org.phellang.run.settings.PhelRunConfigurationEditor
 import java.io.File
 
+/** Runs one `.phel` file through `phel run`. */
 class PhelRunConfiguration(
     project: Project,
     factory: ConfigurationFactory,
     name: String,
-) : LocatableConfigurationBase<RunProfileState>(project, factory, name) {
+) : PhelCliRunConfiguration(project, factory, name) {
 
     var scriptPath: String = ""
-    var workingDirectory: String = ""
 
     override fun getConfigurationEditor(): SettingsEditor<out RunConfiguration> = PhelRunConfigurationEditor(project)
+
+    override fun commandLine(binary: File): GeneralCommandLine =
+        PhelRunCommandLine.run(binary, scriptPath, effectiveWorkingDirectory())
 
     override fun checkConfiguration() {
         if (scriptPath.isBlank()) {
@@ -39,56 +33,22 @@ class PhelRunConfiguration(
         if (!File(scriptPath).isFile) {
             throw RuntimeConfigurationError("Phel file does not exist: $scriptPath")
         }
-        val basePath = project.basePath ?: throw RuntimeConfigurationError("No project base path available")
-        if (PhelCliLocator.locate(basePath) == null) {
-            throw RuntimeConfigurationError(PhelCliLocator.NOT_FOUND_MESSAGE)
-        }
+        super.checkConfiguration()
     }
-
-    /**
-     * Resolved again at launch rather than carried over from [checkConfiguration]: a `composer
-     * install` between validating the dialog and pressing Run is exactly when this changes.
-     */
-    private fun requireBinary(): File {
-        val basePath = project.basePath ?: throw ExecutionException("No project base path available")
-        return PhelCliLocator.locate(basePath) ?: throw ExecutionException(PhelCliLocator.NOT_FOUND_MESSAGE)
-    }
-
-    override fun getState(executor: Executor, environment: ExecutionEnvironment): RunProfileState =
-        PhelRunState(environment)
-
-    /** Falls back to the project root, which is where `phel run` expects to resolve `phel-config.php`. */
-    fun effectiveWorkingDirectory(): String = workingDirectory.ifBlank { project.basePath.orEmpty() }
 
     override fun suggestedName(): String = File(scriptPath).name.ifBlank { "Phel" }
 
     override fun writeExternal(element: Element) {
         super.writeExternal(element)
         JDOMExternalizerUtil.writeField(element, SCRIPT_PATH_FIELD, scriptPath)
-        JDOMExternalizerUtil.writeField(element, WORKING_DIRECTORY_FIELD, workingDirectory)
     }
 
     override fun readExternal(element: Element) {
         super.readExternal(element)
         scriptPath = JDOMExternalizerUtil.readField(element, SCRIPT_PATH_FIELD).orEmpty()
-        workingDirectory = JDOMExternalizerUtil.readField(element, WORKING_DIRECTORY_FIELD).orEmpty()
-    }
-
-    private inner class PhelRunState(environment: ExecutionEnvironment) : CommandLineState(environment) {
-
-        override fun startProcess(): ProcessHandler {
-            val commandLine = PhelRunCommandLine.build(requireBinary(), scriptPath, effectiveWorkingDirectory())
-
-            // Killable so Stop actually terminates a long-running script rather than detaching from it.
-            val handler = KillableColoredProcessHandler(commandLine)
-            ProcessTerminatedListener.attach(handler)
-            return handler
-        }
     }
 
     private companion object {
-        // Field names are persisted in workspace.xml; changing one silently drops the saved value.
         const val SCRIPT_PATH_FIELD = "SCRIPT_PATH"
-        const val WORKING_DIRECTORY_FIELD = "WORKING_DIRECTORY"
     }
 }

--- a/src/main/kotlin/org/phellang/run/PhelRunConfigurationProducer.kt
+++ b/src/main/kotlin/org/phellang/run/PhelRunConfigurationProducer.kt
@@ -11,7 +11,7 @@ import org.phellang.language.psi.files.PhelFile
 class PhelRunConfigurationProducer : LazyRunConfigurationProducer<PhelRunConfiguration>() {
 
     override fun getConfigurationFactory(): ConfigurationFactory =
-        PhelRunConfigurationType.getInstance().configurationFactories.first()
+        PhelRunConfigurationType.fileFactory()
 
     override fun setupConfigurationFromContext(
         configuration: PhelRunConfiguration,

--- a/src/main/kotlin/org/phellang/run/PhelRunConfigurationType.kt
+++ b/src/main/kotlin/org/phellang/run/PhelRunConfigurationType.kt
@@ -10,9 +10,21 @@ import javax.swing.Icon
 
 class PhelRunConfigurationType : ConfigurationType {
 
-    private val fileFactory = PhelRunConfigurationFactory(this)
-    private val replFactory = PhelReplConfigurationFactory(this)
-    private val testFactory = PhelTestConfigurationFactory(this)
+    /**
+     * Factory ids are persisted alongside the type id. `Phel` is the original and keeps its name so
+     * configurations saved before the REPL and test factories existed still load.
+     */
+    private val fileFactory = factory("Phel", "Phel file") { project, factory ->
+        PhelRunConfiguration(project, factory, "Phel")
+    }
+
+    private val replFactory = factory("PhelRepl", "Phel REPL") { project, factory ->
+        PhelReplConfiguration(project, factory, "Phel REPL")
+    }
+
+    private val testFactory = factory("PhelTest", "Phel tests") { project, factory ->
+        PhelTestConfiguration(project, factory, "Phel tests")
+    }
 
     override fun getDisplayName(): String = "Phel"
 
@@ -25,6 +37,19 @@ class PhelRunConfigurationType : ConfigurationType {
     override fun getConfigurationFactories(): Array<ConfigurationFactory> =
         arrayOf(fileFactory, replFactory, testFactory)
 
+    private fun factory(
+        id: String,
+        displayName: String,
+        create: (Project, ConfigurationFactory) -> RunConfiguration,
+    ): ConfigurationFactory = object : ConfigurationFactory(this) {
+
+        override fun getId(): String = id
+
+        override fun getName(): String = displayName
+
+        override fun createTemplateConfiguration(project: Project): RunConfiguration = create(project, this)
+    }
+
     companion object {
         /** Persisted in workspace.xml against every saved configuration; renaming it orphans them. */
         const val ID = "PhelRunConfiguration"
@@ -32,41 +57,7 @@ class PhelRunConfigurationType : ConfigurationType {
         fun getInstance(): PhelRunConfigurationType =
             ConfigurationTypeUtil.findConfigurationType(PhelRunConfigurationType::class.java)
 
-        /** The factory the file-running configuration uses, which the context producer creates. */
+        /** The factory the context producer creates a file-running configuration from. */
         fun fileFactory(): ConfigurationFactory = getInstance().fileFactory
     }
-}
-
-/**
- * Factory ids are persisted alongside the type id. `Phel` is the original and keeps its name so
- * configurations saved before the REPL and test factories existed still load.
- */
-class PhelRunConfigurationFactory(type: ConfigurationType) : ConfigurationFactory(type) {
-
-    override fun getId(): String = "Phel"
-
-    override fun getName(): String = "Phel file"
-
-    override fun createTemplateConfiguration(project: Project): RunConfiguration =
-        PhelRunConfiguration(project, this, "Phel")
-}
-
-class PhelReplConfigurationFactory(type: ConfigurationType) : ConfigurationFactory(type) {
-
-    override fun getId(): String = "PhelRepl"
-
-    override fun getName(): String = "Phel REPL"
-
-    override fun createTemplateConfiguration(project: Project): RunConfiguration =
-        PhelReplConfiguration(project, this, "Phel REPL")
-}
-
-class PhelTestConfigurationFactory(type: ConfigurationType) : ConfigurationFactory(type) {
-
-    override fun getId(): String = "PhelTest"
-
-    override fun getName(): String = "Phel tests"
-
-    override fun createTemplateConfiguration(project: Project): RunConfiguration =
-        PhelTestConfiguration(project, this, "Phel tests")
 }

--- a/src/main/kotlin/org/phellang/run/PhelRunConfigurationType.kt
+++ b/src/main/kotlin/org/phellang/run/PhelRunConfigurationType.kt
@@ -10,17 +10,20 @@ import javax.swing.Icon
 
 class PhelRunConfigurationType : ConfigurationType {
 
-    private val factory = PhelRunConfigurationFactory(this)
+    private val fileFactory = PhelRunConfigurationFactory(this)
+    private val replFactory = PhelReplConfigurationFactory(this)
+    private val testFactory = PhelTestConfigurationFactory(this)
 
     override fun getDisplayName(): String = "Phel"
 
-    override fun getConfigurationTypeDescription(): String = "Run a Phel file with the project's phel CLI"
+    override fun getConfigurationTypeDescription(): String = "Run Phel through the project's phel CLI"
 
     override fun getIcon(): Icon = PhelIcons.FILE
 
     override fun getId(): String = ID
 
-    override fun getConfigurationFactories(): Array<ConfigurationFactory> = arrayOf(factory)
+    override fun getConfigurationFactories(): Array<ConfigurationFactory> =
+        arrayOf(fileFactory, replFactory, testFactory)
 
     companion object {
         /** Persisted in workspace.xml against every saved configuration; renaming it orphans them. */
@@ -28,13 +31,42 @@ class PhelRunConfigurationType : ConfigurationType {
 
         fun getInstance(): PhelRunConfigurationType =
             ConfigurationTypeUtil.findConfigurationType(PhelRunConfigurationType::class.java)
+
+        /** The factory the file-running configuration uses, which the context producer creates. */
+        fun fileFactory(): ConfigurationFactory = getInstance().fileFactory
     }
 }
 
+/**
+ * Factory ids are persisted alongside the type id. `Phel` is the original and keeps its name so
+ * configurations saved before the REPL and test factories existed still load.
+ */
 class PhelRunConfigurationFactory(type: ConfigurationType) : ConfigurationFactory(type) {
 
     override fun getId(): String = "Phel"
 
+    override fun getName(): String = "Phel file"
+
     override fun createTemplateConfiguration(project: Project): RunConfiguration =
         PhelRunConfiguration(project, this, "Phel")
+}
+
+class PhelReplConfigurationFactory(type: ConfigurationType) : ConfigurationFactory(type) {
+
+    override fun getId(): String = "PhelRepl"
+
+    override fun getName(): String = "Phel REPL"
+
+    override fun createTemplateConfiguration(project: Project): RunConfiguration =
+        PhelReplConfiguration(project, this, "Phel REPL")
+}
+
+class PhelTestConfigurationFactory(type: ConfigurationType) : ConfigurationFactory(type) {
+
+    override fun getId(): String = "PhelTest"
+
+    override fun getName(): String = "Phel tests"
+
+    override fun createTemplateConfiguration(project: Project): RunConfiguration =
+        PhelTestConfiguration(project, this, "Phel tests")
 }

--- a/src/main/kotlin/org/phellang/run/PhelTestConfiguration.kt
+++ b/src/main/kotlin/org/phellang/run/PhelTestConfiguration.kt
@@ -1,0 +1,53 @@
+package org.phellang.run
+
+import com.intellij.execution.configurations.ConfigurationFactory
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.configurations.RunConfiguration
+import com.intellij.openapi.options.SettingsEditor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.JDOMExternalizerUtil
+import org.jdom.Element
+import org.phellang.run.execution.PhelRunCommandLine
+import org.phellang.run.settings.PhelTestConfigurationEditor
+import java.io.File
+
+/**
+ * Runs `phel test`, over the whole suite or over named paths.
+ *
+ * Output goes to the plain console rather than a test tree. `phel test` takes a `--reporter`, which
+ * is the hook an SM tree would need, but mapping a reporter's output onto
+ * `SMTRunnerConsoleProperties` means pinning a format this plugin cannot verify from here. Running
+ * the suite without leaving the IDE is the part worth having first.
+ */
+class PhelTestConfiguration(
+    project: Project,
+    factory: ConfigurationFactory,
+    name: String,
+) : PhelCliRunConfiguration(project, factory, name) {
+
+    /** Space-separated paths, empty meaning the whole suite. */
+    var testPaths: String = ""
+
+    override fun getConfigurationEditor(): SettingsEditor<out RunConfiguration> = PhelTestConfigurationEditor(project)
+
+    override fun commandLine(binary: File): GeneralCommandLine =
+        PhelRunCommandLine.test(binary, paths(), effectiveWorkingDirectory())
+
+    fun paths(): List<String> = testPaths.split(' ', '\n').map(String::trim).filter(String::isNotEmpty)
+
+    override fun suggestedName(): String = if (testPaths.isBlank()) "All tests" else "Tests: $testPaths"
+
+    override fun writeExternal(element: Element) {
+        super.writeExternal(element)
+        JDOMExternalizerUtil.writeField(element, TEST_PATHS_FIELD, testPaths)
+    }
+
+    override fun readExternal(element: Element) {
+        super.readExternal(element)
+        testPaths = JDOMExternalizerUtil.readField(element, TEST_PATHS_FIELD).orEmpty()
+    }
+
+    private companion object {
+        const val TEST_PATHS_FIELD = "TEST_PATHS"
+    }
+}

--- a/src/main/kotlin/org/phellang/run/execution/PhelRunCommandLine.kt
+++ b/src/main/kotlin/org/phellang/run/execution/PhelRunCommandLine.kt
@@ -6,18 +6,36 @@ import java.io.File
 import java.nio.charset.StandardCharsets
 
 /**
- * Builds the `phel run <path>` invocation.
+ * Builds the `phel` invocations the run configurations need.
  *
- * Kept apart from the run configuration so the command can be asserted on without constructing a
- * project: the argument order and the inherited environment are the parts that actually break.
+ * Kept apart from the configurations so a command can be asserted on without constructing a project:
+ * the subcommand, the argument order and the inherited environment are the parts that actually
+ * break.
+ *
+ * Subcommand names are verified against
+ * https://phel-lang.org/documentation/tooling/cli-commands/ — `run [options] [--] <path> [<argv>...]`,
+ * `repl`, and `test [options] [--] [<paths>...]`.
  */
 object PhelRunCommandLine {
 
-    /** Verified against https://phel-lang.org/documentation/tooling/cli-commands/: `run [options] [--] <path> [<argv>...]`. */
-    private const val RUN_COMMAND = "run"
+    fun run(binary: File, scriptPath: String, workingDirectory: String): GeneralCommandLine =
+        command(binary, "run", listOf(scriptPath), workingDirectory)
 
-    fun build(binary: File, scriptPath: String, workingDirectory: String): GeneralCommandLine =
-        GeneralCommandLine(binary.absolutePath, RUN_COMMAND, scriptPath)
+    fun repl(binary: File, workingDirectory: String): GeneralCommandLine =
+        command(binary, "repl", emptyList(), workingDirectory)
+
+    /** With no paths, `phel test` runs the whole suite as configured by `phel-config.php`. */
+    fun test(binary: File, paths: List<String>, workingDirectory: String): GeneralCommandLine =
+        command(binary, "test", paths, workingDirectory)
+
+    private fun command(
+        binary: File,
+        subcommand: String,
+        arguments: List<String>,
+        workingDirectory: String,
+    ): GeneralCommandLine =
+        GeneralCommandLine(binary.absolutePath)
+            .withParameters(listOf(subcommand) + arguments)
             .withWorkDirectory(workingDirectory)
             .withCharset(StandardCharsets.UTF_8)
             // The same login-shell environment the formatter needs: `vendor/bin/phel` is a PHP

--- a/src/main/kotlin/org/phellang/run/settings/PhelTestConfigurationEditor.kt
+++ b/src/main/kotlin/org/phellang/run/settings/PhelTestConfigurationEditor.kt
@@ -1,0 +1,29 @@
+package org.phellang.run.settings
+
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBTextField
+import com.intellij.openapi.project.Project
+import com.intellij.util.ui.FormBuilder
+import org.phellang.run.PhelTestConfiguration
+import javax.swing.JPanel
+
+class PhelTestConfigurationEditor(project: Project) :
+    PhelWorkingDirectoryEditor<PhelTestConfiguration>(project, "Directory tests run in; defaults to the project root") {
+
+    private val pathsField = JBTextField()
+
+    override fun resetEditorFrom(configuration: PhelTestConfiguration) {
+        super.resetEditorFrom(configuration)
+        pathsField.text = configuration.testPaths
+    }
+
+    override fun applyEditorTo(configuration: PhelTestConfiguration) {
+        super.applyEditorTo(configuration)
+        configuration.testPaths = pathsField.text.trim()
+    }
+
+    override fun buildPanel(): JPanel = FormBuilder.createFormBuilder()
+        .addLabeledComponent(JBLabel("Paths (blank runs everything):"), pathsField, true)
+        .addLabeledComponent(JBLabel("Working directory:"), workingDirectoryField, true)
+        .panel
+}

--- a/src/main/kotlin/org/phellang/run/settings/PhelWorkingDirectoryEditor.kt
+++ b/src/main/kotlin/org/phellang/run/settings/PhelWorkingDirectoryEditor.kt
@@ -1,0 +1,41 @@
+package org.phellang.run.settings
+
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
+import com.intellij.openapi.options.SettingsEditor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.TextFieldWithBrowseButton
+import com.intellij.ui.components.JBLabel
+import com.intellij.util.ui.FormBuilder
+import org.phellang.run.PhelCliRunConfiguration
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+/** The one field every `phel` configuration has. Enough on its own for the REPL. */
+open class PhelWorkingDirectoryEditor<T : PhelCliRunConfiguration>(
+    project: Project,
+    description: String,
+) : SettingsEditor<T>() {
+
+    protected val workingDirectoryField: TextFieldWithBrowseButton = TextFieldWithBrowseButton().apply {
+        addBrowseFolderListener(
+            "Working Directory",
+            description,
+            project,
+            FileChooserDescriptorFactory.createSingleFolderDescriptor(),
+        )
+    }
+
+    override fun resetEditorFrom(configuration: T) {
+        workingDirectoryField.text = configuration.workingDirectory
+    }
+
+    override fun applyEditorTo(configuration: T) {
+        configuration.workingDirectory = workingDirectoryField.text.trim()
+    }
+
+    override fun createEditor(): JComponent = buildPanel()
+
+    protected open fun buildPanel(): JPanel = FormBuilder.createFormBuilder()
+        .addLabeledComponent(JBLabel("Working directory:"), workingDirectoryField, true)
+        .panel
+}

--- a/src/test/kotlin/org/phellang/integration/run/PhelReplAndTestConfigurationTest.kt
+++ b/src/test/kotlin/org/phellang/integration/run/PhelReplAndTestConfigurationTest.kt
@@ -1,0 +1,117 @@
+package org.phellang.integration.run
+
+import com.intellij.execution.configurations.ConfigurationFactory
+import org.jdom.Element
+import org.phellang.integration.PhelIntegrationTestCase
+import org.phellang.run.PhelReplConfiguration
+import org.phellang.run.PhelRunConfigurationType
+import org.phellang.run.PhelTestConfiguration
+
+class PhelReplAndTestConfigurationTest : PhelIntegrationTestCase() {
+
+    private fun factories(): Array<ConfigurationFactory> = PhelRunConfigurationType().configurationFactories
+
+    private fun replConfiguration() = PhelReplConfiguration(project, factories()[1], "Phel REPL")
+
+    private fun testConfiguration() = PhelTestConfiguration(project, factories()[2], "Phel tests")
+
+    fun testTypeOffersFileReplAndTestFactories() {
+        assertEquals(listOf("Phel file", "Phel REPL", "Phel tests"), factories().map { it.name })
+    }
+
+    /**
+     * The original factory keeps its id: it is persisted alongside the type id, so renaming it
+     * would orphan every configuration saved before the REPL and test factories existed.
+     */
+    fun testOriginalFactoryIdIsUnchanged() {
+        assertEquals("Phel", factories()[0].id)
+    }
+
+    fun testReplAndTestFactoryIdsAreDistinct() {
+        assertEquals(listOf("Phel", "PhelRepl", "PhelTest"), factories().map { it.id })
+    }
+
+    // ---- REPL ----
+
+    fun testReplNamesItself() {
+        assertEquals("Phel REPL", replConfiguration().suggestedName())
+    }
+
+    fun testReplDefaultsToTheProjectRoot() {
+        assertEquals(project.basePath.orEmpty(), replConfiguration().effectiveWorkingDirectory())
+    }
+
+    fun testReplKeepsAnExplicitWorkingDirectory() {
+        val configuration = replConfiguration().apply { workingDirectory = "/elsewhere" }
+
+        assertEquals("/elsewhere", configuration.effectiveWorkingDirectory())
+    }
+
+    fun testReplRoundTripsThroughXml() {
+        val saved = replConfiguration().apply { workingDirectory = "/project" }
+        val element = Element("configuration")
+        saved.writeExternal(element)
+
+        val loaded = replConfiguration()
+        loaded.readExternal(element)
+
+        assertEquals("/project", loaded.workingDirectory)
+    }
+
+    // ---- tests ----
+
+    fun testTestConfigurationRunsEverythingByDefault() {
+        val configuration = testConfiguration()
+
+        assertEmpty(configuration.paths())
+        assertEquals("All tests", configuration.suggestedName())
+    }
+
+    fun testTestConfigurationSplitsPathsOnWhitespace() {
+        val configuration = testConfiguration().apply { testPaths = "tests/a.phel   tests/b.phel" }
+
+        assertEquals(listOf("tests/a.phel", "tests/b.phel"), configuration.paths())
+    }
+
+    fun testTestConfigurationIgnoresStrayWhitespace() {
+        val configuration = testConfiguration().apply { testPaths = "  \n tests/a.phel \n " }
+
+        assertEquals(listOf("tests/a.phel"), configuration.paths())
+    }
+
+    fun testTestConfigurationNamesItselfAfterItsPaths() {
+        val configuration = testConfiguration().apply { testPaths = "tests/a.phel" }
+
+        assertEquals("Tests: tests/a.phel", configuration.suggestedName())
+    }
+
+    fun testTestConfigurationRoundTripsThroughXml() {
+        val saved = testConfiguration().apply {
+            testPaths = "tests/a.phel"
+            workingDirectory = "/project"
+        }
+        val element = Element("configuration")
+        saved.writeExternal(element)
+
+        val loaded = testConfiguration()
+        loaded.readExternal(element)
+
+        assertEquals("tests/a.phel", loaded.testPaths)
+        assertEquals("/project", loaded.workingDirectory)
+    }
+
+    /** Neither can run without a binary, and both must say so before launching. */
+    fun testBothRejectAProjectWithNoPhelBinary() {
+        for (configuration in listOf(replConfiguration(), testConfiguration())) {
+            val message = try {
+                configuration.checkConfiguration()
+                null
+            } catch (e: com.intellij.execution.configurations.RuntimeConfigurationError) {
+                e.message
+            }
+
+            assertNotNull("expected ${configuration.javaClass.simpleName} to reject a binary-less project", message)
+            assertTrue(message!!, message.startsWith("Phel binary not found"))
+        }
+    }
+}

--- a/src/test/kotlin/org/phellang/integration/run/PhelRunCommandLineTest.kt
+++ b/src/test/kotlin/org/phellang/integration/run/PhelRunCommandLineTest.kt
@@ -20,19 +20,19 @@ class PhelRunCommandLineTest : PhelIntegrationTestCase() {
     private val workingDir = "/project"
 
     fun testInvokesRunWithTheScriptPath() {
-        val command = PhelRunCommandLine.build(binary, script, workingDir).getCommandLineList(null)
+        val command = PhelRunCommandLine.run(binary, script, workingDir).getCommandLineList(null)
 
         assertEquals(listOf(binary.absolutePath, "run", script), command)
     }
 
     fun testRunsInTheGivenWorkingDirectory() {
-        val commandLine = PhelRunCommandLine.build(binary, script, workingDir)
+        val commandLine = PhelRunCommandLine.run(binary, script, workingDir)
 
         assertEquals(File(workingDir), commandLine.workDirectory)
     }
 
     fun testCarriesTheShellEnvironment() {
-        val environment = PhelRunCommandLine.build(binary, script, workingDir).environment
+        val environment = PhelRunCommandLine.run(binary, script, workingDir).environment
 
         val shell = EnvironmentUtil.getEnvironmentMap()
         val missing = shell.filter { (key, value) -> environment[key] != value }
@@ -41,6 +41,38 @@ class PhelRunCommandLineTest : PhelIntegrationTestCase() {
     }
 
     fun testDecodesOutputAsUtf8() {
-        assertEquals(StandardCharsets.UTF_8, PhelRunCommandLine.build(binary, script, workingDir).charset)
+        assertEquals(StandardCharsets.UTF_8, PhelRunCommandLine.run(binary, script, workingDir).charset)
+    }
+
+    fun testInvokesReplWithNoArguments() {
+        val command = PhelRunCommandLine.repl(binary, workingDir).getCommandLineList(null)
+
+        assertEquals(listOf(binary.absolutePath, "repl"), command)
+    }
+
+    fun testInvokesTestOverTheWholeSuiteWhenNoPathsGiven() {
+        val command = PhelRunCommandLine.test(binary, emptyList(), workingDir).getCommandLineList(null)
+
+        assertEquals(listOf(binary.absolutePath, "test"), command)
+    }
+
+    fun testInvokesTestWithTheGivenPaths() {
+        val command = PhelRunCommandLine.test(binary, listOf("tests/a.phel", "tests/b.phel"), workingDir)
+            .getCommandLineList(null)
+
+        assertEquals(listOf(binary.absolutePath, "test", "tests/a.phel", "tests/b.phel"), command)
+    }
+
+    fun testEverySubcommandCarriesTheShellEnvironment() {
+        val shell = EnvironmentUtil.getEnvironmentMap()
+
+        for (commandLine in listOf(
+            PhelRunCommandLine.run(binary, script, workingDir),
+            PhelRunCommandLine.repl(binary, workingDir),
+            PhelRunCommandLine.test(binary, emptyList(), workingDir),
+        )) {
+            val missing = shell.filter { (key, value) -> commandLine.environment[key] != value }
+            assertTrue("shell environment must reach ${commandLine.commandLineString}: ${missing.keys}", missing.isEmpty())
+        }
     }
 }


### PR DESCRIPTION
Completes the two remaining boxes on #263, beside the file runner and gutter marker that shipped in
#269.

## REPL

`phel repl` in the Run console. The console the platform builds for a `CommandLineState` accepts
typed input and forwards it to the process, which is what makes an interactive prompt work without a
dedicated tool window.

Worth noting for later: `phel nrepl --port=7888 --host=127.0.0.1` exists, and a real REPL tool
window — send-form-at-caret, evaluate-selection, namespace switching — would be better built on that
than on driving the interactive prompt. This is the console version.

## Tests

`phel test`, over the whole suite or over named paths, into the plain console.

**Not an IDE test tree, deliberately.** `phel test` takes a `--reporter`, which is the hook an
`SMTRunnerConsoleProperties` mapping would need, but that means pinning a reporter's exact output
format — and I cannot verify any of those formats from the plugin side. Guessing at one produces a
tree that silently mis-parses. Running the suite without leaving the IDE is the part worth having
first; the tree is a follow-up once a format is confirmed against a real `phel` build.

## Shared base

All three configurations now extend `PhelCliRunConfiguration`, which owns binary resolution, the
working-directory fallback and the killable process handler. Each carrying its own copy is how the
three would have drifted.

The original factory keeps its id (`Phel`). Factory ids are persisted alongside the type id, so
renaming it would orphan every configuration saved from #269.

## Test plan

- `./gradlew test` — 1492 tests, 0 failures, over three consecutive full runs.
- 4 new command-line tests: `repl` takes no arguments; `test` with no paths runs the whole suite;
  `test` passes given paths through in order; all three subcommands carry the login-shell
  environment.
- 13 new configuration tests: the type offers all three factories with distinct ids and the original
  unchanged; REPL naming, working-directory default and override, XML round trip; test-path splitting
  on whitespace, stray-whitespace handling, naming, XML round trip; and both rejecting a project with
  no `phel` binary.

Not verified in a sandbox IDE: neither configuration was launched against a real `phel` binary. The
command lines are asserted, the process wiring is not.

Related to #263
