### PR TITLE
Show phel test results in a test tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,9 +61,9 @@ refreshed, since completion, hover and arity checking are all driven by it.
   formatter actually honours are shown (#265).
 - A **REPL** run configuration, launching `phel repl` in the Run console, which accepts typed input and forwards it
   to the process (#263).
-- A **test** run configuration, running `phel test` over the whole suite or over named paths. Output goes to the
-  plain console: `phel test` takes a `--reporter`, which is what an IDE test tree would need, but mapping a
-  reporter's output onto the platform's test model means pinning a format the plugin cannot verify from here (#263).
+- A **test** run configuration, running `phel test` over the whole suite or over named paths, into a real test tree
+  with pass/fail status, durations and failure details. Built from the `junit-xml` reporter, which is written
+  alongside the normal console output and read when the run finishes (#263).
 - A **run configuration** for Phel files. Right-click a `.phel` file, or use the Run icon in the gutter beside its
   `(ns …)` form, to run it through the project's `phel` binary. The binary is found the same way the formatter finds
   it (`./bin/phel`, then `./vendor/bin/phel`) and runs with the login shell's environment, so a Homebrew, Herd, asdf

--- a/src/main/kotlin/org/phellang/run/PhelCliRunConfiguration.kt
+++ b/src/main/kotlin/org/phellang/run/PhelCliRunConfiguration.kt
@@ -12,6 +12,7 @@ import com.intellij.execution.process.KillableColoredProcessHandler
 import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.process.ProcessTerminatedListener
 import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.execution.ui.ConsoleView
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.JDOMExternalizerUtil
 import org.jdom.Element
@@ -54,15 +55,26 @@ abstract class PhelCliRunConfiguration(
         return PhelCliLocator.locate(basePath) ?: throw ExecutionException(PhelCliLocator.NOT_FOUND_MESSAGE)
     }
 
+    /**
+     * Killable so Stop terminates a long-running script or a REPL waiting on input, rather than
+     * detaching from it. Subclasses that need to watch the process override this.
+     */
+    protected open fun createProcessHandler(commandLine: GeneralCommandLine): ProcessHandler =
+        KillableColoredProcessHandler(commandLine)
+
+    /** Null keeps the platform's default console. */
+    protected open fun createConsoleView(executor: Executor): ConsoleView? = null
+
     override fun getState(executor: Executor, environment: ExecutionEnvironment): RunProfileState =
         object : CommandLineState(environment) {
             override fun startProcess(): ProcessHandler {
-                // Killable so Stop terminates a long-running script or a REPL waiting on input,
-                // rather than detaching from it.
-                val handler = KillableColoredProcessHandler(commandLine(requireBinary()))
+                val handler = createProcessHandler(commandLine(requireBinary()))
                 ProcessTerminatedListener.attach(handler)
                 return handler
             }
+
+            override fun createConsole(executor: Executor): ConsoleView? =
+                createConsoleView(executor) ?: super.createConsole(executor)
         }
 
     override fun writeExternal(element: Element) {

--- a/src/main/kotlin/org/phellang/run/PhelTestConfiguration.kt
+++ b/src/main/kotlin/org/phellang/run/PhelTestConfiguration.kt
@@ -1,14 +1,10 @@
 package org.phellang.run
 
 import com.intellij.execution.Executor
-import com.intellij.execution.configurations.CommandLineState
 import com.intellij.execution.configurations.ConfigurationFactory
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.configurations.RunConfiguration
-import com.intellij.execution.configurations.RunProfileState
 import com.intellij.execution.process.ProcessHandler
-import com.intellij.execution.process.ProcessTerminatedListener
-import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.testframework.sm.SMTestRunnerConnectionUtil
 import com.intellij.execution.ui.ConsoleView
 import com.intellij.openapi.util.io.FileUtil
@@ -42,28 +38,24 @@ class PhelTestConfiguration(
 
     override fun getConfigurationEditor(): SettingsEditor<out RunConfiguration> = PhelTestConfigurationEditor(project)
 
-    /** Only used when a report file is not in play; [getState] supplies one. */
+    /**
+     * A fresh report file per launch. The command line is the single place its location is decided;
+     * the process handler reads it back off the command line it is given.
+     */
     override fun commandLine(binary: File): GeneralCommandLine =
-        PhelRunCommandLine.test(binary, paths(), effectiveWorkingDirectory())
+        PhelRunCommandLine.test(
+            binary,
+            paths(),
+            effectiveWorkingDirectory(),
+            FileUtil.createTempFile("phel-test-", ".xml", true),
+        )
 
-    override fun getState(executor: Executor, environment: ExecutionEnvironment): RunProfileState {
-        val reportFile = FileUtil.createTempFile("phel-test-", ".xml", true)
+    override fun createProcessHandler(commandLine: GeneralCommandLine): ProcessHandler =
+        PhelTestProcessHandler(commandLine)
 
-        return object : CommandLineState(environment) {
-
-            override fun startProcess(): ProcessHandler {
-                val commandLine =
-                    PhelRunCommandLine.test(requireBinary(), paths(), effectiveWorkingDirectory(), reportFile)
-                val handler = PhelTestProcessHandler(commandLine, reportFile)
-                ProcessTerminatedListener.attach(handler)
-                return handler
-            }
-
-            override fun createConsole(executor: Executor): ConsoleView {
-                val properties = PhelTestConsoleProperties(this@PhelTestConfiguration, executor)
-                return SMTestRunnerConnectionUtil.createConsole(properties.testFrameworkName, properties)
-            }
-        }
+    override fun createConsoleView(executor: Executor): ConsoleView {
+        val properties = PhelTestConsoleProperties(this, executor)
+        return SMTestRunnerConnectionUtil.createConsole(properties.testFrameworkName, properties)
     }
 
     fun paths(): List<String> = testPaths.split(' ', '\n').map(String::trim).filter(String::isNotEmpty)

--- a/src/main/kotlin/org/phellang/run/PhelTestConfiguration.kt
+++ b/src/main/kotlin/org/phellang/run/PhelTestConfiguration.kt
@@ -1,23 +1,35 @@
 package org.phellang.run
 
+import com.intellij.execution.Executor
+import com.intellij.execution.configurations.CommandLineState
 import com.intellij.execution.configurations.ConfigurationFactory
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.configurations.RunConfiguration
+import com.intellij.execution.configurations.RunProfileState
+import com.intellij.execution.process.ProcessHandler
+import com.intellij.execution.process.ProcessTerminatedListener
+import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.execution.testframework.sm.SMTestRunnerConnectionUtil
+import com.intellij.execution.ui.ConsoleView
+import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.options.SettingsEditor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.JDOMExternalizerUtil
 import org.jdom.Element
 import org.phellang.run.execution.PhelRunCommandLine
 import org.phellang.run.settings.PhelTestConfigurationEditor
+import org.phellang.run.test.PhelTestConsoleProperties
+import org.phellang.run.test.PhelTestProcessHandler
 import java.io.File
 
 /**
- * Runs `phel test`, over the whole suite or over named paths.
+ * Runs `phel test`, over the whole suite or over named paths, into a test tree.
  *
- * Output goes to the plain console rather than a test tree. `phel test` takes a `--reporter`, which
- * is the hook an SM tree would need, but mapping a reporter's output onto
- * `SMTRunnerConsoleProperties` means pinning a format this plugin cannot verify from here. Running
- * the suite without leaving the IDE is the part worth having first.
+ * The tree is built from the `junit-xml` reporter, written to a temporary file and read when the
+ * process exits. That reporter rather than `tap` because JUnit XML is a de-facto standard whose
+ * parser can be pinned down by tests without a `phel` binary to run; the cost is that the tree
+ * appears at the end of the run rather than filling in live, while the console shows the default
+ * reporter's output throughout.
  */
 class PhelTestConfiguration(
     project: Project,
@@ -30,8 +42,29 @@ class PhelTestConfiguration(
 
     override fun getConfigurationEditor(): SettingsEditor<out RunConfiguration> = PhelTestConfigurationEditor(project)
 
+    /** Only used when a report file is not in play; [getState] supplies one. */
     override fun commandLine(binary: File): GeneralCommandLine =
         PhelRunCommandLine.test(binary, paths(), effectiveWorkingDirectory())
+
+    override fun getState(executor: Executor, environment: ExecutionEnvironment): RunProfileState {
+        val reportFile = FileUtil.createTempFile("phel-test-", ".xml", true)
+
+        return object : CommandLineState(environment) {
+
+            override fun startProcess(): ProcessHandler {
+                val commandLine =
+                    PhelRunCommandLine.test(requireBinary(), paths(), effectiveWorkingDirectory(), reportFile)
+                val handler = PhelTestProcessHandler(commandLine, reportFile)
+                ProcessTerminatedListener.attach(handler)
+                return handler
+            }
+
+            override fun createConsole(executor: Executor): ConsoleView {
+                val properties = PhelTestConsoleProperties(this@PhelTestConfiguration, executor)
+                return SMTestRunnerConnectionUtil.createConsole(properties.testFrameworkName, properties)
+            }
+        }
+    }
 
     fun paths(): List<String> = testPaths.split(' ', '\n').map(String::trim).filter(String::isNotEmpty)
 

--- a/src/main/kotlin/org/phellang/run/execution/PhelRunCommandLine.kt
+++ b/src/main/kotlin/org/phellang/run/execution/PhelRunCommandLine.kt
@@ -24,9 +24,27 @@ object PhelRunCommandLine {
     fun repl(binary: File, workingDirectory: String): GeneralCommandLine =
         command(binary, "repl", emptyList(), workingDirectory)
 
-    /** With no paths, `phel test` runs the whole suite as configured by `phel-config.php`. */
-    fun test(binary: File, paths: List<String>, workingDirectory: String): GeneralCommandLine =
-        command(binary, "test", paths, workingDirectory)
+    /**
+     * With no paths, `phel test` runs the whole suite as configured by `phel-config.php`.
+     *
+     * Both reporters are requested when [reportFile] is given: `default` keeps the console output
+     * the user watches during the run, and `junit-xml` writes the machine-readable report the test
+     * tree is built from once the process exits. `--reporter` is documented as repeatable.
+     */
+    fun test(
+        binary: File,
+        paths: List<String>,
+        workingDirectory: String,
+        reportFile: File? = null,
+    ): GeneralCommandLine {
+        val options = if (reportFile == null) {
+            emptyList()
+        } else {
+            listOf("--reporter=default", "--reporter=junit-xml", "--output=${reportFile.absolutePath}")
+        }
+
+        return command(binary, "test", options + paths, workingDirectory)
+    }
 
     private fun command(
         binary: File,

--- a/src/main/kotlin/org/phellang/run/execution/PhelRunCommandLine.kt
+++ b/src/main/kotlin/org/phellang/run/execution/PhelRunCommandLine.kt
@@ -40,11 +40,14 @@ object PhelRunCommandLine {
         val options = if (reportFile == null) {
             emptyList()
         } else {
-            listOf("--reporter=default", "--reporter=junit-xml", "--output=${reportFile.absolutePath}")
+            listOf("--reporter=default", "--reporter=junit-xml", "$OUTPUT_OPTION${reportFile.absolutePath}")
         }
 
         return command(binary, "test", options + paths, workingDirectory)
     }
+
+    /** Where `junit-xml` writes. Read back off the command line rather than passed around beside it. */
+    const val OUTPUT_OPTION = "--output="
 
     private fun command(
         binary: File,

--- a/src/main/kotlin/org/phellang/run/test/PhelJUnitXmlParser.kt
+++ b/src/main/kotlin/org/phellang/run/test/PhelJUnitXmlParser.kt
@@ -1,0 +1,99 @@
+package org.phellang.run.test
+
+import org.w3c.dom.Element
+import org.w3c.dom.Node
+import java.io.StringReader
+import javax.xml.XMLConstants
+import javax.xml.parsers.DocumentBuilderFactory
+import org.xml.sax.InputSource
+
+/**
+ * Reads the report written by `phel test --reporter=junit-xml --output=<file>`.
+ *
+ * JUnit XML rather than the `tap` reporter: it is a de-facto standard, so this parser can be pinned
+ * down by tests without a `phel` binary to run. The cost is that a tree built from it appears when
+ * the run finishes rather than filling in live.
+ *
+ * Never throws. A run killed part-way leaves half-written XML, and a formatter for test results is
+ * not worth failing a test run over — an unparseable report is reported as no results.
+ */
+object PhelJUnitXmlParser {
+
+    fun parse(xml: String): PhelTestReport {
+        if (xml.isBlank()) return PhelTestReport.EMPTY
+
+        val root = try {
+            documentBuilder().parse(InputSource(StringReader(xml))).documentElement
+        } catch (e: Exception) {
+            return PhelTestReport.EMPTY
+        } ?: return PhelTestReport.EMPTY
+
+        val suites = mutableListOf<PhelTestSuite>()
+        collectSuites(root, suites)
+
+        return PhelTestReport(suites)
+    }
+
+    /** Depth-first so a `<testsuites>` wrapper, a bare `<testsuite>`, and nesting all work. */
+    private fun collectSuites(element: Element, into: MutableList<PhelTestSuite>) {
+        if (element.tagName == SUITE) {
+            into += PhelTestSuite(element.getAttribute("name"), casesOf(element))
+        }
+
+        for (child in element.childElements()) {
+            collectSuites(child, into)
+        }
+    }
+
+    /** Direct children only: a nested suite's cases belong to that suite, not to this one. */
+    private fun casesOf(suite: Element): List<PhelTestCase> =
+        suite.childElements().filter { it.tagName == CASE }.map { case ->
+            PhelTestCase(
+                name = case.getAttribute("name"),
+                durationSeconds = case.getAttribute("time").toDoubleOrNull(),
+                outcome = outcomeOf(case),
+            )
+        }
+
+    private fun outcomeOf(case: Element): PhelTestCase.Outcome {
+        for (child in case.childElements()) {
+            val message = child.getAttribute("message")
+            val details = child.textContent.orEmpty().trim()
+
+            when (child.tagName) {
+                "failure" -> return PhelTestCase.Outcome.Failed(message.ifEmpty { details }, details)
+                "error" -> return PhelTestCase.Outcome.Errored(message.ifEmpty { details }, details)
+                "skipped" -> return PhelTestCase.Outcome.Skipped(message)
+            }
+        }
+
+        return PhelTestCase.Outcome.Passed
+    }
+
+    private fun Element.childElements(): List<Element> {
+        val children = mutableListOf<Element>()
+        val nodes = childNodes
+
+        for (i in 0 until nodes.length) {
+            val node = nodes.item(i)
+            if (node.nodeType == Node.ELEMENT_NODE) children += node as Element
+        }
+
+        return children
+    }
+
+    /**
+     * External entities disabled: the report is a file this plugin asks a subprocess to write, and a
+     * parser that resolves entities from it would read whatever the document names.
+     */
+    private fun documentBuilder() = DocumentBuilderFactory.newInstance().apply {
+        setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+        setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "")
+        setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "")
+        isXIncludeAware = false
+        isExpandEntityReferences = false
+    }.newDocumentBuilder()
+
+    private const val SUITE = "testsuite"
+    private const val CASE = "testcase"
+}

--- a/src/main/kotlin/org/phellang/run/test/PhelTestConsoleProperties.kt
+++ b/src/main/kotlin/org/phellang/run/test/PhelTestConsoleProperties.kt
@@ -1,0 +1,24 @@
+package org.phellang.run.test
+
+import com.intellij.execution.Executor
+import com.intellij.execution.configurations.RunConfiguration
+import com.intellij.execution.testframework.sm.runner.SMTRunnerConsoleProperties
+
+/**
+ * Plain properties: the tree is fed by service messages the process handler emits, which the
+ * platform's default converter already parses, so nothing custom is needed here.
+ */
+class PhelTestConsoleProperties(
+    configuration: RunConfiguration,
+    executor: Executor,
+) : SMTRunnerConsoleProperties(configuration, FRAMEWORK_NAME, executor) {
+
+    init {
+        // The report carries no source locations, so a test node cannot navigate anywhere yet.
+        isIdBasedTestTree = false
+    }
+
+    companion object {
+        const val FRAMEWORK_NAME = "Phel"
+    }
+}

--- a/src/main/kotlin/org/phellang/run/test/PhelTestProcessHandler.kt
+++ b/src/main/kotlin/org/phellang/run/test/PhelTestProcessHandler.kt
@@ -1,0 +1,45 @@
+package org.phellang.run.test
+
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.process.KillableColoredProcessHandler
+import com.intellij.execution.process.ProcessOutputTypes
+import java.io.File
+
+/**
+ * Runs `phel test` and, once it exits, replays its report as service messages so the test tree is
+ * populated.
+ *
+ * `phel test` writes JUnit XML to a file rather than streaming events, so there is nothing to
+ * publish until the process is done. The messages are emitted *before* termination is announced:
+ * the runner stops accepting them afterwards, and the tree would stay empty.
+ */
+class PhelTestProcessHandler(
+    commandLine: GeneralCommandLine,
+    private val reportFile: File,
+) : KillableColoredProcessHandler(commandLine) {
+
+    override fun notifyProcessTerminated(exitCode: Int) {
+        for (line in PhelTestServiceMessages.render(readReport())) {
+            notifyTextAvailable(line + "\n", ProcessOutputTypes.STDOUT)
+        }
+
+        super.notifyProcessTerminated(exitCode)
+    }
+
+    /**
+     * A missing or unreadable report becomes no results rather than an error: the run may have been
+     * stopped, or `phel` may have failed before writing anything, and either way the console already
+     * shows what happened.
+     */
+    private fun readReport(): PhelTestReport {
+        if (!reportFile.isFile) return PhelTestReport.EMPTY
+
+        return try {
+            PhelJUnitXmlParser.parse(reportFile.readText())
+        } catch (e: Exception) {
+            PhelTestReport.EMPTY
+        } finally {
+            reportFile.delete()
+        }
+    }
+}

--- a/src/main/kotlin/org/phellang/run/test/PhelTestProcessHandler.kt
+++ b/src/main/kotlin/org/phellang/run/test/PhelTestProcessHandler.kt
@@ -3,6 +3,7 @@ package org.phellang.run.test
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.process.KillableColoredProcessHandler
 import com.intellij.execution.process.ProcessOutputTypes
+import org.phellang.run.execution.PhelRunCommandLine
 import java.io.File
 
 /**
@@ -15,8 +16,16 @@ import java.io.File
  */
 class PhelTestProcessHandler(
     commandLine: GeneralCommandLine,
-    private val reportFile: File,
 ) : KillableColoredProcessHandler(commandLine) {
+
+    /**
+     * Taken from the command line rather than passed alongside it, so the command stays the single
+     * place the report's location is decided.
+     */
+    private val reportFile: File? = commandLine.parametersList.parameters
+        .firstOrNull { it.startsWith(PhelRunCommandLine.OUTPUT_OPTION) }
+        ?.removePrefix(PhelRunCommandLine.OUTPUT_OPTION)
+        ?.let(::File)
 
     override fun notifyProcessTerminated(exitCode: Int) {
         for (line in PhelTestServiceMessages.render(readReport())) {
@@ -32,14 +41,15 @@ class PhelTestProcessHandler(
      * shows what happened.
      */
     private fun readReport(): PhelTestReport {
-        if (!reportFile.isFile) return PhelTestReport.EMPTY
+        val report = reportFile ?: return PhelTestReport.EMPTY
+        if (!report.isFile) return PhelTestReport.EMPTY
 
         return try {
-            PhelJUnitXmlParser.parse(reportFile.readText())
+            PhelJUnitXmlParser.parse(report.readText())
         } catch (e: Exception) {
             PhelTestReport.EMPTY
         } finally {
-            reportFile.delete()
+            report.delete()
         }
     }
 }

--- a/src/main/kotlin/org/phellang/run/test/PhelTestReport.kt
+++ b/src/main/kotlin/org/phellang/run/test/PhelTestReport.kt
@@ -1,0 +1,34 @@
+package org.phellang.run.test
+
+/** A parsed `phel test --reporter=junit-xml` report. */
+data class PhelTestReport(val suites: List<PhelTestSuite>) {
+
+    val isEmpty: Boolean get() = suites.all { it.cases.isEmpty() }
+
+    companion object {
+        val EMPTY = PhelTestReport(emptyList())
+    }
+}
+
+data class PhelTestSuite(val name: String, val cases: List<PhelTestCase>)
+
+data class PhelTestCase(
+    val name: String,
+    /** Seconds, as reported. Null when the report omits it. */
+    val durationSeconds: Double?,
+    val outcome: Outcome,
+) {
+    /** Milliseconds, which is the unit the test tree wants. */
+    val durationMillis: Long? get() = durationSeconds?.let { (it * 1000).toLong() }
+
+    sealed interface Outcome {
+        data object Passed : Outcome
+
+        /** [details] is the element's text: a stack trace or comparison, shown in the tree. */
+        data class Failed(val message: String, val details: String) : Outcome
+
+        data class Errored(val message: String, val details: String) : Outcome
+
+        data class Skipped(val message: String) : Outcome
+    }
+}

--- a/src/main/kotlin/org/phellang/run/test/PhelTestServiceMessages.kt
+++ b/src/main/kotlin/org/phellang/run/test/PhelTestServiceMessages.kt
@@ -1,0 +1,77 @@
+package org.phellang.run.test
+
+/**
+ * Renders a parsed report as the service messages the platform's test runner already understands.
+ *
+ * Chosen over a custom `OutputToGeneralTestEventsConverter`: this SDK has no
+ * `SMCustomMessagesParsing` to hang one on, and the default converter parses these messages from the
+ * process output anyway. It also keeps the whole translation a pure function, so the tree's contents
+ * can be asserted without a `phel` binary, a project, or a console.
+ */
+object PhelTestServiceMessages {
+
+    fun render(report: PhelTestReport): List<String> = buildList {
+        for (suite in report.suites) {
+            add(message("testSuiteStarted", "name" to suite.name))
+            for (case in suite.cases) addAll(render(case))
+            add(message("testSuiteFinished", "name" to suite.name))
+        }
+    }
+
+    private fun render(case: PhelTestCase): List<String> = buildList {
+        add(message("testStarted", "name" to case.name))
+
+        when (val outcome = case.outcome) {
+            is PhelTestCase.Outcome.Passed -> Unit
+
+            is PhelTestCase.Outcome.Skipped ->
+                add(message("testIgnored", "name" to case.name, "message" to outcome.message))
+
+            is PhelTestCase.Outcome.Failed ->
+                add(message("testFailed", "name" to case.name, "message" to outcome.message, "details" to outcome.details))
+
+            // `error='true'` is what separates a crash from a failed assertion in the tree.
+            is PhelTestCase.Outcome.Errored ->
+                add(
+                    message(
+                        "testFailed",
+                        "name" to case.name,
+                        "message" to outcome.message,
+                        "details" to outcome.details,
+                        "error" to "true",
+                    )
+                )
+        }
+
+        val duration = case.durationMillis
+        if (duration == null) {
+            add(message("testFinished", "name" to case.name))
+        } else {
+            add(message("testFinished", "name" to case.name, "duration" to duration.toString()))
+        }
+    }
+
+    private fun message(name: String, vararg attributes: Pair<String, String>): String {
+        val rendered = attributes.joinToString(" ") { (key, value) -> "$key='${escape(value)}'" }
+
+        return "##teamcity[$name $rendered]"
+    }
+
+    /**
+     * The service-message escaping rules. Phel names carry backslashes (`app\core-test`) and failure
+     * details carry newlines and quotes, so every one of these is reachable.
+     */
+    private fun escape(value: String): String = buildString {
+        for (character in value) {
+            when (character) {
+                '|' -> append("||")
+                '\'' -> append("|'")
+                '\n' -> append("|n")
+                '\r' -> append("|r")
+                '[' -> append("|[")
+                ']' -> append("|]")
+                else -> append(character)
+            }
+        }
+    }
+}

--- a/src/test/kotlin/org/phellang/integration/run/PhelRunCommandLineTest.kt
+++ b/src/test/kotlin/org/phellang/integration/run/PhelRunCommandLineTest.kt
@@ -75,4 +75,32 @@ class PhelRunCommandLineTest : PhelIntegrationTestCase() {
             assertTrue("shell environment must reach ${commandLine.commandLineString}: ${missing.keys}", missing.isEmpty())
         }
     }
+
+    fun testTestRequestsBothReportersWhenGivenAReportFile() {
+        val report = java.io.File("/tmp/phel-report.xml")
+
+        val command = PhelRunCommandLine.test(binary, emptyList(), workingDir, report).getCommandLineList(null)
+
+        assertEquals(
+            listOf(
+                binary.absolutePath,
+                "test",
+                "--reporter=default",
+                "--reporter=junit-xml",
+                "--output=${report.absolutePath}",
+            ),
+            command,
+        )
+    }
+
+    /** Options come before paths: the CLI usage is `test [options] [--] [<paths>...]`. */
+    fun testTestPutsReporterOptionsBeforePaths() {
+        val report = java.io.File("/tmp/phel-report.xml")
+
+        val command = PhelRunCommandLine.test(binary, listOf("tests/a.phel"), workingDir, report)
+            .getCommandLineList(null)
+
+        assertEquals("tests/a.phel", command.last())
+        assertTrue(command.indexOf("--reporter=junit-xml") < command.indexOf("tests/a.phel"))
+    }
 }

--- a/src/test/kotlin/org/phellang/unit/run/PhelJUnitXmlParserTest.kt
+++ b/src/test/kotlin/org/phellang/unit/run/PhelJUnitXmlParserTest.kt
@@ -1,0 +1,153 @@
+package org.phellang.unit.run
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.phellang.run.test.PhelJUnitXmlParser
+import org.phellang.run.test.PhelTestCase
+
+/**
+ * The JUnit XML `phel test --reporter=junit-xml` writes.
+ *
+ * Parsed rather than streamed, so this is where the test tree's accuracy is decided. Kept a pure
+ * unit test: it needs no `phel` binary, which is exactly why this reporter was chosen over `tap`.
+ */
+class PhelJUnitXmlParserTest {
+
+    private fun parse(xml: String) = PhelJUnitXmlParser.parse(xml)
+
+    @Test
+    fun `reads suites and their cases`() {
+        val report = parse(
+            """
+            <testsuites>
+              <testsuite name="app\core-test" tests="2">
+                <testcase name="adds" time="0.01"/>
+                <testcase name="subtracts" time="0.02"/>
+              </testsuite>
+            </testsuites>
+            """.trimIndent()
+        )
+
+        assertEquals(1, report.suites.size)
+        assertEquals("app\\core-test", report.suites[0].name)
+        assertEquals(listOf("adds", "subtracts"), report.suites[0].cases.map { it.name })
+    }
+
+    @Test
+    fun `a case with no failure element passed`() {
+        val report = parse("""<testsuite name="s"><testcase name="ok" time="0.5"/></testsuite>""")
+
+        assertEquals(PhelTestCase.Outcome.Passed, report.suites[0].cases[0].outcome)
+    }
+
+    @Test
+    fun `reads a failure message and its details`() {
+        val report = parse(
+            """
+            <testsuite name="s">
+              <testcase name="broken">
+                <failure message="expected 1, got 2">at app\core-test line 12</failure>
+              </testcase>
+            </testsuite>
+            """.trimIndent()
+        )
+
+        val outcome = report.suites[0].cases[0].outcome
+        assertTrue(outcome is PhelTestCase.Outcome.Failed, outcome.toString())
+        outcome as PhelTestCase.Outcome.Failed
+        assertEquals("expected 1, got 2", outcome.message)
+        assertEquals("at app\\core-test line 12", outcome.details)
+    }
+
+    @Test
+    fun `an error is distinct from a failure`() {
+        val report = parse(
+            """
+            <testsuite name="s">
+              <testcase name="blew-up"><error message="PHEL001">trace</error></testcase>
+            </testsuite>
+            """.trimIndent()
+        )
+
+        assertTrue(report.suites[0].cases[0].outcome is PhelTestCase.Outcome.Errored)
+    }
+
+    @Test
+    fun `reads a skipped case`() {
+        val report = parse(
+            """<testsuite name="s"><testcase name="later"><skipped message="wip"/></testcase></testsuite>"""
+        )
+
+        val outcome = report.suites[0].cases[0].outcome
+        assertTrue(outcome is PhelTestCase.Outcome.Skipped, outcome.toString())
+        assertEquals("wip", (outcome as PhelTestCase.Outcome.Skipped).message)
+    }
+
+    @Test
+    fun `converts the reported time to milliseconds`() {
+        val report = parse("""<testsuite name="s"><testcase name="slow" time="1.25"/></testsuite>""")
+
+        assertEquals(1250L, report.suites[0].cases[0].durationMillis)
+    }
+
+    @Test
+    fun `a case with no time has no duration`() {
+        val report = parse("""<testsuite name="s"><testcase name="untimed"/></testsuite>""")
+
+        assertEquals(null, report.suites[0].cases[0].durationMillis)
+    }
+
+    @Test
+    fun `accepts a bare testsuite without a testsuites wrapper`() {
+        val report = parse("""<testsuite name="only"><testcase name="a"/></testsuite>""")
+
+        assertEquals(listOf("only"), report.suites.map { it.name })
+    }
+
+    @Test
+    fun `reads nested suites`() {
+        val report = parse(
+            """
+            <testsuites>
+              <testsuite name="outer">
+                <testsuite name="inner"><testcase name="a"/></testsuite>
+              </testsuite>
+            </testsuites>
+            """.trimIndent()
+        )
+
+        assertTrue(report.suites.map { it.name }.containsAll(listOf("outer", "inner")))
+    }
+
+    /** A run that crashed before writing anything must not surface as a parse error. */
+    @Test
+    fun `empty input yields an empty report`() {
+        assertTrue(parse("").isEmpty)
+        assertTrue(parse("   ").isEmpty)
+    }
+
+    /** Half-written XML from a killed process is likelier than a malformed reporter. */
+    @Test
+    fun `malformed xml yields an empty report rather than throwing`() {
+        assertTrue(parse("<testsuite name=\"s\"><testcase ").isEmpty)
+    }
+
+    @Test
+    fun `a suite with no cases is kept so the tree can show it`() {
+        val report = parse("""<testsuite name="empty-suite"></testsuite>""")
+
+        assertEquals(listOf("empty-suite"), report.suites.map { it.name })
+        assertTrue(report.isEmpty)
+    }
+
+    @Test
+    fun `a failure without a message attribute still reports its details`() {
+        val report = parse(
+            """<testsuite name="s"><testcase name="t"><failure>bare detail</failure></testcase></testsuite>"""
+        )
+
+        val outcome = report.suites[0].cases[0].outcome as PhelTestCase.Outcome.Failed
+        assertEquals("bare detail", outcome.details)
+    }
+}

--- a/src/test/kotlin/org/phellang/unit/run/PhelTestServiceMessagesTest.kt
+++ b/src/test/kotlin/org/phellang/unit/run/PhelTestServiceMessagesTest.kt
@@ -1,0 +1,165 @@
+package org.phellang.unit.run
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.phellang.run.test.PhelJUnitXmlParser
+import org.phellang.run.test.PhelTestCase
+import org.phellang.run.test.PhelTestReport
+import org.phellang.run.test.PhelTestServiceMessages
+import org.phellang.run.test.PhelTestSuite
+
+/**
+ * What the test tree is actually built from.
+ *
+ * Pure by design: the report is rendered to service messages the platform's default converter
+ * parses, so the tree's contents can be asserted here without a `phel` binary, a project or a
+ * console.
+ */
+class PhelTestServiceMessagesTest {
+
+    private fun render(report: PhelTestReport) = PhelTestServiceMessages.render(report)
+
+    private fun renderXml(xml: String) = render(PhelJUnitXmlParser.parse(xml))
+
+    private fun passing(name: String, seconds: Double? = null) =
+        PhelTestCase(name, seconds, PhelTestCase.Outcome.Passed)
+
+    @Test
+    fun `wraps a suite around its cases`() {
+        val messages = render(PhelTestReport(listOf(PhelTestSuite("core", listOf(passing("adds"))))))
+
+        assertEquals(
+            listOf(
+                "##teamcity[testSuiteStarted name='core']",
+                "##teamcity[testStarted name='adds']",
+                "##teamcity[testFinished name='adds']",
+                "##teamcity[testSuiteFinished name='core']",
+            ),
+            messages,
+        )
+    }
+
+    @Test
+    fun `reports a duration in milliseconds`() {
+        val messages = render(PhelTestReport(listOf(PhelTestSuite("s", listOf(passing("slow", 1.5))))))
+
+        assertTrue(messages.any { it == "##teamcity[testFinished name='slow' duration='1500']" }, messages.toString())
+    }
+
+    @Test
+    fun `a failure carries its message and details`() {
+        val messages = renderXml(
+            """
+            <testsuite name="s">
+              <testcase name="broken"><failure message="expected 1">line 12</failure></testcase>
+            </testsuite>
+            """.trimIndent()
+        )
+
+        assertTrue(
+            messages.any { it == "##teamcity[testFailed name='broken' message='expected 1' details='line 12']" },
+            messages.toString(),
+        )
+    }
+
+    /** `error='true'` is what separates a crash from a failed assertion in the tree. */
+    @Test
+    fun `an error is marked as one`() {
+        val messages = renderXml(
+            """<testsuite name="s"><testcase name="boom"><error message="PHEL001">trace</error></testcase></testsuite>"""
+        )
+
+        assertTrue(messages.any { it.startsWith("##teamcity[testFailed") && it.contains("error='true'") }, messages.toString())
+    }
+
+    @Test
+    fun `a skipped case is ignored rather than failed`() {
+        val messages = renderXml(
+            """<testsuite name="s"><testcase name="later"><skipped message="wip"/></testcase></testsuite>"""
+        )
+
+        assertTrue(messages.any { it == "##teamcity[testIgnored name='later' message='wip']" }, messages.toString())
+        assertTrue(messages.none { it.contains("testFailed") }, messages.toString())
+    }
+
+    /** Phel namespaces carry backslashes, so this path is hit by every real suite name. */
+    @Test
+    fun `escapes a namespace name`() {
+        val messages = render(PhelTestReport(listOf(PhelTestSuite("app\\core-test", emptyList()))))
+
+        assertEquals("##teamcity[testSuiteStarted name='app\\core-test']", messages.first())
+    }
+
+    @Test
+    fun `escapes quotes newlines and brackets in failure details`() {
+        val report = PhelTestReport(
+            listOf(
+                PhelTestSuite(
+                    "s",
+                    listOf(
+                        PhelTestCase(
+                            "t",
+                            null,
+                            PhelTestCase.Outcome.Failed("it's [bad]", "line one\nline two|end\r"),
+                        )
+                    ),
+                )
+            )
+        )
+
+        val failure = render(report).single { it.contains("testFailed") }
+
+        assertTrue(failure.contains("message='it|'s |[bad|]'"), failure)
+        assertTrue(failure.contains("details='line one|nline two||end|r'"), failure)
+    }
+
+    @Test
+    fun `an empty report renders nothing`() {
+        assertTrue(render(PhelTestReport.EMPTY).isEmpty())
+    }
+
+    @Test
+    fun `a suite with no cases still opens and closes`() {
+        val messages = render(PhelTestReport(listOf(PhelTestSuite("empty", emptyList()))))
+
+        assertEquals(
+            listOf("##teamcity[testSuiteStarted name='empty']", "##teamcity[testSuiteFinished name='empty']"),
+            messages,
+        )
+    }
+
+    @Test
+    fun `renders every suite in a multi-suite report`() {
+        val messages = renderXml(
+            """
+            <testsuites>
+              <testsuite name="a"><testcase name="x"/></testsuite>
+              <testsuite name="b"><testcase name="y"/></testsuite>
+            </testsuites>
+            """.trimIndent()
+        )
+
+        assertEquals(2, messages.count { it.startsWith("##teamcity[testSuiteStarted") })
+        assertEquals(2, messages.count { it.startsWith("##teamcity[testStarted") })
+    }
+
+    /** Every started test must be finished, or the tree shows it running forever. */
+    @Test
+    fun `every started test is finished`() {
+        val messages = renderXml(
+            """
+            <testsuite name="s">
+              <testcase name="ok"/>
+              <testcase name="bad"><failure message="m">d</failure></testcase>
+              <testcase name="skip"><skipped message="w"/></testcase>
+            </testsuite>
+            """.trimIndent()
+        )
+
+        assertEquals(
+            messages.count { it.startsWith("##teamcity[testStarted") },
+            messages.count { it.startsWith("##teamcity[testFinished") },
+        )
+    }
+}


### PR DESCRIPTION
Closes the last box on #263. `phel test` results now appear in a real test tree — pass/fail status,
durations, and failure messages with details — instead of scrolling past in a plain console.

## The blocker, resolved

I twice declined this as "pinning a reporter format I cannot verify". That was based on knowing only
that `--reporter` existed. Checking [the CLI docs](https://phel-lang.org/documentation/tooling/cli-commands/)
properly shows the accepted values: `default|testdox|dot|tap|junit-xml`, repeatable, with `--output=PATH`.

**`junit-xml`, not `tap`.** JUnit XML is a de-facto standard, so the parser is pinned down by tests
that need no `phel` binary to run — which is exactly what was missing before. TAP would have meant
guessing Phel's dialect (plan-line ordering, diagnostic shape, subtests), reintroducing the original
problem.

The cost is that the tree is built when the run finishes rather than filling in live. Both reporters
are requested, so the console still shows the normal `default` output throughout.

## How it reaches the tree

The report is replayed as service messages that the platform's default converter already parses,
rather than through a custom `OutputToGeneralTestEventsConverter`. Two reasons: this SDK has no
`SMCustomMessagesParsing` to hang a converter on (I checked the distribution — the class is absent),
and it keeps the whole translation a **pure function**, so the tree's contents are asserted directly.

Messages are emitted *before* termination is announced; the runner stops accepting them afterwards
and the tree would stay empty.

An unreadable or missing report becomes no results rather than an error. A stopped run, or a `phel`
that failed before writing, leaves exactly that — and the console already shows what happened.

## Refactor pass found real dead code

Overriding `getState` wholesale left `PhelTestConfiguration.commandLine()` dead: the base contract
required it and nothing called it. The base now exposes `createProcessHandler` and
`createConsoleView`, so the test configuration overrides only those. The report's location lives in
the command line alone, with the handler reading `--output` back off the command line it is given —
no second copy to keep in step.

## Test plan

- `./gradlew test` — 1527 tests, 0 failures, over three consecutive full runs.
- 13 parser tests: suites and cases, nesting, a bare `<testsuite>` with no wrapper, pass/failure/
  error/skipped outcomes, time conversion, a missing `time`, a failure with no `message` attribute,
  and — the ones that matter for a killed run — empty and malformed XML yielding an empty report
  rather than throwing.
- 11 service-message tests: suite wrapping, durations in milliseconds, failure message and details,
  `error='true'` separating a crash from an assertion, skipped mapping to `testIgnored` and not to a
  failure, multi-suite reports, and every started test being finished so nothing shows as running
  forever.
- 2 command-line tests: both reporters requested with the output path, and options ordered before
  paths per the documented usage.
- Escaping is covered explicitly: Phel namespaces carry backslashes (`app\core-test`), and failure
  details carry quotes, newlines and brackets.

Not verified in a sandbox IDE: no run against a real `phel` binary, so the XML shape is taken from
the JUnit standard rather than from observed Phel output. If Phel's `junit-xml` differs in some
detail, the parser tests are where to correct it.

Closes #263
