### PR TITLE
Clear the symbol index between test classes

### DIFF
--- a/src/main/kotlin/org/phellang/indexing/PhelProjectSymbolIndex.kt
+++ b/src/main/kotlin/org/phellang/indexing/PhelProjectSymbolIndex.kt
@@ -42,7 +42,17 @@ class PhelProjectSymbolIndex(private val project: Project) : Disposable {
         PsiManager.getInstance(project).addPsiTreeChangeListener(PhelPsiChangeListener(project), this)
     }
 
-    override fun dispose() {
+    override fun dispose() = clear()
+
+    /**
+     * Drops everything indexed.
+     *
+     * [indexBuilt] is deliberately left alone. Resetting it would have the very next read rebuild
+     * from the project, so "cleared" would last exactly one call — which defeats the isolation this
+     * exists to provide, and makes the emptiness unobservable. The flag only gates the lazy
+     * full-project scan; an explicit [refreshFileFromPsi] repopulates a cleared index either way.
+     */
+    fun clear() {
         symbolsByNamespace.clear()
         symbolsByName.clear()
         symbolsByFile.clear()

--- a/src/test/kotlin/org/phellang/integration/PhelIntegrationTestCase.kt
+++ b/src/test/kotlin/org/phellang/integration/PhelIntegrationTestCase.kt
@@ -16,13 +16,20 @@ import org.phellang.indexing.PhelProjectSymbolIndex
  *
  * Disposing the service in tearDown drops its listeners so each class starts from a clean
  * project; the service is recreated lazily the next time it is needed.
+ *
+ * The index is also cleared explicitly. `Disposer` will not run `dispose()` a second time on an
+ * instance it has already disposed, and `getServiceIfCreated` keeps handing back that same instance,
+ * so from the second test method onward disposal alone cleared nothing and one class's definitions
+ * turned up in the next class's `getAllSymbols()` (#271).
  */
 abstract class PhelIntegrationTestCase : BasePlatformTestCase() {
 
     override fun tearDown() {
         try {
-            project.getServiceIfCreated(PhelProjectSymbolIndex::class.java)
-                ?.let { Disposer.dispose(it) }
+            project.getServiceIfCreated(PhelProjectSymbolIndex::class.java)?.let { index ->
+                index.clear()
+                Disposer.dispose(index)
+            }
         } finally {
             super.tearDown()
         }

--- a/src/test/kotlin/org/phellang/integration/inspection/PhelUnresolvedSymbolInspectionTest.kt
+++ b/src/test/kotlin/org/phellang/integration/inspection/PhelUnresolvedSymbolInspectionTest.kt
@@ -19,9 +19,9 @@ class PhelUnresolvedSymbolInspectionTest : PhelIntegrationTestCase() {
     private var fileIndex = 0
 
     private fun inspect(source: String): List<String> {
-        // Deliberately does not prime the project index. Doing so leaks this file's definitions into
-        // the shared light project, where a later class scanning every .phel file then sees them.
-        // Everything asserted here resolves from the file's own PSI.
+        // Does not prime the project index: everything asserted here resolves from the file's own
+        // PSI, so priming would add nothing. Since #271 the index is cleared between classes, so
+        // this is no longer load-bearing for isolation.
         val file = myFixture.configureByText("i${fileIndex++}.phel", "(ns my\\app)\n$source") as PhelFile
 
         val holder = ProblemsHolder(InspectionManager.getInstance(project), file, true)

--- a/src/test/kotlin/org/phellang/integration/inspection/PhelUnusedDefinitionInspectionsTest.kt
+++ b/src/test/kotlin/org/phellang/integration/inspection/PhelUnusedDefinitionInspectionsTest.kt
@@ -22,8 +22,8 @@ class PhelUnusedDefinitionInspectionsTest : PhelIntegrationTestCase() {
     private var fileIndex = 0
 
     private fun inspect(tool: LocalInspectionTool, source: String): List<String> {
-        // Deliberately does not prime the project index: doing so leaks this file's definitions into
-        // the shared light project (see #271). Everything here resolves from the file's own PSI.
+        // Does not prime the project index: everything here resolves from the file's own PSI. Since
+        // #271 the index is cleared between classes, so this is no longer load-bearing for isolation.
         val file = myFixture.configureByText("u${fileIndex++}.phel", source) as PhelFile
 
         val holder = ProblemsHolder(InspectionManager.getInstance(project), file, true)

--- a/src/test/kotlin/org/phellang/integration/inspection/PhelUnusedImportTest.kt
+++ b/src/test/kotlin/org/phellang/integration/inspection/PhelUnusedImportTest.kt
@@ -39,8 +39,8 @@ class PhelUnusedImportTest : PhelIntegrationTestCase() {
     }
 
     private fun isUnused(text: String, requiredNamespace: String): Boolean {
-        // Unique path per class — the shared test project does not reliably clean files
-        // between classes, so a shared path would risk cross-test interference (see #271).
+        // Unique path per class. The index leak of #271 is fixed, but the shared light project
+        // still keeps the *files* a class adds, so a shared path would collide across classes.
         val vf = myFixture.addFileToProject("src/unused_import_test.phel", text).virtualFile
         val phelFile = com.intellij.psi.PsiManager.getInstance(project).findFile(vf) as PhelFile
         val symbol = PsiTreeUtil.findChildrenOfType(phelFile, PhelSymbol::class.java)

--- a/src/test/kotlin/org/phellang/integration/navigation/PhelGotoSymbolContributorTest.kt
+++ b/src/test/kotlin/org/phellang/integration/navigation/PhelGotoSymbolContributorTest.kt
@@ -1,8 +1,6 @@
 package org.phellang.integration.navigation
 
 import com.intellij.navigation.NavigationItem
-import com.intellij.openapi.application.WriteAction
-import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.util.CommonProcessors
 import com.intellij.util.indexing.FindSymbolParameters
@@ -24,33 +22,10 @@ class PhelGotoSymbolContributorTest : PhelIntegrationTestCase() {
 
     private fun index() = PhelProjectSymbolIndex.getInstance(project)
 
-    private val created = mutableListOf<VirtualFile>()
-
     private fun givenIndexed(path: String, text: String): PhelFile {
         val file = myFixture.addFileToProject(path, text) as PhelFile
-        file.virtualFile?.let { created += it }
         index().refreshFileFromPsi(file)
         return file
-    }
-
-    /**
-     * The light fixture's project, and its symbol index, outlive this class.
-     *
-     * The index is dropped from the index explicitly rather than left to `super.tearDown()`: that
-     * disposes the service, and `Disposer` will not run `dispose()` a second time on an instance it
-     * has already disposed, so from the second test method onward the maps are never cleared. Every
-     * definition named here would otherwise turn up in the next class's `getAllSymbols()`.
-     */
-    override fun tearDown() {
-        try {
-            created.forEach { index().removeFile(it) }
-            WriteAction.runAndWait<Throwable> {
-                created.filter { it.isValid }.forEach { it.delete(this) }
-            }
-            created.clear()
-        } finally {
-            super.tearDown()
-        }
     }
 
     private fun names(): List<String> {

--- a/src/test/kotlin/org/phellang/integration/registry/PhelProjectSymbolIndexClearTest.kt
+++ b/src/test/kotlin/org/phellang/integration/registry/PhelProjectSymbolIndexClearTest.kt
@@ -1,0 +1,73 @@
+package org.phellang.integration.registry
+
+import com.intellij.openapi.util.Disposer
+import org.phellang.indexing.PhelProjectSymbolIndex
+import org.phellang.integration.PhelIntegrationTestCase
+import org.phellang.language.psi.files.PhelFile
+
+/**
+ * Guards the isolation fix from #271.
+ *
+ * The light project, and the index service on it, outlive every test class in the run. Clearing the
+ * index used to be left to `Disposer.dispose`, which will not run `dispose()` a second time on an
+ * instance it has already disposed — so from the second test method onward nothing was cleared, and
+ * one class's definitions surfaced in the next class's `getAllSymbols()`.
+ */
+class PhelProjectSymbolIndexClearTest : PhelIntegrationTestCase() {
+
+    private fun index() = PhelProjectSymbolIndex.getInstance(project)
+
+    /**
+     * Uses `configureByText`, not `addFileToProject`. Clearing resets the built flag, so the next
+     * read rebuilds from the project — and a file left on disk would be found again, making
+     * "empty after clear" unobservable. An in-memory file is not discovered by that scan, which is
+     * what keeps these assertions deterministic.
+     */
+    private fun givenIndexed(path: String, name: String): PhelFile {
+        val file = myFixture.configureByText(path, "(ns app\\clearing)\n(defn $name [] 1)\n") as PhelFile
+        index().refreshFileFromPsi(file)
+        return file
+    }
+
+    fun testClearEmptiesTheIndex() {
+        givenIndexed("clear-one.phel", "clear-one")
+        assertFalse("precondition: the index must hold something", index().getAllSymbols().isEmpty())
+
+        index().clear()
+
+        assertEmpty(index().getAllSymbols())
+    }
+
+    /** The case `Disposer` skips, and the one that made definitions leak between test classes. */
+    fun testClearStillWorksOnAnAlreadyDisposedIndex() {
+        val index = index()
+        givenIndexed("clear-two.phel", "clear-two")
+        Disposer.dispose(index)
+
+        // Repopulate the disposed-but-still-returned instance, exactly as a later test method would.
+        givenIndexed("clear-three.phel", "clear-three")
+        assertFalse(index.getAllSymbols().isEmpty())
+
+        index.clear()
+
+        assertEmpty(index.getAllSymbols())
+    }
+
+    fun testClearedIndexCanBeRepopulated() {
+        givenIndexed("clear-four.phel", "clear-four")
+        index().clear()
+
+        givenIndexed("clear-five.phel", "clear-five")
+
+        assertEquals(listOf("clear-five"), index().getAllSymbols().map { it.name })
+    }
+
+    fun testFindByNameSeesNothingAfterAClear() {
+        givenIndexed("clear-six.phel", "clear-six")
+        assertFalse(index().findByName("clear-six").isEmpty())
+
+        index().clear()
+
+        assertEmpty(index().findByName("clear-six"))
+    }
+}


### PR DESCRIPTION
`PhelIntegrationTestCase` left clearing the symbol index to `Disposer.dispose`, which will not run
`dispose()` a second time on an instance it has already disposed. `getServiceIfCreated` keeps handing
back that same instance, so from the second test method onward nothing was cleared, and one class's
definitions surfaced in the next class's `getAllSymbols()`.

`tearDown` now clears it explicitly. The two local workarounds that grew around this come out with
it — `PhelGotoSymbolContributorTest` no longer tracks and deletes its own files.

## Correcting the issue's own proposal

The issue proposed resetting `indexBuilt` on clear. **That is wrong, and implementing it is how I
found out.**

The flag gates the lazy full-project scan. Resetting it means the very next read rebuilds from the
project, so "cleared" lasts exactly one call: in the fixture it re-finds any file an earlier test
left behind, and the leak returns by a different route. It also makes the emptiness unobservable,
since every public reader goes through `ensureIndexBuilt`.

It surfaced as three guard tests that passed, then failed the moment a fourth test changed the
execution order — the same order-dependence this issue is about.

So `clear()` clears the maps and leaves the flag alone. An explicit `refreshFileFromPsi` repopulates
a cleared index either way, which is what both the tests and the live PSI listener use.

The concern behind the original proposal — a disposed index reporting "built" while empty — stands,
but is unreachable in production: disposal means a closed project, and the next project gets a fresh
service. Trading a reachable bug for an unreachable one is not a good deal. Recorded on the issue.

## What this does not fix

The shared light project still keeps the *files* a class adds; only the index is cleared. Tests that
need a distinct path still need one, and the comments saying so are corrected to give that as the
reason rather than the index leak.

## Test plan

- `./gradlew test` — 1501 tests, 0 failures, over three consecutive full runs.
- 4 new guard tests: clearing empties the index; clearing still works on an already-disposed
  instance (the case `Disposer` skips, and the actual bug); a cleared index can be repopulated;
  `findByName` sees nothing after a clear. They use `configureByText` rather than
  `addFileToProject`, so a project scan cannot repopulate them mid-assertion.
- The workaround removal is itself the regression test: `PhelGotoSymbolContributorTest` populates the
  index heavily and no longer cleans up after itself, so a return of the leak fails
  `PhelProjectSymbolIndexBuildTest` exactly as it did before.

Closes #271
