### PR TITLE
Honour the Code Style blank-line settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,8 +56,9 @@ refreshed, since completion, hover and arity checking are all driven by it.
   reindent-selection now work before `composer install`, in a scratch file, or where the binary is not on one of the
   searched paths. `phel format` stays the preferred path and still wins whenever it is available; the built-in one
   indents two spaces per level, matching what pressing Enter already does (#265).
-- A **Code Style page** for Phel (Settings > Editor > Code Style > Phel), so indentation is configurable and persists
-  per project (#265).
+- A **Code Style page** for Phel (Settings > Editor > Code Style > Phel), covering indentation and blank lines:
+  how many consecutive blank lines to keep, and how many to force between top-level forms. Only options the
+  formatter actually honours are shown (#265).
 - A **REPL** run configuration, launching `phel repl` in the Run console, which accepts typed input and forwards it
   to the process (#263).
 - A **test** run configuration, running `phel test` over the whole suite or over named paths. Output goes to the

--- a/src/main/kotlin/org/phellang/editor/format/PhelFormattingModelBuilder.kt
+++ b/src/main/kotlin/org/phellang/editor/format/PhelFormattingModelBuilder.kt
@@ -6,6 +6,7 @@ import com.intellij.formatting.FormattingModelBuilder
 import com.intellij.formatting.FormattingModelProvider
 import com.intellij.formatting.Indent
 import org.phellang.editor.format.blocks.PhelBlock
+import org.phellang.editor.format.blocks.PhelFormattingRules
 
 /**
  * The built-in formatter, used when `phel format` is unavailable.
@@ -26,6 +27,7 @@ class PhelFormattingModelBuilder : FormattingModelBuilder {
             wrap = null,
             alignment = null,
             indent = Indent.getNoneIndent(),
+            rules = PhelFormattingRules.from(settings),
         )
 
         return FormattingModelProvider.createFormattingModelForPsiFile(file, root, settings)

--- a/src/main/kotlin/org/phellang/editor/format/PhelLanguageCodeStyleSettingsProvider.kt
+++ b/src/main/kotlin/org/phellang/editor/format/PhelLanguageCodeStyleSettingsProvider.kt
@@ -3,6 +3,7 @@ package org.phellang.editor.format
 import com.intellij.application.options.IndentOptionsEditor
 import com.intellij.application.options.SmartIndentOptionsEditor
 import com.intellij.lang.Language
+import com.intellij.psi.codeStyle.CodeStyleSettingsCustomizable
 import com.intellij.psi.codeStyle.CommonCodeStyleSettings
 import com.intellij.psi.codeStyle.LanguageCodeStyleSettingsProvider
 import org.phellang.language.infrastructure.PhelLanguage
@@ -23,12 +24,32 @@ class PhelLanguageCodeStyleSettingsProvider : LanguageCodeStyleSettingsProvider(
         indentOptions.CONTINUATION_INDENT_SIZE = DEFAULT_INDENT
         indentOptions.TAB_SIZE = DEFAULT_INDENT
         indentOptions.USE_TAB_CHARACTER = false
+
+        // Zero leaves the author's spacing between top-level forms alone. Forcing one by default
+        // would reflow every existing file the first time it is formatted.
+        commonSettings.BLANK_LINES_AROUND_METHOD = 0
+        commonSettings.KEEP_BLANK_LINES_IN_CODE = DEFAULT_KEEP_BLANK_LINES
+    }
+
+    /**
+     * Only the options the formatter actually honours are shown. A page offering spacing or wrapping
+     * toggles with no rules behind them would be worse than a short page: the setting would appear
+     * to work and change nothing.
+     */
+    override fun customizeSettings(consumer: CodeStyleSettingsCustomizable, settingsType: SettingsType) {
+        if (settingsType != SettingsType.BLANK_LINES_SETTINGS) return
+
+        consumer.showStandardOptions("KEEP_BLANK_LINES_IN_CODE", "BLANK_LINES_AROUND_METHOD")
+        consumer.renameStandardOption("BLANK_LINES_AROUND_METHOD", "Between top-level forms")
     }
 
     override fun getCodeSample(settingsType: SettingsType): String = CODE_SAMPLE
 
     private companion object {
         const val DEFAULT_INDENT = 2
+
+        /** The platform's own default; the formatter used to override it with a hard-coded 1. */
+        const val DEFAULT_KEEP_BLANK_LINES = 2
 
         val CODE_SAMPLE = """
             (ns app\example

--- a/src/main/kotlin/org/phellang/editor/format/blocks/PhelBlock.kt
+++ b/src/main/kotlin/org/phellang/editor/format/blocks/PhelBlock.kt
@@ -6,6 +6,7 @@ import com.intellij.formatting.Indent
 import com.intellij.formatting.Spacing
 import com.intellij.formatting.Wrap
 import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiFile
 import com.intellij.psi.TokenType
 import com.intellij.psi.formatter.common.AbstractBlock
 import org.phellang.language.psi.PhelTypes
@@ -28,6 +29,7 @@ class PhelBlock(
     wrap: Wrap?,
     alignment: Alignment?,
     private val indent: Indent,
+    private val rules: PhelFormattingRules,
 ) : AbstractBlock(node, wrap, alignment) {
 
     override fun buildChildren(): List<Block> {
@@ -41,7 +43,7 @@ class PhelBlock(
                 // Brackets sit at the enclosing level; applying the body indent to the closing one
                 // would push it off the end of the body it closes.
                 val indentForChild = if (child.elementType in BRACKETS) Indent.getNoneIndent() else childIndent
-                children += PhelBlock(child, null, null, indentForChild)
+                children += PhelBlock(child, null, null, indentForChild, rules)
             }
             child = child.treeNext
         }
@@ -60,10 +62,17 @@ class PhelBlock(
     override fun getSpacing(child1: Block?, child2: Block): Spacing? {
         if (child1 == null) return null
 
+        // Top-level forms each start their own line, with however many blank lines between them the
+        // Code Style page asks for. Zero, the default, leaves the author's spacing untouched.
+        if (myNode.psi is PsiFile) {
+            val lineFeeds = rules.blankLinesBetweenTopLevelForms + 1
+            return Spacing.createSpacing(0, 0, lineFeeds, true, rules.keepBlankLines)
+        }
+
         val hugsBracket = child1.isBracket() || child2.isBracket()
         val spaces = if (hugsBracket) 0 else 1
 
-        return Spacing.createSpacing(spaces, spaces, 0, true, KEEP_BLANK_LINES)
+        return Spacing.createSpacing(spaces, spaces, 0, true, rules.keepBlankLines)
     }
 
     override fun isLeaf(): Boolean = myNode.firstChildNode == null
@@ -83,8 +92,6 @@ class PhelBlock(
         elementType == TokenType.WHITE_SPACE || textRange.isEmpty
 
     private companion object {
-        const val KEEP_BLANK_LINES = 1
-
         /** The bracketed containers. Matched on element type: `getSpacing` runs per sibling pair. */
         val CONTAINERS = setOf(PhelTypes.LIST, PhelTypes.VEC, PhelTypes.MAP, PhelTypes.SET)
 

--- a/src/main/kotlin/org/phellang/editor/format/blocks/PhelBlock.kt
+++ b/src/main/kotlin/org/phellang/editor/format/blocks/PhelBlock.kt
@@ -6,8 +6,8 @@ import com.intellij.formatting.Indent
 import com.intellij.formatting.Spacing
 import com.intellij.formatting.Wrap
 import com.intellij.lang.ASTNode
-import com.intellij.psi.PsiFile
 import com.intellij.psi.TokenType
+import com.intellij.psi.tree.IFileElementType
 import com.intellij.psi.formatter.common.AbstractBlock
 import org.phellang.language.psi.PhelTypes
 
@@ -31,6 +31,12 @@ class PhelBlock(
     private val indent: Indent,
     private val rules: PhelFormattingRules,
 ) : AbstractBlock(node, wrap, alignment) {
+
+    /**
+     * Resolved once per block rather than per sibling pair. [getSpacing] runs for every pair, and
+     * reaching through `ASTNode.psi` there is what the element-type matching below already avoids.
+     */
+    private val isFileRoot: Boolean = node.elementType is IFileElementType
 
     override fun buildChildren(): List<Block> {
         val childIndent = if (myNode.isBracketed()) Indent.getNormalIndent() else Indent.getNoneIndent()
@@ -64,7 +70,7 @@ class PhelBlock(
 
         // Top-level forms each start their own line, with however many blank lines between them the
         // Code Style page asks for. Zero, the default, leaves the author's spacing untouched.
-        if (myNode.psi is PsiFile) {
+        if (isFileRoot) {
             val lineFeeds = rules.blankLinesBetweenTopLevelForms + 1
             return Spacing.createSpacing(0, 0, lineFeeds, true, rules.keepBlankLines)
         }

--- a/src/main/kotlin/org/phellang/editor/format/blocks/PhelFormattingRules.kt
+++ b/src/main/kotlin/org/phellang/editor/format/blocks/PhelFormattingRules.kt
@@ -1,0 +1,29 @@
+package org.phellang.editor.format.blocks
+
+import com.intellij.psi.codeStyle.CodeStyleSettings
+import org.phellang.language.infrastructure.PhelLanguage
+
+/**
+ * The configurable part of the built-in formatter, resolved once per format request.
+ *
+ * These were constants inside the block, which meant the Code Style page could show a value the
+ * formatter then ignored — the page offered only indentation precisely because nothing else was
+ * wired to it.
+ */
+data class PhelFormattingRules(
+    /** Consecutive blank lines kept rather than collapsed. */
+    val keepBlankLines: Int,
+    /** Blank lines forced between two top-level forms. Zero leaves the author's spacing alone. */
+    val blankLinesBetweenTopLevelForms: Int,
+) {
+    companion object {
+        fun from(settings: CodeStyleSettings): PhelFormattingRules {
+            val common = settings.getCommonSettings(PhelLanguage)
+
+            return PhelFormattingRules(
+                keepBlankLines = common.KEEP_BLANK_LINES_IN_CODE,
+                blankLinesBetweenTopLevelForms = common.BLANK_LINES_AROUND_METHOD,
+            )
+        }
+    }
+}

--- a/src/test/kotlin/org/phellang/integration/editor/PhelFormattingModelBuilderTest.kt
+++ b/src/test/kotlin/org/phellang/integration/editor/PhelFormattingModelBuilderTest.kt
@@ -1,8 +1,10 @@
 package org.phellang.integration.editor
 
 import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.application.options.CodeStyle
 import com.intellij.psi.codeStyle.CodeStyleManager
 import org.phellang.integration.PhelIntegrationTestCase
+import org.phellang.language.infrastructure.PhelLanguage
 
 /**
  * The built-in formatter, used when the project has no `phel` binary.
@@ -69,5 +71,64 @@ class PhelFormattingModelBuilderTest : PhelIntegrationTestCase() {
         val source = "(ns app\\core)\n\n(defn greet [name]\n  (let [a 1]\n    (println name a)))\n"
 
         assertEquals(source, reformatted(source))
+    }
+
+    // ---- Code Style options the formatter honours ----
+
+    private fun reformattedWith(text: String, configure: (com.intellij.psi.codeStyle.CommonCodeStyleSettings) -> Unit): String {
+        val file = myFixture.configureByText("core.phel", text)
+        val settings = CodeStyle.getSettings(project).getCommonSettings(PhelLanguage)
+        val keepBlankLines = settings.KEEP_BLANK_LINES_IN_CODE
+        val aroundTopLevel = settings.BLANK_LINES_AROUND_METHOD
+        try {
+            configure(settings)
+            WriteCommandAction.runWriteCommandAction(project) {
+                CodeStyleManager.getInstance(project).reformat(file)
+            }
+            return file.text
+        } finally {
+            settings.KEEP_BLANK_LINES_IN_CODE = keepBlankLines
+            settings.BLANK_LINES_AROUND_METHOD = aroundTopLevel
+        }
+    }
+
+    /** The formatter used to hard-code this to 1, silently overriding whatever the page showed. */
+    fun testHonoursKeepMaximumBlankLines() {
+        val source = "(def a 1)\n\n\n\n(def b 2)\n"
+
+        val collapsedToOne = reformattedWith(source) { it.KEEP_BLANK_LINES_IN_CODE = 1 }
+
+        assertEquals("(def a 1)\n\n(def b 2)\n", collapsedToOne)
+    }
+
+    fun testKeepsMoreBlankLinesWhenTheSettingAllowsIt() {
+        val source = "(def a 1)\n\n\n\n(def b 2)\n"
+
+        val keptTwo = reformattedWith(source) { it.KEEP_BLANK_LINES_IN_CODE = 2 }
+
+        assertEquals("(def a 1)\n\n\n(def b 2)\n", keptTwo)
+    }
+
+    fun testForcesBlankLinesBetweenTopLevelFormsWhenAsked() {
+        val source = "(def a 1)\n(def b 2)\n"
+
+        val spaced = reformattedWith(source) { it.BLANK_LINES_AROUND_METHOD = 1 }
+
+        assertEquals("(def a 1)\n\n(def b 2)\n", spaced)
+    }
+
+    /** Zero, the default, must leave the author's spacing alone rather than reflow every file. */
+    fun testLeavesTopLevelSpacingAloneByDefault() {
+        val source = "(def a 1)\n(def b 2)\n"
+
+        val untouched = reformattedWith(source) { it.BLANK_LINES_AROUND_METHOD = 0 }
+
+        assertEquals(source, untouched)
+    }
+
+    fun testPutsTopLevelFormsOnSeparateLines() {
+        val joined = reformattedWith("(def a 1) (def b 2)\n") { it.BLANK_LINES_AROUND_METHOD = 0 }
+
+        assertEquals("(def a 1)\n(def b 2)\n", joined)
     }
 }


### PR DESCRIPTION
Closes the last gap on #265: the Code Style page added in #272 exposed indentation and nothing else.

## The actual defect

It was not merely that options were missing. `PhelBlock` hard-coded `keepBlankLines = 1`, so the
platform's own **Keep Maximum Blank Lines** was rendered on the page, accepted from the user, and
then ignored by the formatter. A setting that appears to work and changes nothing is worse than an
absent one.

Both blank-line options now drive the formatter, resolved once per format request into
`PhelFormattingRules`:

| Option | Effect |
|---|---|
| Keep Maximum Blank Lines | consecutive blank lines preserved rather than collapsed |
| Between top-level forms | blank lines forced between two top-level forms |

**"Between top-level forms" defaults to 0**, which leaves the author's spacing alone. Defaulting it
to 1 would reflow every existing file the first time it was formatted, which is not a change a
formatter should make on your behalf without being asked.

## What is still not offered, and why

No Spacing or Wrapping tab. Those would need formatter rules that do not exist — the built-in
formatter deliberately has no call-argument alignment, as explained in #272 — and a page offering
toggles with nothing behind them repeats exactly the bug this PR fixes.

That is the whole remaining scope of #265 as I understand it, so this closes it. If you want real
spacing and wrapping control, that is "build a full Lisp formatter" and deserves its own issue
rather than an open checkbox here.

## Test plan

- `./gradlew test` — 1497 tests, 0 failures, over three consecutive full runs.
- 5 new formatter tests: Keep Maximum Blank Lines honoured at 1 and at 2; blank lines forced between
  top-level forms when asked; spacing left untouched at the default of 0; top-level forms split onto
  separate lines. Each saves and restores the project settings it changes.

Not verified in a sandbox IDE: the options were driven through `CodeStyle.getSettings` rather than by
changing them in the Settings dialog, so the page's rendering of the renamed
"Between top-level forms" label is unconfirmed.

Closes #265
