### PR TITLE
feat(run): run test files and single tests into the test tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,13 @@ refreshed, since completion, hover and arity checking are all driven by it.
 
 ### Added
 
+- **Test files now run into the test tree.** Opening a file whose `ns` requires `phel\test` and using the gutter icon,
+  the context menu or Run Anything runs `phel test` on it, so results arrive as a green or red bar instead of plain
+  console output. Ordinary `.phel` files still run through `phel run` and its console. Detection is based on the
+  `phel\test` require rather than on `phel-config.php`, so it works for a test file kept outside the configured test
+  directories, and both the `phel.test` and `phel\test` spellings are recognised.
+- **Run a single test** from the gutter icon beside any `deftest`. The test is selected with an anchored pattern, so
+  running `void-tags` cannot also pull in `void-tags-ignore-content`, which a plain name filter would.
 - **Live templates** for eleven forms: `defn-`, `defmacro`, `ns`, `deftest`, `when`, `when-let`, `loop`, `cond`,
   `case`, `try` and `foreach`. They appear under Settings > Editor > Live Templates > Phel, expand with Tab, and can
   be edited or extended. The six abbreviations completion already offers (`()`, `defn`, `def`, `let`, `if`, `fn`) are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,9 @@ refreshed, since completion, hover and arity checking are all driven by it.
   to the process (#263).
 - A **test** run configuration, running `phel test` over the whole suite or over named paths, into a real test tree
   with pass/fail status, durations and failure details. Built from the `junit-xml` reporter, which is written
-  alongside the normal console output and read when the run finishes (#263).
+  alongside the normal console output and read when the run finishes (#263). The tree shows one node per `deftest`:
+  that reporter emits an entry per `is` form, so the entries of a test are folded into a single node that fails when
+  any of its assertions does and lists every failing form in its details.
 - A **run configuration** for Phel files. Right-click a `.phel` file, or use the Run icon in the gutter beside its
   `(ns …)` form, to run it through the project's `phel` binary. The binary is found the same way the formatter finds
   it (`./bin/phel`, then `./vendor/bin/phel`) and runs with the login shell's environment, so a Homebrew, Herd, asdf

--- a/src/main/kotlin/org/phellang/run/PhelRunConfigurationProducer.kt
+++ b/src/main/kotlin/org/phellang/run/PhelRunConfigurationProducer.kt
@@ -6,33 +6,53 @@ import com.intellij.execution.configurations.ConfigurationFactory
 import com.intellij.openapi.util.Ref
 import com.intellij.psi.PsiElement
 import org.phellang.language.psi.files.PhelFile
+import org.phellang.run.test.PhelTestDetection
 
-/** Makes Run available from a `.phel` file's context menu, editor gutter and Run Anything. */
-class PhelRunConfigurationProducer : LazyRunConfigurationProducer<PhelRunConfiguration>() {
+/**
+ * Makes Run available from a `.phel` file's context menu, editor gutter and Run Anything.
+ *
+ * Parameterised on [PhelCliRunConfiguration] for the same reason as [PhelTestConfigurationProducer]:
+ * the file, REPL and test configurations share one `ConfigurationType`, so the platform offers this
+ * producer configurations that are not [PhelRunConfiguration]s, and a narrower type parameter turns
+ * that into a `ClassCastException` in the generated bridge method.
+ */
+class PhelRunConfigurationProducer : LazyRunConfigurationProducer<PhelCliRunConfiguration>() {
 
     override fun getConfigurationFactory(): ConfigurationFactory =
         PhelRunConfigurationType.fileFactory()
 
     override fun setupConfigurationFromContext(
-        configuration: PhelRunConfiguration,
+        configuration: PhelCliRunConfiguration,
         context: ConfigurationContext,
         sourceElement: Ref<PsiElement>,
     ): Boolean {
+        val runConfiguration = configuration as? PhelRunConfiguration ?: return false
         val virtualFile = phelFilePath(context) ?: return false
 
-        configuration.scriptPath = virtualFile
-        configuration.workingDirectory = context.project.basePath.orEmpty()
-        configuration.setName(configuration.suggestedName())
+        runConfiguration.scriptPath = virtualFile
+        runConfiguration.workingDirectory = context.project.basePath.orEmpty()
+        runConfiguration.setName(runConfiguration.suggestedName())
         return true
     }
 
     override fun isConfigurationFromContext(
-        configuration: PhelRunConfiguration,
+        configuration: PhelCliRunConfiguration,
         context: ConfigurationContext,
-    ): Boolean = phelFilePath(context) == configuration.scriptPath
+    ): Boolean {
+        val runConfiguration = configuration as? PhelRunConfiguration ?: return false
 
+        return phelFilePath(context) == runConfiguration.scriptPath
+    }
+
+    /**
+     * Test files are declined so [PhelTestConfigurationProducer] takes them. Declining outright,
+     * rather than leaning on producer precedence, keeps which one wins independent of the platform's
+     * ordering rules.
+     */
     private fun phelFilePath(context: ConfigurationContext): String? {
         val file = context.psiLocation?.containingFile as? PhelFile ?: return null
+        if (PhelTestDetection.isTestFile(file)) return null
+
         return file.virtualFile?.path
     }
 }

--- a/src/main/kotlin/org/phellang/run/PhelRunConfigurationType.kt
+++ b/src/main/kotlin/org/phellang/run/PhelRunConfigurationType.kt
@@ -59,5 +59,8 @@ class PhelRunConfigurationType : ConfigurationType {
 
         /** The factory the context producer creates a file-running configuration from. */
         fun fileFactory(): ConfigurationFactory = getInstance().fileFactory
+
+        /** The factory the context producer creates a test configuration from. */
+        fun testFactory(): ConfigurationFactory = getInstance().testFactory
     }
 }

--- a/src/main/kotlin/org/phellang/run/PhelRunLineMarkerContributor.kt
+++ b/src/main/kotlin/org/phellang/run/PhelRunLineMarkerContributor.kt
@@ -8,18 +8,25 @@ import com.intellij.psi.util.PsiTreeUtil
 import org.phellang.language.psi.PhelNamespaceUtils
 import org.phellang.language.psi.files.PhelFile
 import org.phellang.language.psi.utils.PhelPsiUtils
+import org.phellang.run.test.PhelTestDetection
 
 /**
- * Puts a Run gutter icon on the `ns` of a file's namespace declaration.
+ * Puts a Run gutter icon on the `ns` of a file's namespace declaration, and on each `deftest`.
  *
- * One marker per file, on the form that names it. Marking every top-level `defn` would suggest the
- * CLI can run a single function, which `phel run <path>` cannot: it takes a file or a namespace.
+ * Still no marker on a top-level `defn`: that would suggest the CLI can run a single function, which
+ * `phel run <path>` cannot, since it takes a file or a namespace. A `deftest` is different because
+ * `phel test --filter` genuinely can run one test, so the icon offers something that exists.
  */
 class PhelRunLineMarkerContributor : RunLineMarkerContributor() {
 
     override fun getInfo(element: PsiElement): Info? {
         // Called for every element in the file, so reject non-leaves before touching the tree.
         if (element.firstChild != null) return null
+
+        return namespaceInfo(element) ?: testInfo(element)
+    }
+
+    private fun namespaceInfo(element: PsiElement): Info? {
         if (element.text != NS_KEYWORD) return null
 
         val file = element.containingFile as? PhelFile ?: return null
@@ -29,12 +36,17 @@ class PhelRunLineMarkerContributor : RunLineMarkerContributor() {
         // itself, so this covers both shapes without a separate identity check.
         if (!PsiTreeUtil.isAncestor(head, element, false)) return null
 
-        return Info(
-            AllIcons.RunConfigurations.TestState.Run,
-            { "Run ${file.name}" },
-            *ExecutorAction.getActions(0),
-        )
+        return info("Run ${file.name}")
     }
+
+    private fun testInfo(element: PsiElement): Info? {
+        val name = PhelTestDetection.deftestHeadedBy(element) ?: return null
+
+        return info("Run $name")
+    }
+
+    private fun info(tooltip: String): Info =
+        Info(AllIcons.RunConfigurations.TestState.Run, { tooltip }, *ExecutorAction.getActions(0))
 
     private companion object {
         const val NS_KEYWORD = "ns"

--- a/src/main/kotlin/org/phellang/run/PhelTestConfiguration.kt
+++ b/src/main/kotlin/org/phellang/run/PhelTestConfiguration.kt
@@ -36,6 +36,16 @@ class PhelTestConfiguration(
     /** Space-separated paths, empty meaning the whole suite. */
     var testPaths: String = ""
 
+    /**
+     * A single test to run, empty meaning every test in scope.
+     *
+     * Held as the plain name rather than as a `--filter` pattern so that what the run dialog shows
+     * is a test name, and so that every run is anchored: `--filter` matches unanchored substrings,
+     * so a hand-typed `basic-tags` would silently also run `basic-tags-extended`. The anchoring is
+     * applied on the way out, in [commandLine].
+     */
+    var testName: String = ""
+
     override fun getConfigurationEditor(): SettingsEditor<out RunConfiguration> = PhelTestConfigurationEditor(project)
 
     /**
@@ -48,6 +58,7 @@ class PhelTestConfiguration(
             paths(),
             effectiveWorkingDirectory(),
             FileUtil.createTempFile("phel-test-", ".xml", true),
+            filter = testName.ifBlank { null }?.let(PhelRunCommandLine::exactNameFilter),
         )
 
     override fun createProcessHandler(commandLine: GeneralCommandLine): ProcessHandler =
@@ -60,19 +71,32 @@ class PhelTestConfiguration(
 
     fun paths(): List<String> = testPaths.split(' ', '\n').map(String::trim).filter(String::isNotEmpty)
 
-    override fun suggestedName(): String = if (testPaths.isBlank()) "All tests" else "Tests: $testPaths"
+    /** File names rather than whole paths: the producer stores absolute ones, and the run widget is narrow. */
+    override fun suggestedName(): String {
+        if (testName.isNotBlank()) return testName
+
+        val paths = paths()
+        if (paths.isEmpty()) return "All tests"
+
+        return "Tests: ${paths.joinToString(" ") { File(it).name }}"
+    }
 
     override fun writeExternal(element: Element) {
         super.writeExternal(element)
         JDOMExternalizerUtil.writeField(element, TEST_PATHS_FIELD, testPaths)
+        JDOMExternalizerUtil.writeField(element, TEST_NAME_FIELD, testName)
     }
 
     override fun readExternal(element: Element) {
         super.readExternal(element)
         testPaths = JDOMExternalizerUtil.readField(element, TEST_PATHS_FIELD).orEmpty()
+        testName = JDOMExternalizerUtil.readField(element, TEST_NAME_FIELD).orEmpty()
     }
 
     private companion object {
+        // Persisted in workspace.xml; append-only, so a configuration saved before TEST_NAME existed
+        // still reads back as the whole-suite or whole-file run it was.
         const val TEST_PATHS_FIELD = "TEST_PATHS"
+        const val TEST_NAME_FIELD = "TEST_NAME"
     }
 }

--- a/src/main/kotlin/org/phellang/run/PhelTestConfigurationProducer.kt
+++ b/src/main/kotlin/org/phellang/run/PhelTestConfigurationProducer.kt
@@ -1,0 +1,70 @@
+package org.phellang.run
+
+import com.intellij.execution.actions.ConfigurationContext
+import com.intellij.execution.actions.LazyRunConfigurationProducer
+import com.intellij.execution.configurations.ConfigurationFactory
+import com.intellij.openapi.util.Ref
+import com.intellij.psi.PsiElement
+import org.phellang.language.psi.files.PhelFile
+import org.phellang.run.test.PhelTestDetection
+
+/**
+ * Sends a test file to `phel test`, and so into the test tree, rather than to `phel run`.
+ *
+ * Scope follows the context: inside a `deftest` it is that one test, anywhere else in the file it is
+ * the whole file. `PhelRunConfigurationProducer` declines test files outright, which is what keeps
+ * the two from competing.
+ *
+ * Parameterised on [PhelCliRunConfiguration], not on [PhelTestConfiguration], because the platform
+ * offers every configuration of a *type* to every producer registered for it, and the file, REPL and
+ * test configurations all share `PhelRunConfigurationType` — they differ only by factory. Narrowing
+ * the type parameter instead made the generated bridge cast a `PhelRunConfiguration` to
+ * `PhelTestConfiguration`, and the resulting `ClassCastException` killed the whole gutter popup, so
+ * clicking Run reported "Nothing here" on *every* Phel file. The `as?` below is the real guard.
+ */
+class PhelTestConfigurationProducer : LazyRunConfigurationProducer<PhelCliRunConfiguration>() {
+
+    override fun getConfigurationFactory(): ConfigurationFactory = PhelRunConfigurationType.testFactory()
+
+    override fun setupConfigurationFromContext(
+        configuration: PhelCliRunConfiguration,
+        context: ConfigurationContext,
+        sourceElement: Ref<PsiElement>,
+    ): Boolean {
+        val testConfiguration = configuration as? PhelTestConfiguration ?: return false
+        val location = locate(context) ?: return false
+
+        testConfiguration.testPaths = location.path
+        testConfiguration.testName = location.testName
+        testConfiguration.workingDirectory = context.project.basePath.orEmpty()
+        testConfiguration.setName(testConfiguration.suggestedName())
+        return true
+    }
+
+    /**
+     * The test name as well as the path: comparing the path alone would make a single-test run
+     * indistinguishable from a whole-file run of the same file, and the second invocation would
+     * silently reuse the first configuration and run the wrong set of tests.
+     */
+    override fun isConfigurationFromContext(
+        configuration: PhelCliRunConfiguration,
+        context: ConfigurationContext,
+    ): Boolean {
+        val testConfiguration = configuration as? PhelTestConfiguration ?: return false
+        val location = locate(context) ?: return false
+
+        return testConfiguration.testPaths == location.path && testConfiguration.testName == location.testName
+    }
+
+    private fun locate(context: ConfigurationContext): TestLocation? {
+        val element = context.psiLocation ?: return null
+        val file = element.containingFile as? PhelFile ?: return null
+        if (!PhelTestDetection.isTestFile(file)) return null
+
+        val path = file.virtualFile?.path ?: return null
+
+        return TestLocation(path, PhelTestDetection.enclosingDeftestName(element).orEmpty())
+    }
+
+    private data class TestLocation(val path: String, val testName: String)
+}

--- a/src/main/kotlin/org/phellang/run/execution/PhelRunCommandLine.kt
+++ b/src/main/kotlin/org/phellang/run/execution/PhelRunCommandLine.kt
@@ -30,24 +30,60 @@ object PhelRunCommandLine {
      * Both reporters are requested when [reportFile] is given: `default` keeps the console output
      * the user watches during the run, and `junit-xml` writes the machine-readable report the test
      * tree is built from once the process exits. `--reporter` is documented as repeatable.
+     *
+     * [filter] narrows the run to a single test; see [exactNameFilter] for why it has to arrive
+     * already anchored.
+     *
+     * There is deliberately no `--ns` companion. Pinning the namespace would close the small hole
+     * where a same-named `deftest` in a dependency also matches, but the namespace `phel` matches
+     * against is derived from the file's location, not from its `(ns …)` form, and the two differ
+     * freely: `tests/html.phel` declaring `(ns test.html …)` is matched as `tests.html`. A wrong pin
+     * silently selects nothing, which is a worse failure than the over-match it was guarding.
      */
     fun test(
         binary: File,
         paths: List<String>,
         workingDirectory: String,
         reportFile: File? = null,
+        filter: String? = null,
     ): GeneralCommandLine {
-        val options = if (reportFile == null) {
+        val reporters = if (reportFile == null) {
             emptyList()
         } else {
             listOf("--reporter=default", "--reporter=junit-xml", "$OUTPUT_OPTION${reportFile.absolutePath}")
         }
 
-        return command(binary, "test", options + paths, workingDirectory)
+        val selectors = if (filter.isNullOrBlank()) emptyList() else listOf("$FILTER_OPTION$filter")
+
+        return command(binary, "test", reporters + selectors + paths, workingDirectory)
     }
+
+    /**
+     * An anchored PCRE selecting [testName] and nothing else.
+     *
+     * `--filter` treats a bare fragment as an *unanchored substring*: `compile-filter-regex` in
+     * `phel/test/selector.phel` runs it through `preg_quote` and wraps it in `/.../`, so the bare
+     * name `basic-tags` would also select `basic-tags-extended`. Only a pattern that already opens
+     * and closes with `/` is passed through as raw PCRE, so anchoring means delimiting it here.
+     *
+     * The escaping is done character by character rather than with [Regex.escape], which emits
+     * `\Q...\E`: PCRE resolves the `/` delimiter before it honours `\Q`, so a `/` inside the name
+     * would still cut the pattern short. Characters above ASCII are left alone — they carry no
+     * special meaning in PCRE, and it is backslash-escaping them that is unsafe.
+     */
+    fun exactNameFilter(testName: String): String =
+        testName.map { char ->
+            when {
+                char in 'a'..'z' || char in 'A'..'Z' || char in '0'..'9' || char == '_' -> char.toString()
+                char.code > 127 -> char.toString()
+                else -> "\\$char"
+            }
+        }.joinToString("", prefix = "/^", postfix = "$/")
 
     /** Where `junit-xml` writes. Read back off the command line rather than passed around beside it. */
     const val OUTPUT_OPTION = "--output="
+
+    private const val FILTER_OPTION = "--filter="
 
     private fun command(
         binary: File,

--- a/src/main/kotlin/org/phellang/run/settings/PhelTestConfigurationEditor.kt
+++ b/src/main/kotlin/org/phellang/run/settings/PhelTestConfigurationEditor.kt
@@ -12,18 +12,24 @@ class PhelTestConfigurationEditor(project: Project) :
 
     private val pathsField = JBTextField()
 
+    /** Editable so a configuration created from a `deftest` gutter icon survives a trip through the dialog. */
+    private val testNameField = JBTextField()
+
     override fun resetEditorFrom(configuration: PhelTestConfiguration) {
         super.resetEditorFrom(configuration)
         pathsField.text = configuration.testPaths
+        testNameField.text = configuration.testName
     }
 
     override fun applyEditorTo(configuration: PhelTestConfiguration) {
         super.applyEditorTo(configuration)
         configuration.testPaths = pathsField.text.trim()
+        configuration.testName = testNameField.text.trim()
     }
 
     override fun buildPanel(): JPanel = FormBuilder.createFormBuilder()
         .addLabeledComponent(JBLabel("Paths (blank runs everything):"), pathsField, true)
+        .addLabeledComponent(JBLabel("Test name (blank runs every test in scope):"), testNameField, true)
         .addLabeledComponent(JBLabel("Working directory:"), workingDirectoryField, true)
         .panel
 }

--- a/src/main/kotlin/org/phellang/run/test/PhelJUnitXmlParser.kt
+++ b/src/main/kotlin/org/phellang/run/test/PhelJUnitXmlParser.kt
@@ -53,7 +53,69 @@ object PhelJUnitXmlParser {
                 durationSeconds = case.getAttribute("time").toDoubleOrNull(),
                 outcome = outcomeOf(case),
             )
+        }.let(::foldAssertions)
+
+    /**
+     * Folds the repeated entries `phel` emits per assertion into one case per test.
+     *
+     * `--reporter=junit-xml` writes one `<testcase>` per `is` form, each carrying the *enclosing
+     * test's* name, so a `deftest` with four assertions arrived as four identically named siblings in
+     * the tree. Running a single test from the gutter made that unmistakable.
+     *
+     * Grouping by name is safe because a namespace cannot define the same `deftest` twice, and
+     * `groupBy` keeps first-appearance order so the tree still follows the file.
+     */
+    private fun foldAssertions(cases: List<PhelTestCase>): List<PhelTestCase> =
+        cases.groupBy { it.name }.map { (_, assertions) -> merge(assertions) }
+
+    private fun merge(assertions: List<PhelTestCase>): PhelTestCase {
+        // A test reported as a single case is left exactly as it was parsed.
+        if (assertions.size == 1) return assertions.single()
+
+        val durations = assertions.mapNotNull { it.durationSeconds }
+
+        return PhelTestCase(
+            name = assertions.first().name,
+            durationSeconds = if (durations.isEmpty()) null else durations.sum(),
+            outcome = mergedOutcome(assertions.map { it.outcome }),
+        )
+    }
+
+    /**
+     * The worst outcome in the group wins, since one failed assertion fails the test. Errors outrank
+     * failures because a crash is not a comparison that came out false, and a test counts as skipped
+     * only when nothing in it ran.
+     */
+    private fun mergedOutcome(outcomes: List<PhelTestCase.Outcome>): PhelTestCase.Outcome {
+        val errored = outcomes.filterIsInstance<PhelTestCase.Outcome.Errored>()
+        if (errored.isNotEmpty()) {
+            return PhelTestCase.Outcome.Errored(
+                summarize(errored.map { it.message }, outcomes.size, "errored"),
+                errored.joinToString(DETAIL_SEPARATOR) { it.details },
+            )
         }
+
+        val failed = outcomes.filterIsInstance<PhelTestCase.Outcome.Failed>()
+        if (failed.isNotEmpty()) {
+            return PhelTestCase.Outcome.Failed(
+                summarize(failed.map { it.message }, outcomes.size, "failed"),
+                failed.joinToString(DETAIL_SEPARATOR) { it.details },
+            )
+        }
+
+        val skipped = outcomes.filterIsInstance<PhelTestCase.Outcome.Skipped>()
+        if (skipped.size == outcomes.size) return PhelTestCase.Outcome.Skipped(skipped.first().message)
+
+        return PhelTestCase.Outcome.Passed
+    }
+
+    /**
+     * One bad assertion keeps its own message, which for Phel is the failing form. Several would
+     * otherwise be reduced to whichever came first, so the count is reported instead and every form
+     * stays in the details.
+     */
+    private fun summarize(messages: List<String>, total: Int, verb: String): String =
+        messages.singleOrNull() ?: "${messages.size} of $total assertions $verb"
 
     private fun outcomeOf(case: Element): PhelTestCase.Outcome {
         for (child in case.childElements()) {
@@ -96,4 +158,7 @@ object PhelJUnitXmlParser {
 
     private const val SUITE = "testsuite"
     private const val CASE = "testcase"
+
+    /** A blank line between the folded assertions, so the tree's detail pane stays readable. */
+    private const val DETAIL_SEPARATOR = "\n\n"
 }

--- a/src/main/kotlin/org/phellang/run/test/PhelTestDetection.kt
+++ b/src/main/kotlin/org/phellang/run/test/PhelTestDetection.kt
@@ -1,0 +1,86 @@
+package org.phellang.run.test
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelNamespaceUtils
+import org.phellang.language.psi.files.PhelFile
+import org.phellang.language.psi.utils.PhelPsiUtils
+
+/**
+ * Tells a Phel test file from an ordinary one, and locates the `deftest` forms in it.
+ *
+ * Detection is semantic — the file's `ns` requires `phel\test` — rather than positional. Deriving it
+ * from `withTestDirs([...])` in `phel-config.php` was rejected: that file is PHP evaluated by PHP,
+ * its `testDirs` already defaults to `['tests']` so the call's presence carries no information, and
+ * `phel-config-local.php` overrides it. It would also err both ways here, marking a fixture inside
+ * `tests/` that defines nothing and missing a test file kept outside it.
+ */
+object PhelTestDetection {
+
+    fun isTestFile(file: PhelFile): Boolean {
+        val declaration = PhelNamespaceUtils.findNamespaceDeclaration(file) ?: return false
+        return PhelNamespaceUtils.isNamespaceRequired(declaration, TEST_NAMESPACE)
+    }
+
+    /**
+     * The test [list] defines, or null when it is not a `deftest`.
+     *
+     * [PhelPsiUtils.activeForms] rather than `list.forms`, because `#_` leaves the discarded form in
+     * the tree: reading raw children would take the discarded name of `(deftest #_old new ...)`.
+     * [PhelPsiUtils.asSymbol] rather than a cast, because a simple symbol parses as `PhelAccess`.
+     */
+    fun deftestName(list: PhelList): String? {
+        val forms = PhelPsiUtils.activeForms(list)
+        if (forms.size < 2) return null
+
+        val head = PhelPsiUtils.asSymbol(forms[0])?.text ?: return null
+        if (!isDeftest(head)) return null
+
+        return PhelPsiUtils.asSymbol(forms[1])?.text
+    }
+
+    /**
+     * The name of the test [element] heads, or null when it heads nothing runnable.
+     *
+     * Ordered cheapest-first: this is called for every leaf in the file while highlighting.
+     */
+    fun deftestHeadedBy(element: PsiElement): String? {
+        val text = element.text
+        if (text != DEFTEST && !text.endsWith(ALIASED_DEFTEST)) return null
+
+        val file = element.containingFile as? PhelFile ?: return null
+        if (!isTestFile(file)) return null
+
+        val list = PsiTreeUtil.getParentOfType(element, PhelList::class.java) ?: return null
+        if (list.parent !== file) return null
+
+        val name = deftestName(list) ?: return null
+        // The head text sits on a leaf beneath the symbol; `strict = false` also accepts the symbol
+        // itself, so this covers both shapes without a separate identity check.
+        val head = PhelPsiUtils.asSymbol(PhelPsiUtils.activeForms(list).firstOrNull()) ?: return null
+        if (!PsiTreeUtil.isAncestor(head, element, false)) return null
+
+        return name
+    }
+
+    /** The test [element] sits inside, however deep, or null when it is not within one. */
+    fun enclosingDeftestName(element: PsiElement): String? {
+        var list = PsiTreeUtil.getParentOfType(element, PhelList::class.java)
+        while (list != null) {
+            if (list.parent is PhelFile) return deftestName(list)
+            list = PsiTreeUtil.getParentOfType(list, PhelList::class.java)
+        }
+
+        return null
+    }
+
+    /** `deftest` when referred, `t/deftest` when the require was aliased with `:as`. */
+    private fun isDeftest(head: String): Boolean = head == DEFTEST || head.endsWith(ALIASED_DEFTEST)
+
+    private const val DEFTEST = "deftest"
+
+    private const val ALIASED_DEFTEST = "/$DEFTEST"
+
+    private const val TEST_NAMESPACE = "phel\\test"
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -192,6 +192,8 @@
                 implementation="org.phellang.run.PhelRunConfigurationType"/>
         <runConfigurationProducer
                 implementation="org.phellang.run.PhelRunConfigurationProducer"/>
+        <runConfigurationProducer
+                implementation="org.phellang.run.PhelTestConfigurationProducer"/>
         <runLineMarkerContributor
                 language="Phel"
                 implementationClass="org.phellang.run.PhelRunLineMarkerContributor"/>

--- a/src/test/kotlin/org/phellang/integration/run/PhelReplAndTestConfigurationTest.kt
+++ b/src/test/kotlin/org/phellang/integration/run/PhelReplAndTestConfigurationTest.kt
@@ -79,10 +79,20 @@ class PhelReplAndTestConfigurationTest : PhelIntegrationTestCase() {
         assertEquals(listOf("tests/a.phel"), configuration.paths())
     }
 
+    /** File names, not whole paths: the producer stores absolute ones and the run widget is narrow. */
     fun testTestConfigurationNamesItselfAfterItsPaths() {
         val configuration = testConfiguration().apply { testPaths = "tests/a.phel" }
 
-        assertEquals("Tests: tests/a.phel", configuration.suggestedName())
+        assertEquals("Tests: a.phel", configuration.suggestedName())
+    }
+
+    fun testTestConfigurationNamesItselfAfterASingleTest() {
+        val configuration = testConfiguration().apply {
+            testPaths = "/project/tests/html.phel"
+            testName = "basic-tags"
+        }
+
+        assertEquals("basic-tags", configuration.suggestedName())
     }
 
     fun testTestConfigurationRoundTripsThroughXml() {
@@ -98,6 +108,36 @@ class PhelReplAndTestConfigurationTest : PhelIntegrationTestCase() {
 
         assertEquals("tests/a.phel", loaded.testPaths)
         assertEquals("/project", loaded.workingDirectory)
+    }
+
+    fun testTestConfigurationRoundTripsASingleTestThroughXml() {
+        val saved = testConfiguration().apply {
+            testPaths = "/project/tests/html.phel"
+            testName = "basic-tags"
+        }
+        val element = Element("configuration")
+        saved.writeExternal(element)
+
+        val loaded = testConfiguration()
+        loaded.readExternal(element)
+
+        assertEquals("/project/tests/html.phel", loaded.testPaths)
+        assertEquals("basic-tags", loaded.testName)
+    }
+
+    /**
+     * The new keys are append-only: a configuration saved before they existed must still load as
+     * the whole-file run it was, rather than silently acquiring a filter.
+     */
+    fun testTestConfigurationLoadsAnElementSavedBeforeTheTestFieldsExisted() {
+        val element = Element("configuration")
+        com.intellij.openapi.util.JDOMExternalizerUtil.writeField(element, "TEST_PATHS", "tests/a.phel")
+
+        val loaded = testConfiguration()
+        loaded.readExternal(element)
+
+        assertEquals("tests/a.phel", loaded.testPaths)
+        assertEquals("", loaded.testName)
     }
 
     /** Neither can run without a binary, and both must say so before launching. */

--- a/src/test/kotlin/org/phellang/integration/run/PhelRunCommandLineTest.kt
+++ b/src/test/kotlin/org/phellang/integration/run/PhelRunCommandLineTest.kt
@@ -103,4 +103,96 @@ class PhelRunCommandLineTest : PhelIntegrationTestCase() {
         assertEquals("tests/a.phel", command.last())
         assertTrue(command.indexOf("--reporter=junit-xml") < command.indexOf("tests/a.phel"))
     }
+
+    fun testTestOmitsSelectorsWhenNoneAreGiven() {
+        val command = PhelRunCommandLine.test(binary, listOf("tests/a.phel"), workingDir).getCommandLineList(null)
+
+        assertEquals(listOf(binary.absolutePath, "test", "tests/a.phel"), command)
+    }
+
+    fun testTestNarrowsToASingleTestWithAFilter() {
+        val command = PhelRunCommandLine.test(
+            binary,
+            listOf("tests/html.phel"),
+            workingDir,
+            filter = PhelRunCommandLine.exactNameFilter("basic-tags"),
+        ).getCommandLineList(null)
+
+        assertEquals(
+            listOf(binary.absolutePath, "test", "--filter=/^basic\\-tags$/", "tests/html.phel"),
+            command,
+        )
+    }
+
+    /**
+     * No `--ns` companion. `phel` derives the namespace it matches from the file's location, not
+     * from its `(ns …)` form, so a pin built from the declared name selects nothing at all:
+     * `tests/html.phel` declaring `(ns test.html …)` is matched as `tests.html`.
+     */
+    fun testTestNeverPinsTheNamespace() {
+        val command = PhelRunCommandLine.test(
+            binary,
+            listOf("tests/html.phel"),
+            workingDir,
+            filter = PhelRunCommandLine.exactNameFilter("basic-tags"),
+        ).getCommandLineList(null)
+
+        assertFalse(command.toString(), command.any { it.startsWith("--ns") })
+    }
+
+    fun testTestPutsSelectorsBeforePaths() {
+        val command = PhelRunCommandLine.test(
+            binary,
+            listOf("tests/html.phel"),
+            workingDir,
+            java.io.File("/tmp/phel-report.xml"),
+            filter = PhelRunCommandLine.exactNameFilter("basic-tags"),
+        ).getCommandLineList(null)
+
+        assertEquals("tests/html.phel", command.last())
+        assertTrue(command.indexOf("--filter=/^basic\\-tags$/") < command.indexOf("tests/html.phel"))
+    }
+
+    fun testABlankFilterIsNotPassedAsAnEmptyOption() {
+        val command = PhelRunCommandLine.test(binary, listOf("tests/a.phel"), workingDir, filter = "")
+            .getCommandLineList(null)
+
+        assertEquals(listOf(binary.absolutePath, "test", "tests/a.phel"), command)
+    }
+
+    /**
+     * The pattern must survive `compile-filter-regex` in `phel/test/selector.phel` unchanged, which
+     * only happens when it is longer than one character and both opens and closes with `/`.
+     * Anything else is `preg_quote`d into an unanchored substring match.
+     */
+    fun testAnExactFilterIsHandedToPhelAsRawPcre() {
+        for (name in listOf("basic-tags", "empty?", "parse*", "a/b", "ok")) {
+            val pattern = PhelRunCommandLine.exactNameFilter(name)
+
+            assertTrue(pattern, pattern.length > 1)
+            assertTrue(pattern, pattern.startsWith("/") && pattern.endsWith("/"))
+        }
+    }
+
+    /** Anchored, so `basic-tags` cannot also select `basic-tags-extended`. */
+    fun testAnExactFilterAnchorsBothEnds() {
+        assertEquals("/^basic\\-tags$/", PhelRunCommandLine.exactNameFilter("basic-tags"))
+    }
+
+    /** Metacharacters that are idiomatic in Phel names must match literally, not as regex syntax. */
+    fun testAnExactFilterEscapesRegexMetacharacters() {
+        assertEquals("/^empty\\?$/", PhelRunCommandLine.exactNameFilter("empty?"))
+        assertEquals("/^parse\\*$/", PhelRunCommandLine.exactNameFilter("parse*"))
+        assertEquals("/^a\\.b$/", PhelRunCommandLine.exactNameFilter("a.b"))
+        assertEquals("/^x\\+y$/", PhelRunCommandLine.exactNameFilter("x+y"))
+    }
+
+    /** The delimiter itself, which `\Q...\E` would not have protected. */
+    fun testAnExactFilterEscapesTheDelimiter() {
+        assertEquals("/^a\\/b$/", PhelRunCommandLine.exactNameFilter("a/b"))
+    }
+
+    fun testAnExactFilterLeavesLettersDigitsAndUnderscoreAlone() {
+        assertEquals("/^abc_123$/", PhelRunCommandLine.exactNameFilter("abc_123"))
+    }
 }

--- a/src/test/kotlin/org/phellang/integration/run/PhelRunLineMarkerContributorTest.kt
+++ b/src/test/kotlin/org/phellang/integration/run/PhelRunLineMarkerContributorTest.kt
@@ -51,4 +51,54 @@ class PhelRunLineMarkerContributorTest : PhelIntegrationTestCase() {
 
         assertTrue("expected at least one executor action on the gutter marker", info.actions.isNotEmpty())
     }
+
+    // ---- tests ----
+
+    private val testFile = """
+        (ns test.html
+          (:require phel.test :refer [deftest is]))
+
+        (deftest basic-tags
+          (is (= "<div></div>" (html [:div]))))
+
+        (deftest empty-tags
+          (is (= "<h1></h1>" (html [:h1]))))
+    """.trimIndent()
+
+    fun testMarksTheNamespaceAndEveryTest() {
+        val marked = markedElements(testFile)
+
+        assertEquals(listOf("ns", "deftest", "deftest"), marked.map { it.text })
+    }
+
+    fun testDoesNotMarkAssertionsOrOtherInnerForms() {
+        val marked = markedElements(testFile)
+
+        assertFalse("assertions are not independently runnable", marked.any { it.text == "is" })
+    }
+
+    /** Without the `phel\test` require there is nothing for `phel test` to find, so no icon. */
+    fun testDoesNotMarkTestsInAFileThatDoesNotRequirePhelTest() {
+        val marked = markedElements("(ns app.html)\n\n(deftest basic-tags\n  (is true))\n")
+
+        assertEquals(listOf("ns"), marked.map { it.text })
+    }
+
+    fun testNamesTheTestInItsTooltip() {
+        val file = myFixture.configureByText("html.phel", testFile)
+        val info = PsiTreeUtil.collectElements(file) { it.firstChild == null }
+            .filter { it.text == "deftest" }
+            .mapNotNull { contributor.getInfo(it) }
+
+        assertEquals(listOf("Run basic-tags", "Run empty-tags"), info.map { it.tooltipProvider?.apply(null) })
+    }
+
+    fun testNamesTheFileInTheNamespaceTooltip() {
+        val file = myFixture.configureByText("html.phel", testFile)
+        val info = PsiTreeUtil.collectElements(file) { it.firstChild == null }
+            .single { it.text == "ns" }
+            .let { contributor.getInfo(it) }
+
+        assertEquals("Run html.phel", info?.tooltipProvider?.apply(null))
+    }
 }

--- a/src/test/kotlin/org/phellang/integration/run/PhelTestConfigurationProducerTest.kt
+++ b/src/test/kotlin/org/phellang/integration/run/PhelTestConfigurationProducerTest.kt
@@ -1,0 +1,140 @@
+package org.phellang.integration.run
+
+import com.intellij.execution.actions.ConfigurationContext
+import com.intellij.execution.actions.LazyRunConfigurationProducer
+import com.intellij.execution.actions.RunConfigurationProducer
+import com.intellij.execution.configurations.RunConfiguration
+import org.phellang.integration.PhelIntegrationTestCase
+import org.phellang.run.PhelRunConfiguration
+import org.phellang.run.PhelRunConfigurationProducer
+import org.phellang.run.PhelRunConfigurationType
+import org.phellang.run.PhelTestConfiguration
+import org.phellang.run.PhelTestConfigurationProducer
+
+/**
+ * Which configuration a context yields, asserted end to end rather than reasoned about: the
+ * precedence contract between competing producers is platform behavior, so the only trustworthy
+ * answer is the one the platform actually gives.
+ */
+class PhelTestConfigurationProducerTest : PhelIntegrationTestCase() {
+
+    private val testFile = """
+        (ns test.html
+          (:require phel.test :refer [deftest is]))
+
+        (deftest basic-tags
+          (is (= "<div></div>" (html [:div]))))
+
+        (deftest empty-tags
+          (is (= "<h1></h1>" (html [:h1]))))
+    """.trimIndent()
+
+    private fun configurationAt(text: String, marker: String): RunConfiguration? {
+        val file = myFixture.configureByText("html.phel", text)
+        val offset = text.indexOf(marker)
+        assertTrue("marker '$marker' not found in fixture", offset >= 0)
+
+        val element = file.findElementAt(offset) ?: return null
+        return ConfigurationContext(element).configurationsFromContext?.firstOrNull()?.configuration
+    }
+
+    private fun testConfigurationAt(text: String, marker: String): PhelTestConfiguration {
+        val configuration = configurationAt(text, marker)
+        assertInstanceOf(configuration, PhelTestConfiguration::class.java)
+        return configuration as PhelTestConfiguration
+    }
+
+    fun testATestFileProducesATestConfiguration() {
+        val configuration = testConfigurationAt(testFile, "(ns")
+
+        assertTrue(configuration.testPaths.endsWith("html.phel"))
+    }
+
+    /** Outside any `deftest`, the whole file runs, so no filter is set. */
+    fun testTheNamespaceFormRunsTheWholeFile() {
+        val configuration = testConfigurationAt(testFile, "(ns")
+
+        assertEquals("", configuration.testName)
+        assertEquals("Tests: html.phel", configuration.name)
+    }
+
+    fun testAContextInsideATestRunsOnlyThatTest() {
+        val configuration = testConfigurationAt(testFile, "basic-tags")
+
+        assertEquals("basic-tags", configuration.testName)
+        assertEquals("basic-tags", configuration.name)
+    }
+
+    fun testEachTestGetsItsOwnScope() {
+        assertEquals("empty-tags", testConfigurationAt(testFile, "empty-tags").testName)
+    }
+
+    fun testTheDeepestPartOfATestStillRunsThatTest() {
+        val configuration = testConfigurationAt(testFile, "\"<div></div>\"")
+
+        assertEquals("basic-tags", configuration.testName)
+    }
+
+    fun testTheWorkingDirectoryIsTheProjectRoot() {
+        val configuration = testConfigurationAt(testFile, "(ns")
+
+        assertEquals(project.basePath.orEmpty(), configuration.workingDirectory)
+    }
+
+    /** The whole point: an ordinary file must keep going to `phel run` and its plain console. */
+    fun testANonTestFileStillProducesARunConfiguration() {
+        val configuration = configurationAt("(ns app.html)\n\n(defn greet [] \"hi\")\n", "(ns")
+
+        assertInstanceOf(configuration, PhelRunConfiguration::class.java)
+    }
+
+    fun testAFileThatOnlyLooksLikeATestStillProducesARunConfiguration() {
+        val configuration = configurationAt("(ns app.html)\n\n(deftest basic-tags\n  (is true))\n", "basic-tags")
+
+        assertInstanceOf(configuration, PhelRunConfiguration::class.java)
+    }
+
+    /**
+     * The file, REPL and test configurations share one `ConfigurationType`, so the platform offers
+     * every saved configuration to every producer registered for it. With a narrower type parameter
+     * the generated bridge method cast a `PhelRunConfiguration` to `PhelTestConfiguration`, and the
+     * `ClassCastException` aborted the action update — which emptied the gutter popup for *every*
+     * Phel file, test or not, reporting "Nothing here".
+     *
+     * Nothing reproduces it without a saved sibling configuration for the platform to walk, which is
+     * exactly why the rest of this class missed it.
+     */
+    @Suppress("UNCHECKED_CAST")
+    private fun erased(producer: LazyRunConfigurationProducer<*>) =
+        producer as RunConfigurationProducer<RunConfiguration>
+
+    private fun contextAt(marker: String): ConfigurationContext {
+        val file = myFixture.configureByText("html.phel", testFile)
+        return ConfigurationContext(file.findElementAt(testFile.indexOf(marker))!!)
+    }
+
+    private fun configurationOfKind(index: Int, name: String) =
+        PhelRunConfigurationType().configurationFactories[index]
+            .createTemplateConfiguration(project)
+            .also { it.name = name }
+
+    fun testToleratesBeingOfferedAConfigurationOfASiblingKind() {
+        val context = contextAt("basic-tags")
+
+        for (index in 0..1) {
+            val foreign = configurationOfKind(index, "sibling")
+
+            assertFalse(
+                "the test producer must decline ${foreign.javaClass.simpleName}, not crash on it",
+                erased(PhelTestConfigurationProducer()).isConfigurationFromContext(foreign, context),
+            )
+        }
+    }
+
+    fun testTheFileProducerAlsoToleratesASiblingKind() {
+        val context = contextAt("basic-tags")
+        val foreign = configurationOfKind(2, "sibling test")
+
+        assertFalse(erased(PhelRunConfigurationProducer()).isConfigurationFromContext(foreign, context))
+    }
+}

--- a/src/test/kotlin/org/phellang/integration/run/PhelTestDetectionTest.kt
+++ b/src/test/kotlin/org/phellang/integration/run/PhelTestDetectionTest.kt
@@ -1,0 +1,129 @@
+package org.phellang.integration.run
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.integration.PhelIntegrationTestCase
+import org.phellang.language.psi.files.PhelFile
+import org.phellang.run.test.PhelTestDetection
+
+/**
+ * Detection is what decides whether a file gets a green bar at all, so the cases that matter are the
+ * spellings real projects use: `phel.test` with dots as often as `phel\test` with backslashes.
+ */
+class PhelTestDetectionTest : PhelIntegrationTestCase() {
+
+    private fun configure(text: String): PhelFile = myFixture.configureByText("html.phel", text) as PhelFile
+
+    private fun leaves(file: PhelFile): List<PsiElement> =
+        PsiTreeUtil.collectElements(file) { it.firstChild == null }.toList()
+
+    private fun headedTests(file: PhelFile): List<String> = leaves(file).mapNotNull(PhelTestDetection::deftestHeadedBy)
+
+    fun testRecognizesATestFileWrittenWithDots() {
+        val file = configure("(ns test.html\n  (:require phel.test :refer [deftest is]))\n")
+
+        assertTrue(PhelTestDetection.isTestFile(file))
+    }
+
+    fun testRecognizesATestFileWrittenWithBackslashes() {
+        val file = configure("(ns test\\html\n  (:require phel\\test :refer [deftest is]))\n")
+
+        assertTrue(PhelTestDetection.isTestFile(file))
+    }
+
+    fun testRecognizesATestFileThatAliasesTheRequire() {
+        val file = configure("(ns test.html\n  (:require phel\\test :as t))\n")
+
+        assertTrue(PhelTestDetection.isTestFile(file))
+    }
+
+    fun testDoesNotRecognizeAFileThatNeverRequiresPhelTest() {
+        val file = configure("(ns app.html\n  (:require phel\\str :refer [split]))\n(defn greet [] \"hi\")\n")
+
+        assertFalse(PhelTestDetection.isTestFile(file))
+    }
+
+    fun testDoesNotRecognizeAFileWithoutANamespace() {
+        assertFalse(PhelTestDetection.isTestFile(configure("(defn greet [] \"hi\")\n")))
+    }
+
+    fun testFindsEveryTopLevelTest() {
+        val file = configure(
+            """
+            (ns test.html
+              (:require phel.test :refer [deftest is]))
+
+            (deftest basic-tags
+              (is (= "<div></div>" (html [:div]))))
+
+            (deftest empty-tags
+              (is (= "<h1></h1>" (html [:h1]))))
+            """.trimIndent()
+        )
+
+        assertEquals(listOf("basic-tags", "empty-tags"), headedTests(file))
+    }
+
+    fun testFindsATestHeadedByAnAliasedDeftest() {
+        val file = configure(
+            "(ns test.html\n  (:require phel\\test :as t))\n\n(t/deftest basic-tags\n  (t/is true))\n"
+        )
+
+        assertEquals(listOf("basic-tags"), headedTests(file))
+    }
+
+    /** `#_` leaves the discarded form in the tree, so a naive `forms[1]` would report `old`. */
+    fun testTakesTheNameAfterADiscardedForm() {
+        val file = configure(
+            "(ns test.html\n  (:require phel.test :refer [deftest is]))\n\n(deftest #_old new-name\n  (is true))\n"
+        )
+
+        assertEquals(listOf("new-name"), headedTests(file))
+    }
+
+    fun testDoesNotMarkTestsInAFileThatIsNotATestFile() {
+        val file = configure("(ns app.html)\n\n(deftest basic-tags\n  (is true))\n")
+
+        assertEmpty(headedTests(file))
+    }
+
+    fun testDoesNotMarkANestedDeftest() {
+        val file = configure(
+            "(ns test.html\n  (:require phel.test :refer [deftest is]))\n\n(comment (deftest inner (is true)))\n"
+        )
+
+        assertEmpty(headedTests(file))
+    }
+
+    fun testDoesNotMarkADeftestWithNoName() {
+        val file = configure("(ns test.html\n  (:require phel.test :refer [deftest is]))\n\n(deftest)\n")
+
+        assertEmpty(headedTests(file))
+    }
+
+    fun testFindsTheTestSurroundingAnInnerElement() {
+        val file = configure(
+            """
+            (ns test.html
+              (:require phel.test :refer [deftest is]))
+
+            (deftest basic-tags
+              (is (= "<div></div>" (html [:div]))))
+            """.trimIndent()
+        )
+
+        val inner = leaves(file).single { it.text == "html" && it.textOffset > 60 }
+
+        assertEquals("basic-tags", PhelTestDetection.enclosingDeftestName(inner))
+    }
+
+    fun testHasNoSurroundingTestOutsideOne() {
+        val file = configure(
+            "(ns test.html\n  (:require phel.test :refer [deftest is]))\n\n(defn helper [] 1)\n"
+        )
+
+        val inner = leaves(file).single { it.text == "helper" }
+
+        assertNull(PhelTestDetection.enclosingDeftestName(inner))
+    }
+}

--- a/src/test/kotlin/org/phellang/unit/run/PhelJUnitXmlParserTest.kt
+++ b/src/test/kotlin/org/phellang/unit/run/PhelJUnitXmlParserTest.kt
@@ -150,4 +150,151 @@ class PhelJUnitXmlParserTest {
         val outcome = report.suites[0].cases[0].outcome as PhelTestCase.Outcome.Failed
         assertEquals("bare detail", outcome.details)
     }
+
+    // ---- one node per test, not per assertion ----
+    //
+    // `phel` writes a <testcase> per `is` form, each named after the enclosing test, so these are
+    // the shapes a real report has. Verbatim from `phel test --reporter=junit-xml` on a `deftest`
+    // with four passing assertions and one with three failing ones.
+
+    @Test
+    fun `folds the repeated cases of one test into a single node`() {
+        val report = parse(
+            """
+            <testsuites tests="4">
+              <testsuite name="tests.html" tests="4">
+                <testcase name="void-tags" classname="" file="/p/tests/html.phel" line="22"></testcase>
+                <testcase name="void-tags" classname="" file="/p/tests/html.phel" line="22"></testcase>
+                <testcase name="void-tags" classname="" file="/p/tests/html.phel" line="22"></testcase>
+                <testcase name="void-tags" classname="" file="/p/tests/html.phel" line="22"></testcase>
+              </testsuite>
+            </testsuites>
+            """.trimIndent()
+        )
+
+        assertEquals(listOf("void-tags"), report.suites[0].cases.map { it.name })
+        assertEquals(PhelTestCase.Outcome.Passed, report.suites[0].cases[0].outcome)
+    }
+
+    @Test
+    fun `a folded test keeps every failing assertion in its details`() {
+        val report = parse(
+            """
+            <testsuite name="tests.html" tests="3">
+              <testcase name="void-tags-ignore-content"><failure type="AssertionFailed">(= "&lt;br /&gt;" a)</failure></testcase>
+              <testcase name="void-tags-ignore-content"><failure type="AssertionFailed">(= "&lt;img /&gt;" b)</failure></testcase>
+              <testcase name="void-tags-ignore-content"><failure type="AssertionFailed">(= "&lt;input /&gt;" c)</failure></testcase>
+            </testsuite>
+            """.trimIndent()
+        )
+
+        val outcome = report.suites[0].cases.single().outcome as PhelTestCase.Outcome.Failed
+        assertEquals("3 of 3 assertions failed", outcome.message)
+        assertEquals("""(= "<br />" a)""" + "\n\n" + """(= "<img />" b)""" + "\n\n" + """(= "<input />" c)""", outcome.details)
+    }
+
+    @Test
+    fun `one bad assertion among many fails the whole test and keeps its own message`() {
+        val report = parse(
+            """
+            <testsuite name="s">
+              <testcase name="mixed"/>
+              <testcase name="mixed"><failure message="boom">detail</failure></testcase>
+              <testcase name="mixed"/>
+            </testsuite>
+            """.trimIndent()
+        )
+
+        val outcome = report.suites[0].cases.single().outcome as PhelTestCase.Outcome.Failed
+        assertEquals("boom", outcome.message)
+        assertEquals("detail", outcome.details)
+    }
+
+    /** A crash is not a comparison that came out false, so it outranks a failed assertion. */
+    @Test
+    fun `an error outranks a failure in the same test`() {
+        val report = parse(
+            """
+            <testsuite name="s">
+              <testcase name="mixed"><failure message="assert">f</failure></testcase>
+              <testcase name="mixed"><error message="PHEL001">trace</error></testcase>
+            </testsuite>
+            """.trimIndent()
+        )
+
+        val outcome = report.suites[0].cases.single().outcome as PhelTestCase.Outcome.Errored
+        assertEquals("PHEL001", outcome.message)
+    }
+
+    @Test
+    fun `a test counts as skipped only when nothing in it ran`() {
+        val allSkipped = parse(
+            """
+            <testsuite name="s">
+              <testcase name="wip"><skipped message="later"/></testcase>
+              <testcase name="wip"><skipped message="later"/></testcase>
+            </testsuite>
+            """.trimIndent()
+        )
+        assertEquals(
+            PhelTestCase.Outcome.Skipped("later"),
+            allSkipped.suites[0].cases.single().outcome,
+        )
+
+        val partlySkipped = parse(
+            """
+            <testsuite name="s">
+              <testcase name="wip"><skipped message="later"/></testcase>
+              <testcase name="wip"/>
+            </testsuite>
+            """.trimIndent()
+        )
+        assertEquals(PhelTestCase.Outcome.Passed, partlySkipped.suites[0].cases.single().outcome)
+    }
+
+    @Test
+    fun `a folded test totals the time of its assertions`() {
+        val report = parse(
+            """
+            <testsuite name="s">
+              <testcase name="t" time="0.01"/>
+              <testcase name="t" time="0.02"/>
+            </testsuite>
+            """.trimIndent()
+        )
+
+        assertEquals(30L, report.suites[0].cases.single().durationMillis)
+    }
+
+    @Test
+    fun `distinct tests in one suite stay distinct`() {
+        val report = parse(
+            """
+            <testsuite name="s">
+              <testcase name="second"/>
+              <testcase name="second"/>
+              <testcase name="first"/>
+            </testsuite>
+            """.trimIndent()
+        )
+
+        // Order follows the report, so the tree still follows the file.
+        assertEquals(listOf("second", "first"), report.suites[0].cases.map { it.name })
+    }
+
+    /** Same name, different suites: two namespaces may each define `basic-tags`. */
+    @Test
+    fun `tests with the same name in different suites are not folded together`() {
+        val report = parse(
+            """
+            <testsuites>
+              <testsuite name="a"><testcase name="shared"/></testsuite>
+              <testsuite name="b"><testcase name="shared"/></testsuite>
+            </testsuites>
+            """.trimIndent()
+        )
+
+        assertEquals(listOf("shared"), report.suites[0].cases.map { it.name })
+        assertEquals(listOf("shared"), report.suites[1].cases.map { it.name })
+    }
 }

--- a/src/test/kotlin/org/phellang/unit/run/PhelTestServiceMessagesTest.kt
+++ b/src/test/kotlin/org/phellang/unit/run/PhelTestServiceMessagesTest.kt
@@ -162,4 +162,45 @@ class PhelTestServiceMessagesTest {
             messages.count { it.startsWith("##teamcity[testFinished") },
         )
     }
+
+    // ---- real reporter output ----
+    //
+    // Both documents below are verbatim `phel test --reporter=junit-xml` output, captured from a
+    // real project. They are the end-to-end check that the tree gets one node per `deftest`: the
+    // reporter emits one entry per `is` form, and every one of them carries the test's name.
+
+    @Test
+    fun `four passing assertions become one passing node`() {
+        val messages = renderXml(
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <testsuites tests="4" failures="0" errors="0" time="0.0"><testsuite name="tests.html" tests="4" failures="0" errors="0" time="0.0"><testcase name="void-tags" classname="" file="/p/tests/html.phel" line="22"></testcase><testcase name="void-tags" classname="" file="/p/tests/html.phel" line="22"></testcase><testcase name="void-tags" classname="" file="/p/tests/html.phel" line="22"></testcase><testcase name="void-tags" classname="" file="/p/tests/html.phel" line="22"></testcase></testsuite></testsuites>
+            """.trimIndent()
+        )
+
+        assertEquals(1, messages.count { it.startsWith("##teamcity[testStarted") })
+        assertEquals(1, messages.count { it.startsWith("##teamcity[testFinished") })
+        assertTrue(messages.none { it.startsWith("##teamcity[testFailed") }, messages.toString())
+        assertTrue(messages.any { it.contains("name='void-tags'") }, messages.toString())
+    }
+
+    @Test
+    fun `three failing assertions become one failing node listing every form`() {
+        val messages = renderXml(
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <testsuites tests="3" failures="3" errors="0" time="0.0"><testsuite name="tests.html" tests="3" failures="3" errors="0" time="0.0"><testcase name="void-tags-ignore-content" classname="" file="/p/tests/html.phel" line="28"><failure message="" type="AssertionFailed">(= &quot;&lt;br /&gt;&quot; (html [:br &quot;ignored&quot;]))</failure></testcase><testcase name="void-tags-ignore-content" classname="" file="/p/tests/html.phel" line="28"><failure message="" type="AssertionFailed">(= &quot;&lt;img src=\&quot;x\&quot; /&gt;&quot; (html [:img {:src &quot;x&quot;} &quot;alt&quot;]))</failure></testcase><testcase name="void-tags-ignore-content" classname="" file="/p/tests/html.phel" line="28"><failure message="" type="AssertionFailed">(= &quot;&lt;input type=\&quot;text\&quot; /&gt;&quot; (html [:input {:type &quot;text&quot;} &quot;x&quot;]))</failure></testcase></testsuite></testsuites>
+            """.trimIndent()
+        )
+
+        assertEquals(1, messages.count { it.startsWith("##teamcity[testStarted") })
+        assertEquals(1, messages.count { it.startsWith("##teamcity[testFinished") })
+
+        val failure = messages.single { it.startsWith("##teamcity[testFailed") }
+        assertTrue(failure.contains("message='3 of 3 assertions failed'"), failure)
+        // Every failing form survives into the detail pane, `[` and `]` service-message escaped.
+        for (tag in listOf(":br", ":img", ":input")) {
+            assertTrue(failure.contains(tag), "expected $tag in: $failure")
+        }
+    }
 }


### PR DESCRIPTION
Completes the run integration from #263: the test tree shipped in #279, but nothing could reach it from a test file. Opening one and using the gutter icon ran `phel run` into a plain console.

## Scope

- A test file's gutter icon, context menu and Run Anything produce a `phel test` configuration scoped to that file, so results land in the test tree.
- Each `deftest` gets its own icon that runs only that test.
- The tree shows one node per `deftest` rather than one per assertion.
- Ordinary `.phel` files are unchanged: still `phel run`, still a plain console.

## Key decisions

**Detection is the `phel\test` require, not `phel-config.php`.** Reading `withTestDirs([...])` was considered and rejected: the config is PHP evaluated by PHP, `testDirs` already defaults to `['tests']` so the call's presence carries no information, and `phel-config-local.php` overrides it. It also errs both ways as a marker rule, flagging fixtures inside `tests/` that define nothing and missing test files kept outside it. Both the `phel.test` and `phel\test` spellings are accepted.

**A single test is selected with an anchored `/^name$/` pattern.** A bare `--filter` is an unanchored substring, so `void-tags` would otherwise also run `void-tags-ignore-content`.

**No `--ns` companion.** `phel` derives the namespace it matches from a file's location rather than from its `ns` form, so a pin built from the declared name selects nothing at all and fails silently.

**Both producers are parameterised on `PhelCliRunConfiguration`.** The file, REPL and test configurations share one `ConfigurationType` and differ only by factory, so the platform offers every producer configurations of the sibling kinds.

**Assertions are folded into their test.** `--reporter=junit-xml` emits a `<testcase>` per `is` form, each named after the enclosing test. Entries sharing a name within a suite become one node: the worst outcome wins, an error outranks a failure, and a test counts as skipped only when nothing in it ran.

## Verification

- `./gradlew build` green, including `ArchitectureBoundaryTest` and `koverVerify`.
- Command lines and the report parser are asserted without a `phel` binary, matching the existing tests in this package. The folding tests use XML taken verbatim from real `phel` output.
- Driven against a real Phel project: absolute paths accepted; bare `--filter=void-tags` selects 7 assertions across two tests while the anchored form selects 4, exactly one test; the JUnit report contains only the filtered test.
- Verified in the IDE sandbox: the bar goes green, per-`deftest` icons run one test, non-test files still open a plain console.

## Findings and remediation

Three defects were found by running the real binary and the sandbox, all of which the test suite passed straight through at the time:

1. The `--ns` pin selected zero tests. Removed, pinned by `testTestNeverPinsTheNamespace`.
2. A `ClassCastException` between sibling configuration classes aborted the action update and emptied the gutter popup on **every** Phel file, so the feature was dead in a real IDE. Fixed, pinned by tests that call the producers through the erased `RunConfigurationProducer` interface exactly as the platform does. Both tests were falsified against the unfixed code.
3. The tree showed one node per assertion. Fixed in the parser; the `#279` changelog entry is amended in place rather than logged as a fix, since that behavior was never released.

## Remaining risk and follow-ups

- `suggestedName()` now renders path basenames, so two test files sharing a basename in different directories look alike in the run widget. Accepted: the producer stores absolute paths, and the previous format would have put a full filesystem path in the widget.
- Producer tests must go through the erased interface. Every typed test missed the `ClassCastException` above.

No grammar, PSI, registry or generated-source impact, so no regeneration. Version compatibility range unchanged.

Related to #263