### PR TITLE
fix: audit findings from #281 — indentation, drifted rule sets, index races, dead code

### DIFF
--- a/.agnostic-ai/AGNOSTIC_AI.md
+++ b/.agnostic-ai/AGNOSTIC_AI.md
@@ -39,7 +39,7 @@ Plugin sources live under `src/main/kotlin/org/phellang/`:
 ## Conventions
 
 - Every plugin feature must be registered in `src/main/resources/META-INF/plugin.xml`.
-- In completion logic use `PhelTypes.SYMBOL` (not `SYM`); use `PlainPrefixMatcher` for `namespace/function` matching.
+- In completion logic match on `PhelTypes.SYM` (the lexer token at the caret), not `PhelTypes.SYMBOL` (the parser element type); use `PlainPrefixMatcher` for `namespace/function` matching.
 - Registry: `NamespaceConfig.kt` is the single source of truth — add one entry and run `./gradlew updatePhelRegistry`; generated files, the `Namespace` enum, and registry wiring are produced automatically. Hand-edit only the curated `ALIASES` map.
 - New unit tests go in `unit/`, integration tests in `integration/`. Test Phel features against the official docs.
 

--- a/.agnostic-ai/rules/plugin-architecture.md
+++ b/.agnostic-ai/rules/plugin-architecture.md
@@ -84,7 +84,8 @@ the test deliberately, not by working around it.
   generator's output package is pinned in `tools/generator/KotlinCodeGenerator.kt` and
   `RegistryWiringGenerator.kt` — relocating the registry means updating those too, or the next
   regeneration silently recreates the old layout.
-- Completion logic: use `PhelTypes.SYMBOL` (not `SYM`); use `PlainPrefixMatcher` for
-  `namespace/function` matching.
+- Completion logic: the `psiElement(...)` pattern matches the **leaf at the caret**, which is the
+  lexer token `PhelTypes.SYM` — not `PhelTypes.SYMBOL`, the parser element type wrapping it. Use
+  `PlainPrefixMatcher` for `namespace/function` matching.
 - Form-comment detection is hybrid PSI + text-based.
 - Follow IntelliJ Platform SDK conventions.

--- a/src/main/kotlin/org/phellang/annotator/highlighters/rules/PhelInteropRules.kt
+++ b/src/main/kotlin/org/phellang/annotator/highlighters/rules/PhelInteropRules.kt
@@ -10,10 +10,8 @@ import org.phellang.language.psi.PhelInteropShorthands
  * Kept ahead of [InteropShorthandRule] so the common case never triggers the `(:use ...)` scan.
  */
 object PhpQualifiedRule : PhelHighlightRule {
-    private const val PHP_PREFIX = "php/"
-
     override fun decide(context: PhelSymbolContext): PhelHighlightDecision? {
-        if (!context.text.startsWith(PHP_PREFIX)) return null
+        if (!PhelInteropShorthands.isPhpQualified(context.text)) return null
 
         return PhelHighlightDecision.Paint(PHP_INTEROP)
     }

--- a/src/main/kotlin/org/phellang/completion/PhelCompletionCharFilter.kt
+++ b/src/main/kotlin/org/phellang/completion/PhelCompletionCharFilter.kt
@@ -3,6 +3,7 @@ package org.phellang.completion
 import com.intellij.codeInsight.lookup.CharFilter
 import com.intellij.codeInsight.lookup.Lookup
 import org.phellang.language.infrastructure.PhelFileType
+import org.phellang.language.psi.PhelSymbolChars
 
 class PhelCompletionCharFilter : CharFilter() {
 
@@ -13,28 +14,13 @@ class PhelCompletionCharFilter : CharFilter() {
             return null
         }
 
-        if (isPhelIdentifierChar(c)) {
+        // [PhelSymbolChars] rather than a list of its own: that list allowed `%` but not `.` or `\`,
+        // so the lookup closed on the `.` of `.method` and the `\` of `\DateTime` — both of which the
+        // completion offers in the first place.
+        if (PhelSymbolChars.isSymbolPart(c)) {
             return Result.ADD_TO_PREFIX
         }
 
         return null
-    }
-
-    fun isPhelIdentifierChar(c: Char): Boolean {
-        return c.isLetterOrDigit() ||
-                c == '-' ||
-                c == '_' ||
-                c == '?' ||
-                c == '!' ||
-                c == '*' ||
-                c == '+' ||
-                c == '<' ||
-                c == '>' ||
-                c == '=' ||
-                c == '&' ||
-                c == '%' ||
-                c == '$' ||
-                c == '/' ||
-                c == ':'
     }
 }

--- a/src/main/kotlin/org/phellang/documentation/resolvers/PhelApiDocumentation.kt
+++ b/src/main/kotlin/org/phellang/documentation/resolvers/PhelApiDocumentation.kt
@@ -1,5 +1,6 @@
 package org.phellang.documentation.resolvers
 
+import org.phellang.language.psi.PhelInteropShorthands
 import org.phellang.registry.PhelFunctionRegistry
 import java.util.concurrent.ConcurrentHashMap
 
@@ -18,7 +19,7 @@ object PhelApiDocumentation {
                 append(function.toHtmlDocumentation())
                 // Native PHP functions document at php.net (their prose is not in Phel's api.json).
                 // Only php/ entries link out; the dormant links on Phel stdlib entries stay unrendered.
-                if (function.name.startsWith("php/")) {
+                if (PhelInteropShorthands.isPhpQualified(function.name)) {
                     function.documentation.links.docs.takeIf(String::isNotBlank)?.let {
                         append("<a href=\"").append(it).append("\">php.net documentation</a><br />")
                     }

--- a/src/main/kotlin/org/phellang/editor/enter/PhelEnterHandlerDelegate.kt
+++ b/src/main/kotlin/org/phellang/editor/enter/PhelEnterHandlerDelegate.kt
@@ -31,7 +31,7 @@ class PhelEnterHandlerDelegate : EnterHandlerDelegate {
         val lineInfo = documentProcessor.extractLineInformation(document, caretOffset)
         
         val targetIndentation = indentationCalculator.targetIndentation(
-            document, lineInfo.currentLineNumber, lineInfo.textBeforeCaret
+            file, document, lineInfo.currentLineNumber, lineInfo.textBeforeCaret
         )
 
         originalHandler?.execute(editor, editor.caretModel.currentCaret, dataContext)

--- a/src/main/kotlin/org/phellang/editor/enter/PhelEnterHandlerIndentationCalculator.kt
+++ b/src/main/kotlin/org/phellang/editor/enter/PhelEnterHandlerIndentationCalculator.kt
@@ -1,6 +1,8 @@
 package org.phellang.editor.enter
 
+import com.intellij.application.options.CodeStyle
 import com.intellij.openapi.editor.Document
+import com.intellij.psi.PsiFile
 import org.phellang.editor.indentation.PhelIndentationCalculator
 
 class PhelEnterHandlerIndentationCalculator {
@@ -8,25 +10,30 @@ class PhelEnterHandlerIndentationCalculator {
     private val indentationCalculator = PhelIndentationCalculator()
 
     /**
-     * The indentation the new line should end up with: one level per still-open parenthesis.
+     * The indentation the new line should end up with: one level per still-open bracket.
      *
      * Absolute, not relative. This used to return only the *extra* indentation to add on top of what
      * the platform's enter handler had already copied from the previous line, clamped at zero — so it
      * could indent further but never less. Closing a form therefore left the new line at the old
      * depth: enter after `(print "hello"))` gave two spaces where the form was over and the answer
      * was none, and after `(print 1)))` gave four.
+     *
+     * The width comes from [file]'s Code Style options rather than a constant. It was hard-coded to
+     * two spaces, so the Code Style page could show an indent size the formatter honoured and Enter
+     * ignored, and switching the page to tabs reformatted with tabs but typed spaces.
      */
-    fun targetIndentation(document: Document, currentLineNumber: Int, textBeforeCaret: String): String {
+    fun targetIndentation(file: PsiFile, document: Document, currentLineNumber: Int, textBeforeCaret: String): String {
         val level = indentationCalculator.calculateIndentationLevel(document, currentLineNumber, textBeforeCaret)
+        val options = CodeStyle.getIndentOptions(file)
 
-        return " ".repeat(level * SPACES_PER_LEVEL)
+        if (options.USE_TAB_CHARACTER) {
+            return "\t".repeat(level)
+        }
+
+        return " ".repeat(level * options.INDENT_SIZE)
     }
 
     fun getCurrentIndentationSpaces(currentLineText: String): Int {
         return currentLineText.takeWhile { it.isWhitespace() }.length
-    }
-
-    private companion object {
-        const val SPACES_PER_LEVEL = 2
     }
 }

--- a/src/main/kotlin/org/phellang/editor/format/blocks/PhelBlock.kt
+++ b/src/main/kotlin/org/phellang/editor/format/blocks/PhelBlock.kt
@@ -98,14 +98,25 @@ class PhelBlock(
         elementType == TokenType.WHITE_SPACE || textRange.isEmpty
 
     private companion object {
-        /** The bracketed containers. Matched on element type: `getSpacing` runs per sibling pair. */
-        val CONTAINERS = setOf(PhelTypes.LIST, PhelTypes.VEC, PhelTypes.MAP, PhelTypes.SET)
+        /**
+         * The bracketed containers. Matched on element type: `getSpacing` runs per sibling pair.
+         *
+         * The same seven `PhelPareditContainers.isContainer` recognises. `HASH_FN` and the two reader
+         * conditionals were missing, so Reformat left the body of a `#(...)` or `#?(...)` flush left
+         * while the Enter handler indented it — the two disagreeing about the same line, which is
+         * exactly what the class doc above says must not happen.
+         */
+        val CONTAINERS = setOf(
+            PhelTypes.LIST, PhelTypes.VEC, PhelTypes.MAP, PhelTypes.SET,
+            PhelTypes.HASH_FN, PhelTypes.READER_CONDITIONAL, PhelTypes.READER_CONDITIONAL_SPLICE,
+        )
 
         val BRACKETS = setOf(
             PhelTypes.PAREN1, PhelTypes.PAREN2,
             PhelTypes.BRACKET1, PhelTypes.BRACKET2,
             PhelTypes.BRACE1, PhelTypes.BRACE2,
             PhelTypes.HASH_BRACE, PhelTypes.HASH_PAREN,
+            PhelTypes.READER_COND, PhelTypes.READER_COND_SPLICE,
         )
     }
 }

--- a/src/main/kotlin/org/phellang/editor/indentation/PhelIndentationCalculator.kt
+++ b/src/main/kotlin/org/phellang/editor/indentation/PhelIndentationCalculator.kt
@@ -21,10 +21,10 @@ class PhelIndentationCalculator {
 
         for (lineNumber in 0 until upToLine) {
             val lineText = lineAnalyzer.getLineText(lineNumber)
-            nestingLevel += lineAnalyzer.getParenthesesBalance(lineText)
+            nestingLevel += lineAnalyzer.bracketBalance(lineText)
         }
 
-        nestingLevel += lineAnalyzer.getParenthesesBalance(textBeforeCaret)
+        nestingLevel += lineAnalyzer.bracketBalance(textBeforeCaret)
 
         return nestingLevel
     }

--- a/src/main/kotlin/org/phellang/editor/indentation/PhelLineAnalyzer.kt
+++ b/src/main/kotlin/org/phellang/editor/indentation/PhelLineAnalyzer.kt
@@ -13,20 +13,18 @@ class PhelLineAnalyzer(private val document: Document) {
         return document.text.substring(lineStart, lineEnd)
     }
 
-    fun countOpenParentheses(text: String): Int {
-        return countParentheses(text, '(')
-    }
-
-    fun countCloseParentheses(text: String): Int {
-        return countParentheses(text, ')')
-    }
-
-    fun getParenthesesBalance(text: String): Int {
-        return countOpenParentheses(text) - countCloseParentheses(text)
-    }
-
-    private fun countParentheses(text: String, targetChar: Char): Int {
-        var count = 0
+    /**
+     * How many levels [text] opens, minus how many it closes.
+     *
+     * Every bracket counts, not only parentheses. Counting `(` alone left the Enter handler blind to
+     * binding vectors and map literals, so `(let [x 1` put the next line at the `let`'s level rather
+     * than inside its bindings, and a top-level `[` or `{` indented nothing at all. It also disagreed
+     * with the formatter, which has always treated VEC, MAP and SET as indenting containers.
+     *
+     * `#(` and `#{` need no special case: each contains a counted opener and the `#` is inert.
+     */
+    fun bracketBalance(text: String): Int {
+        var balance = 0
         var inString = false
         var inComment = false
         var i = 0
@@ -35,39 +33,33 @@ class PhelLineAnalyzer(private val document: Document) {
             val char = text[i]
 
             when {
-                char == ';' && !inString -> {
-                    inComment = true
-                }
+                inComment -> Unit
 
-                char == '"' && !inComment -> {
-                    if (!inString) {
-                        inString = true
-                    } else {
-                        // Check if it's escaped
-                        val backslashCount = countPrecedingBackslashes(text, i)
-                        if (backslashCount % 2 == 0) {
-                            inString = false
-                        }
-                    }
-                }
+                // Outside a string `\(` is a character literal, not an opening paren: the lexer's
+                // CHARACTER rule ends in a catch-all `.`, so whatever follows the backslash is part
+                // of the literal. Inside a string the same backslash escapes the next character. Both
+                // cases consume the pair, which is also what keeps `"\""` from ending the string.
+                char == '\\' -> i++
 
-                char == targetChar && !inString && !inComment -> {
-                    count++
-                }
+                char == '"' -> inString = !inString
+
+                inString -> Unit
+
+                char == ';' -> inComment = true
+
+                char in OPENERS -> balance++
+
+                char in CLOSERS -> balance--
             }
+
             i++
         }
 
-        return count
+        return balance
     }
 
-    private fun countPrecedingBackslashes(text: String, position: Int): Int {
-        var count = 0
-        var i = position - 1
-        while (i >= 0 && text[i] == '\\') {
-            count++
-            i--
-        }
-        return count
+    private companion object {
+        val OPENERS = setOf('(', '[', '{')
+        val CLOSERS = setOf(')', ']', '}')
     }
 }

--- a/src/main/kotlin/org/phellang/editor/paredit/PhelPareditActionGroup.kt
+++ b/src/main/kotlin/org/phellang/editor/paredit/PhelPareditActionGroup.kt
@@ -1,0 +1,27 @@
+package org.phellang.editor.paredit
+
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.DefaultActionGroup
+import org.phellang.language.psi.files.PhelFile
+
+/**
+ * The Paredit submenu, shown only where it does anything.
+ *
+ * The group was declared in `plugin.xml` with no `<add-to-group>` at all, so nine registered actions
+ * were reachable only by their `Ctrl+Alt+Shift+P` chords or through Find Action. Adding it to the
+ * editor popup makes them discoverable.
+ *
+ * The visibility check is the group's own: [PhelPareditActionHandler] already disables each action
+ * outside a Phel file, but a `popup="true"` group renders its own entry regardless, so without this
+ * "Phel Paredit" would appear in the right-click menu of every file type in the IDE.
+ */
+class PhelPareditActionGroup : DefaultActionGroup() {
+
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
+
+    override fun update(e: AnActionEvent) {
+        e.presentation.isEnabledAndVisible = e.getData(CommonDataKeys.PSI_FILE) is PhelFile
+    }
+}

--- a/src/main/kotlin/org/phellang/editor/typing/pairing/PhelCharacterPairing.kt
+++ b/src/main/kotlin/org/phellang/editor/typing/pairing/PhelCharacterPairing.kt
@@ -55,15 +55,4 @@ object PhelCharacterPairing {
         return charAtOffset == closingChar
     }
 
-    fun getAllPairableCharacters(): Set<Char> {
-        return getOpeningCharacters() + getClosingCharacters()
-    }
-
-    private fun getOpeningCharacters(): Set<Char> {
-        return OPENING_TO_CLOSING.keys.toSet()
-    }
-
-    private fun getClosingCharacters(): Set<Char> {
-        return CLOSING_CHARS.toSet()
-    }
 }

--- a/src/main/kotlin/org/phellang/editor/typing/pairing/PhelCharacterPairing.kt
+++ b/src/main/kotlin/org/phellang/editor/typing/pairing/PhelCharacterPairing.kt
@@ -54,5 +54,4 @@ object PhelCharacterPairing {
         // Skip if the same closing character is already at this position
         return charAtOffset == closingChar
     }
-
 }

--- a/src/main/kotlin/org/phellang/indexing/PhelProjectSymbolIndex.kt
+++ b/src/main/kotlin/org/phellang/indexing/PhelProjectSymbolIndex.kt
@@ -129,11 +129,22 @@ class PhelProjectSymbolIndex(private val project: Project) : Disposable {
         }
     }
 
+    /**
+     * Drops a deleted file's entries.
+     *
+     * Under [refreshLock] for the same reason [refreshFileFromPsi] is, and against the same two
+     * threads: this used to mutate the three maps unsynchronised, so a delete racing a refresh of the
+     * same path could interleave into `symbolsByFile` losing the path while `symbolsByNamespace` and
+     * `symbolsByName` kept the symbols. Nothing would ever evict them after that, because eviction
+     * reads the entry that had just been removed.
+     */
     fun removeFile(file: VirtualFile) {
-        val oldSymbols = symbolsByFile.remove(file.path) ?: return
-        for (symbol in oldSymbols) {
-            removeFromMap(symbolsByNamespace, symbol.shortNamespace, file.path)
-            removeFromMap(symbolsByName, symbol.name, file.path)
+        synchronized(refreshLock) {
+            val oldSymbols = symbolsByFile.remove(file.path) ?: return
+            for (symbol in oldSymbols) {
+                removeFromMap(symbolsByNamespace, symbol.shortNamespace, file.path)
+                removeFromMap(symbolsByName, symbol.name, file.path)
+            }
         }
     }
 

--- a/src/main/kotlin/org/phellang/indexing/PhelPsiChangeListener.kt
+++ b/src/main/kotlin/org/phellang/indexing/PhelPsiChangeListener.kt
@@ -8,14 +8,26 @@ import com.intellij.psi.PsiManager
 import com.intellij.psi.PsiTreeChangeAdapter
 import com.intellij.psi.PsiTreeChangeEvent
 import org.phellang.language.psi.files.PhelFile
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
 
 class PhelPsiChangeListener(private val project: Project) : PsiTreeChangeAdapter() {
 
-    @Volatile
-    private var pendingRefresh: VirtualFile? = null
+    /**
+     * Every file edited since the last pass, not just the most recent one.
+     *
+     * This was a single slot. Editing file A and then file B before the scheduled pass ran overwrote
+     * A's entry, and the already-set `refreshScheduled` flag meant no second pass was queued — so A's
+     * symbols stayed stale until something else happened to touch it. A split editor, a multi-file
+     * quick fix or a rename across files hit this every time.
+     *
+     * VirtualFile rather than PsiFile: it stays valid across the reparse, and the PSI is resolved
+     * freshly when the pass runs.
+     */
+    private val pendingRefresh: MutableSet<VirtualFile> = ConcurrentHashMap.newKeySet()
 
-    @Volatile
-    private var refreshScheduled = false
+    /** Coalesces one typing burst into a single pass. */
+    private val refreshScheduled = AtomicBoolean(false)
 
     override fun childAdded(event: PsiTreeChangeEvent) {
         handleChange(event)
@@ -39,25 +51,39 @@ class PhelPsiChangeListener(private val project: Project) : PsiTreeChangeAdapter
         val psiFile = event.file as? PhelFile ?: return
         val virtualFile = psiFile.virtualFile ?: return
 
-        // Debounce: store VirtualFile (stable across reparse) and resolve PSI freshly later
-        pendingRefresh = virtualFile
+        pendingRefresh += virtualFile
 
-        if (!refreshScheduled) {
-            refreshScheduled = true
-            ApplicationManager.getApplication().invokeLater {
-                refreshScheduled = false
-                val fileToRefresh = pendingRefresh ?: return@invokeLater
-                pendingRefresh = null
+        if (refreshScheduled.compareAndSet(false, true)) {
+            ApplicationManager.getApplication().invokeLater { refreshPending() }
+        }
+    }
 
-                if (project.isDisposed || !fileToRefresh.isValid) return@invokeLater
+    /**
+     * The flag is cleared before the set is drained, so an edit arriving mid-pass schedules the next
+     * pass rather than being swallowed by this one. The cost is an occasional redundant refresh,
+     * which [PhelProjectSymbolIndex.refreshFileFromPsi] is idempotent under.
+     */
+    private fun refreshPending() {
+        refreshScheduled.set(false)
 
-                ApplicationManager.getApplication().runReadAction {
-                    if (project.isDisposed) return@runReadAction
-                    val freshPsi = PsiManager.getInstance(project).findFile(fileToRefresh) as? PhelFile
-                        ?: return@runReadAction
-                    PhelProjectSymbolIndex.getInstance(project).refreshFileFromPsi(freshPsi)
-                    DaemonCodeAnalyzer.getInstance(project).restart(freshPsi)
-                }
+        val files = pendingRefresh.toSet()
+        pendingRefresh -= files
+
+        if (project.isDisposed) return
+
+        ApplicationManager.getApplication().runReadAction {
+            if (project.isDisposed) return@runReadAction
+
+            val psiManager = PsiManager.getInstance(project)
+            val index = PhelProjectSymbolIndex.getInstance(project)
+            val daemon = DaemonCodeAnalyzer.getInstance(project)
+
+            for (file in files) {
+                if (!file.isValid) continue
+                val freshPsi = psiManager.findFile(file) as? PhelFile ?: continue
+
+                index.refreshFileFromPsi(freshPsi)
+                daemon.restart(freshPsi)
             }
         }
     }

--- a/src/main/kotlin/org/phellang/inlay/PhelParameterHintsProvider.kt
+++ b/src/main/kotlin/org/phellang/inlay/PhelParameterHintsProvider.kt
@@ -13,6 +13,7 @@ import org.phellang.registry.PhelArity
 import org.phellang.indexing.PhelArityResolver
 import org.phellang.registry.selectFor
 import org.phellang.language.psi.PhelForm
+import org.phellang.language.psi.PhelInteropShorthands
 import org.phellang.language.psi.PhelList
 import org.phellang.language.psi.PhelSpecialForms
 import org.phellang.language.psi.PhelSymbol
@@ -46,7 +47,7 @@ class PhelParameterHintsProvider : InlayHintsProvider {
         private fun takesPositionalParameters(headSymbol: PhelSymbol, headName: String): Boolean {
             if (headName in PhelSpecialForms.VARIADIC_HEADS) return false
             // Interop resolves to PHP, whose parameter names the registry does not carry.
-            if (INTEROP_PREFIXES.any { headName.startsWith(it) }) return false
+            if (PhelInteropShorthands.isInteropCall(headName)) return false
 
             // A local binding shadowing a known name is a different function entirely.
             return !PhelLocalBindingScope.resolvesToLocalBinding(headSymbol, headName)
@@ -76,11 +77,6 @@ class PhelParameterHintsProvider : InlayHintsProvider {
             } else {
                 arity.params.getOrNull(argIndex)
             }
-        }
-
-        private companion object {
-            /** `php/foo`, `.method` / `.-field`, and the `php-` helper family. */
-            val INTEROP_PREFIXES = listOf("php/", ".", "php-")
         }
     }
 }

--- a/src/main/kotlin/org/phellang/inspection/PhelArityCallSite.kt
+++ b/src/main/kotlin/org/phellang/inspection/PhelArityCallSite.kt
@@ -2,6 +2,7 @@ package org.phellang.inspection
 
 import com.intellij.psi.PsiElement
 import org.phellang.language.psi.PhelForm
+import org.phellang.language.psi.PhelInteropShorthands
 import org.phellang.language.psi.PhelList
 import org.phellang.language.psi.PhelSpecialForms
 import org.phellang.language.psi.PhelSymbol
@@ -20,7 +21,7 @@ internal object PhelArityCallSite {
     /** True when the arity check must not run for [list] with head [name]. */
     fun shouldSkip(list: PhelList, head: PhelSymbol, name: String, forms: List<PhelForm>): Boolean {
         if (name in PhelSpecialForms.VARIADIC_HEADS) return true
-        if (name.startsWith("php/") || name.startsWith(".") || name.startsWith("php-")) return true
+        if (PhelInteropShorthands.isInteropCall(name)) return true
         // The dummy identifier the platform injects at the caret mid-completion.
         if (name.contains("IntelliJIdeaRulezzz")) return true
 

--- a/src/main/kotlin/org/phellang/inspection/PhelArityCallSite.kt
+++ b/src/main/kotlin/org/phellang/inspection/PhelArityCallSite.kt
@@ -67,7 +67,7 @@ internal object PhelArityCallSite {
         val parentList = enclosingList(list) ?: return false
         val parentForms = parentList.forms
         val head = PhelPsiUtils.asSymbol(parentForms.firstOrNull())?.text ?: return false
-        if (head !in THREADING_HEADS) return false
+        if (head !in PhelSpecialForms.THREADING) return false
 
         val headRange = parentForms.firstOrNull()?.textRange ?: return false
         // [list] is an argument (not the head form) of the threading macro.
@@ -76,8 +76,4 @@ internal object PhelArityCallSite {
 
     private fun enclosingList(list: PhelList): PhelList? =
         generateSequence(list.parent) { it.parent }.filterIsInstance<PhelList>().firstOrNull()
-
-    private val THREADING_HEADS = setOf(
-        "->", "->>", "as->", "some->", "some->>", "cond->", "cond->>", "doto",
-    )
 }

--- a/src/main/kotlin/org/phellang/inspection/analysis/PhelUnresolvedSymbolFinder.kt
+++ b/src/main/kotlin/org/phellang/inspection/analysis/PhelUnresolvedSymbolFinder.kt
@@ -96,7 +96,7 @@ internal object PhelUnresolvedSymbolFinder {
      * method, and its arguments may be PHP constants — none of it is resolvable as a Phel name.
      */
     private fun isInsidePhpInterop(symbol: PhelSymbol): Boolean =
-        enclosingHeads(symbol).any { it.startsWith(PHP_PREFIX) }
+        enclosingHeads(symbol).any(PhelInteropShorthands::isPhpQualified)
 
     /** The `ns` form is import syntax: namespace names and `:refer` lists, not expressions. */
     private fun isInsideNsForm(symbol: PhelSymbol): Boolean =
@@ -163,8 +163,6 @@ internal object PhelUnresolvedSymbolFinder {
     /** The heads of every list enclosing [symbol], innermost first. */
     private fun enclosingHeads(symbol: PhelSymbol): Sequence<String> =
         PhelFormWalker.enclosingLists(symbol).mapNotNull { PhelFormWalker.headText(it) }
-
-    private const val PHP_PREFIX = "php/"
 
     /**
      * A reader macro is a *prefix* of the form it applies to, not an ancestor of it: the grammar

--- a/src/main/kotlin/org/phellang/language/psi/PhelInteropShorthands.kt
+++ b/src/main/kotlin/org/phellang/language/psi/PhelInteropShorthands.kt
@@ -27,6 +27,26 @@ object PhelInteropShorthands {
     /** `new` is the long-form constructor keyword (sister to `Class.`). */
     private const val NEW_KEYWORD = "new"
 
+    /** The qualifier on every explicit interop form: `php/new`, `php/->`, `php/aget`, `php/strlen`. */
+    const val PHP_QUALIFIER = "php/"
+
+    /** True when [text] is explicitly `php/`-qualified. */
+    fun isPhpQualified(text: String): Boolean = text.startsWith(PHP_QUALIFIER)
+
+    /**
+     * True when a call to [name] reaches PHP rather than Phel, by any spelling.
+     *
+     * `php/foo`, the `.method` / `.-field` accessors, and the `php-` helper family. Anything reading a
+     * call's arguments must skip these: PHP is where the callee lives, so the registry has neither its
+     * arity nor its parameter names.
+     *
+     * Four callers asked this with their own copy of the prefixes, two of them character for
+     * character — the same drift `PhelSpecialForms` exists to prevent, in the set next door.
+     */
+    fun isInteropCall(name: String): Boolean = INTEROP_CALL_PREFIXES.any { name.startsWith(it) }
+
+    private val INTEROP_CALL_PREFIXES = listOf(PHP_QUALIFIER, ".", "php-")
+
     fun isInteropClassName(text: String): Boolean {
         if (text.isEmpty()) return false
         if (text.startsWith("\\")) return true

--- a/src/main/kotlin/org/phellang/language/psi/PhelSpecialForms.kt
+++ b/src/main/kotlin/org/phellang/language/psi/PhelSpecialForms.kt
@@ -17,15 +17,34 @@ object PhelSpecialForms {
      * non-nil rather than on truthy. They were missing, so their bindings were invisible to every
      * consumer of this set at once: unresolved on go-to-definition, absent from local completion,
      * never reported as unused or shadowed, and unrecognised as locals by the parameter hints.
+     *
+     * `when-first` was the same omission a second time: `(when-first bindings & body)` binds the head
+     * of a collection with exactly `when-let`'s shape. Membership is decided by the registry
+     * signature, not by the name.
      */
     val LET_LIKE: Set<String> = setOf(
-        "let", "if-let", "when-let", "if-some", "when-some",
+        "let", "if-let", "when-let", "if-some", "when-some", "when-first",
         "loop", "for", "foreach", "binding", "dofor", "doseq",
     )
 
     /** Forms that introduce a parameter vector — the `fn` / `defn` family. */
     val FUNCTION_DEFINING: Set<String> = setOf(
         "fn", "defn", "defn-", "defmacro", "defmacro-",
+    )
+
+    /**
+     * Macros that thread an expression through their remaining forms.
+     *
+     * Their arguments are rewritten at expansion, so neither the count nor the order the reader sees
+     * survives. Two consumers ask this: the arity inspection skips a *threaded argument list*, and
+     * [VARIADIC_HEADS] skips the threading call itself.
+     *
+     * The conditional pair is easy to forget — the arity inspection's own copy had it while
+     * [VARIADIC_HEADS] did not, so `(cond-> 1 true inc)` was arity-checked and rendered `expr:` /
+     * `clauses:` hints while every other threading macro was left alone.
+     */
+    val THREADING: Set<String> = setOf(
+        "->", "->>", "as->", "some->", "some->>", "cond->", "cond->>", "doto",
     )
 
     /**
@@ -73,14 +92,17 @@ object PhelSpecialForms {
      * `use` is the one that bit: it is a real registry entry with the signature
      * `(use ClassName & options)`, so it resolves, and the hints provider rendered `ClassName:` /
      * `options:` inside `(use \DateTimeImmutable :as Date)`.
+     *
+     * [LET_LIKE], [FUNCTION_DEFINING] and [THREADING] are folded in rather than re-listed. Every form
+     * in them is disqualified from positional reading for a reason this set already encodes, and
+     * spelling the names twice is how `doseq` ended up in one and not the other.
      */
     val VARIADIC_HEADS: Set<String> = setOf(
-        "if", "if-not", "when", "when-not", "if-let", "when-let", "if-some", "when-some",
-        "do", "let", "loop", "recur", "fn", "defn", "defn-", "def", "def-", "defmacro", "defmacro-",
+        "if", "if-not", "when", "when-not",
+        "do", "recur", "def", "def-",
         "defstruct", "definterface", "defexception", "declare", "ns", "quote", "var",
         "try", "catch", "finally", "throw", "case", "cond", "condp", "and", "or",
-        "->", "->>", "as->", "some->", "some->>", "doto", "binding", "for", "foreach", "dofor",
         "comment", "deftest", "is", "are", "testing", "with-output-buffer",
         "import", "require", "use", "set!", "..", ".",
-    )
+    ) + LET_LIKE + FUNCTION_DEFINING + THREADING
 }

--- a/src/main/kotlin/org/phellang/language/psi/PhelSymbolChars.kt
+++ b/src/main/kotlin/org/phellang/language/psi/PhelSymbolChars.kt
@@ -1,0 +1,38 @@
+package org.phellang.language.psi
+
+/**
+ * Which characters a Phel symbol is made of.
+ *
+ * Mirrors the lexer's own `ATOM_START` / `ATOM_CONT` classes in `language/Phel.flex`, which are the
+ * only real answer to this question. Both are written there as *complements* — everything except the
+ * brackets, whitespace and the reader sigils — so any hand-written allowlist is narrower than the
+ * language, and the two that existed were narrower in different directions: the completion char
+ * filter allowed `%` but not `.` or `\`, the rename validator allowed `.` and `'` but not `%`, and
+ * neither allowed `\`. Typing `.` while completing `.method`, or `\` while completing `\DateTime`,
+ * therefore closed the lookup.
+ *
+ * `,` is absent because Phel lexes it as whitespace (`WHITE_SPACE=[\s,]+`).
+ *
+ * `"` is excluded from both, where the lexer's complement class technically admits it mid-atom: the
+ * `STRING` rule matches first at every token boundary, so an atom containing a quote cannot arise
+ * from well-formed source, and treating one as part of a name would have the completion popup swallow
+ * the opening quote of a string.
+ */
+object PhelSymbolChars {
+
+    /** Brackets, whitespace and the sigils that terminate an atom wherever they appear. */
+    private val NEVER = setOf(
+        '(', ')', '[', ']', '{', '}',
+        ',', '`', '@', ';', '~', '^', '"',
+        ' ', '\n', '\r', '\t',
+    )
+
+    /** `'` and `#` may sit inside a symbol but never open one: there they are reader-macro sigils. */
+    private val NEVER_FIRST = NEVER + setOf('\'', '#')
+
+    /** True when [c] may be the first character of a symbol. */
+    fun isSymbolStart(c: Char): Boolean = c !in NEVER_FIRST
+
+    /** True when [c] may appear in a symbol after its first character. */
+    fun isSymbolPart(c: Char): Boolean = c !in NEVER
+}

--- a/src/main/kotlin/org/phellang/language/psi/references/PhelReference.kt
+++ b/src/main/kotlin/org/phellang/language/psi/references/PhelReference.kt
@@ -150,8 +150,11 @@ class PhelReference @JvmOverloads constructor(
         return myElement.setName(newText)
     }
 
-    @Throws(IncorrectOperationException::class)
-    override fun bindToElement(element: PsiElement): PsiElement = myElement
+    // No bindToElement override on purpose. Re-pointing a Phel symbol at a moved target is not
+    // implemented, and PsiReferenceBase already answers that by throwing IncorrectOperationException
+    // — the platform's contract for "not supported", and what PhelLoadReference next door does.
+    // Returning myElement unchanged instead reported success and re-pointed nothing, so a Move left
+    // references aimed at the old target with no error anywhere.
 
     companion object {
         /** Project-wide variants are only collected while the list is still short enough to be useful. */

--- a/src/main/kotlin/org/phellang/refactoring/PhelNamesValidator.kt
+++ b/src/main/kotlin/org/phellang/refactoring/PhelNamesValidator.kt
@@ -2,57 +2,41 @@ package org.phellang.refactoring
 
 import com.intellij.lang.refactoring.NamesValidator
 import com.intellij.openapi.project.Project
+import org.phellang.language.psi.PhelSpecialForms
+import org.phellang.language.psi.PhelSymbolChars
 
 class PhelNamesValidator : NamesValidator {
 
-    override fun isKeyword(name: String, project: Project?): Boolean = name in RESERVED
+    /**
+     * [PhelSpecialForms] rather than a list of this file's own.
+     *
+     * The hand-written one had `defstruct` but not `defstruct*`, and no `defonce`, `defenum`,
+     * `defprotocol`, `defrecord`, `deftype`, `defmulti`, `deftest`, `if-let`, `when-let`, `case`,
+     * `cond`, `for`, `foreach` or `binding` — so renaming a symbol to any of those was accepted
+     * without a word. It was the fourth copy of a set that exists once on purpose.
+     */
+    override fun isKeyword(name: String, project: Project?): Boolean =
+        name in PhelSpecialForms.VARIADIC_HEADS ||
+                name in PhelSpecialForms.NAME_DECLARING ||
+                name in LITERALS
 
+    /**
+     * Character membership comes from [PhelSymbolChars], which mirrors the lexer's atom classes.
+     *
+     * The two leading-character rules are this validator's own, because in the lexer they are not
+     * character rules at all: `1foo` and `:foo` are kept out of `ATOM` by `NUMBER` and `KEYWORD`
+     * matching first, not by `ATOM_START` excluding the character.
+     */
     override fun isIdentifier(name: String, project: Project?): Boolean {
-        if (name.isEmpty()) return false
-        val first = name[0]
-        if (first.isDigit()) return false
-        // Leading `:` is a keyword sigil; leading `'`/`` ` ``/`~`/`@`/`#` is a reader macro.
-        if (first in INVALID_FIRST_CHARS) return false
-        return name.all(::isSymbolChar)
-    }
+        val first = name.firstOrNull() ?: return false
+        if (first.isDigit() || first == KEYWORD_SIGIL) return false
+        if (!PhelSymbolChars.isSymbolStart(first)) return false
 
-    private fun isSymbolChar(c: Char): Boolean {
-        if (c.isLetterOrDigit()) return true
-        return c in ALLOWED_PUNCT
+        return name.all(PhelSymbolChars::isSymbolPart)
     }
-
 }
 
-private val ALLOWED_PUNCT = setOf('-', '_', '?', '!', '*', '+', '/', '<', '>', '=', '.', '&', ':', '\'', '$')
+private const val KEYWORD_SIGIL = ':'
 
-private val INVALID_FIRST_CHARS = setOf(':', '\'', '`', '~', '@', '#')
-
-private val RESERVED = setOf(
-    "def",
-    "defn",
-    "defn-",
-    "def-",
-    "defmacro",
-    "defmacro-",
-    "defstruct",
-    "definterface",
-    "defexception",
-    "declare",
-    "fn",
-    "let",
-    "if",
-    "when",
-    "do",
-    "quote",
-    "var",
-    "throw",
-    "try",
-    "catch",
-    "finally",
-    "loop",
-    "recur",
-    "ns",
-    "true",
-    "false",
-    "nil"
-)
+/** Not forms, but reserved all the same: renaming something to `nil` shadows the literal. */
+private val LITERALS = setOf("true", "false", "nil")

--- a/src/main/kotlin/org/phellang/run/test/PhelTestReport.kt
+++ b/src/main/kotlin/org/phellang/run/test/PhelTestReport.kt
@@ -3,8 +3,6 @@ package org.phellang.run.test
 /** A parsed `phel test --reporter=junit-xml` report. */
 data class PhelTestReport(val suites: List<PhelTestSuite>) {
 
-    val isEmpty: Boolean get() = suites.all { it.cases.isEmpty() }
-
     companion object {
         val EMPTY = PhelTestReport(emptyList())
     }

--- a/src/main/kotlin/org/phellang/syntax/classification/PhelTokenClassifier.kt
+++ b/src/main/kotlin/org/phellang/syntax/classification/PhelTokenClassifier.kt
@@ -61,88 +61,11 @@ object PhelTokenClassifier {
         return if (isBadCharacter(tokenType)) TokenCategory.BAD_CHARACTER else TokenCategory.UNKNOWN
     }
 
-    fun isComment(tokenType: IElementType): Boolean {
-        return tokenType == PhelTypes.LINE_COMMENT || tokenType == PhelTypes.FORM_COMMENT
-    }
-
-    fun isString(tokenType: IElementType): Boolean {
-        return tokenType == PhelTypes.STRING
-    }
-
-    fun isNumber(tokenType: IElementType): Boolean {
-        return tokenType == PhelTypes.NUMBER || tokenType == PhelTypes.BINNUM
-                || tokenType == PhelTypes.OCTNUM || tokenType == PhelTypes.HEXNUM
-                || tokenType == PhelTypes.RADIXNUM || tokenType == PhelTypes.SYMBOLIC_NUM
-                || tokenType == PhelTypes.RATIO
-    }
-
-    fun isBoolean(tokenType: IElementType): Boolean {
-        return tokenType == PhelTypes.BOOL
-    }
-
-    fun isNil(tokenType: IElementType): Boolean {
-        return tokenType == PhelTypes.NIL
-    }
-
-    fun isNan(tokenType: IElementType): Boolean {
-        return tokenType == PhelTypes.NAN
-    }
-
-    fun isCharacter(tokenType: IElementType): Boolean {
-        return tokenType == PhelTypes.CHAR
-    }
-
-    fun isParentheses(tokenType: IElementType): Boolean {
-        return tokenType == PhelTypes.PAREN1 || tokenType == PhelTypes.PAREN2 || tokenType == PhelTypes.HASH_PAREN
-                || tokenType == PhelTypes.READER_COND || tokenType == PhelTypes.READER_COND_SPLICE
-    }
-
-    fun isBrackets(tokenType: IElementType): Boolean {
-        return tokenType == PhelTypes.BRACKET1 || tokenType == PhelTypes.BRACKET2
-    }
-
-    fun isBraces(tokenType: IElementType): Boolean {
-        return tokenType == PhelTypes.BRACE1 || tokenType == PhelTypes.BRACE2
-    }
-
-    fun isSetOpener(tokenType: IElementType): Boolean {
-        return tokenType == PhelTypes.HASH_BRACE
-    }
-
-    fun isQuote(tokenType: IElementType): Boolean {
-        return tokenType == PhelTypes.QUOTE || tokenType == PhelTypes.VAR_QUOTE
-    }
-
-    fun isSyntaxQuote(tokenType: IElementType): Boolean {
-        return tokenType == PhelTypes.SYNTAX_QUOTE
-    }
-
-    fun isUnquote(tokenType: IElementType): Boolean {
-        return tokenType == PhelTypes.TILDE
-    }
-
-    fun isUnquoteSplicing(tokenType: IElementType): Boolean {
-        return tokenType == PhelTypes.TILDE_AT
-    }
-
-    fun isKeyword(tokenType: IElementType): Boolean {
-        return tokenType == PhelTypes.KEYWORD || tokenType == PhelTypes.KEYWORD_TOKEN
-                || tokenType == PhelTypes.COLON || tokenType == PhelTypes.COLONCOLON
-    }
-
-    fun isMetadata(tokenType: IElementType): Boolean {
-        return tokenType == PhelTypes.HAT
-    }
-
-    fun isDotOperator(tokenType: IElementType): Boolean {
-        return tokenType == PhelTypes.DOT || tokenType == PhelTypes.DOTDASH
-    }
-
-    fun isSymbol(tokenType: IElementType): Boolean {
-        return tokenType == PhelTypes.SYM
-    }
-
-    fun isBadCharacter(tokenType: IElementType): Boolean {
+    /**
+     * Matched by name as well as by identity: the lexer's own bad-character token is not always the
+     * platform's, so comparing against [TokenType.BAD_CHARACTER] alone misses it.
+     */
+    private fun isBadCharacter(tokenType: IElementType): Boolean {
         val tokenName = tokenType.toString()
         return "BAD_CHARACTER" == tokenName || tokenType == TokenType.BAD_CHARACTER
     }

--- a/src/main/kotlin/org/phellang/tools/generator/NamespaceConfig.kt
+++ b/src/main/kotlin/org/phellang/tools/generator/NamespaceConfig.kt
@@ -48,8 +48,6 @@ object NamespaceConfig {
 
     fun getInfo(namespace: String): NamespaceInfo? = config[namespace]
 
-    fun isSupported(namespace: String): Boolean = config.containsKey(namespace)
-
     /** All configured namespaces, source of truth for registry/enum wiring. */
     fun all(): Map<String, NamespaceInfo> = config
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -219,7 +219,11 @@
             <add-to-group group-id="NewGroup" anchor="after" relative-to-action="NewScratchFile"/>
         </action>
 
-        <group id="Phel.Paredit" text="Phel Paredit" popup="true">
+        <!-- The group hides itself outside Phel files; see PhelPareditActionGroup. Without the
+             add-to-group these actions had no menu at all and were reachable only by chord. -->
+        <group id="Phel.Paredit" text="Phel Paredit" popup="true"
+               class="org.phellang.editor.paredit.PhelPareditActionGroup">
+            <add-to-group group-id="EditorPopupMenu" anchor="last"/>
             <action id="Phel.Paredit.SlurpForward"
                     class="org.phellang.editor.paredit.PhelSlurpForwardAction"
                     text="Slurp Forward"

--- a/src/test/kotlin/org/phellang/integration/completion/PhelLocalSymbolCompletionTest.kt
+++ b/src/test/kotlin/org/phellang/integration/completion/PhelLocalSymbolCompletionTest.kt
@@ -73,6 +73,7 @@ class PhelLocalSymbolCompletionTest : PhelIntegrationTestCase() {
             "foreach" to "(foreach [zebra [1 2]] zeb<caret>)",
             "dofor" to "(dofor [zebra :in [1 2]] zeb<caret>)",
             "binding" to "(binding [zebra 1] zeb<caret>)",
+            "when-first" to "(when-first [zebra [1 2]] zeb<caret>)",
         )
 
         // A fresh file per case: reusing one name across configureByText calls leaves a later file

--- a/src/test/kotlin/org/phellang/integration/editor/PhelEnterIndentationTest.kt
+++ b/src/test/kotlin/org/phellang/integration/editor/PhelEnterIndentationTest.kt
@@ -1,11 +1,13 @@
 package org.phellang.integration.editor
 
+import com.intellij.application.options.CodeStyle
 import org.phellang.integration.PhelIntegrationTestCase
+import org.phellang.language.infrastructure.PhelLanguage
 
 /**
  * Where the caret lands after ENTER.
  *
- * The indentation of the new line is one level per still-open parenthesis, so closing a form must
+ * The indentation of the new line is one level per still-open bracket, so closing a form must
  * *reduce* it. The handler used to compute only the extra indentation to add to what the platform
  * had already copied from the previous line, clamped at zero — it could indent further but never
  * less, so `(print "hello"))` left the next line two spaces in, and `(print 1)))` four, when both
@@ -64,5 +66,68 @@ class PhelEnterIndentationTest : PhelIntegrationTestCase() {
     /** Nor is one in a comment. */
     fun testParenthesesInCommentsDoNotAffectIndentation() {
         assertEquals(2, indentAfterEnter("(defn f []\n  (print 1) ; ))\n  (print 2)<caret>"))
+    }
+
+    // ---- Every bracket opens a level, not only a parenthesis ----
+
+    /**
+     * A binding vector is a level of its own: `defn`, `let` and the vector make three.
+     *
+     * The scanner counted only `(` and `)`, so the `[` here was invisible and the new line landed at
+     * the `let`'s level instead of inside its bindings.
+     */
+    fun testOpenVectorIndentsItsContents() {
+        assertEquals(6, indentAfterEnter("(defn f []\n  (let [x 1<caret>"))
+    }
+
+    fun testOpenMapIndentsItsContents() {
+        assertEquals(4, indentAfterEnter("(defn f []\n  {:a 1<caret>"))
+    }
+
+    fun testOpenSetIndentsItsContents() {
+        assertEquals(4, indentAfterEnter("(defn f []\n  #{:a<caret>"))
+    }
+
+    /** With no enclosing list at all, a vector still indents its own contents. */
+    fun testTopLevelVectorIndentsItsContents() {
+        assertEquals(2, indentAfterEnter("[1 2<caret>"))
+    }
+
+    /** Closing the binding vector drops back to the `let` body's level, not out of the `let`. */
+    fun testClosingAVectorDedentsByOneLevel() {
+        assertEquals(4, indentAfterEnter("(defn f []\n  (let [x 1]<caret>"))
+    }
+
+    /** `#(` opens one level, not two: the `#` is part of the opener. */
+    fun testAnonymousFunctionIndentsItsBody() {
+        assertEquals(4, indentAfterEnter("(defn f []\n  (map #(inc %)<caret>"))
+    }
+
+    // ---- Character literals are not brackets ----
+
+    /**
+     * `\(` is a character literal, not an opening paren — the lexer's `CHARACTER` rule ends in a
+     * catch-all `.`, so any character can follow the backslash.
+     */
+    fun testCharacterLiteralParenthesesDoNotAffectIndentation() {
+        assertEquals(2, indentAfterEnter("(defn f []\n  (print \\()<caret>"))
+    }
+
+    fun testCharacterLiteralClosingParenthesisDoesNotDedent() {
+        assertEquals(2, indentAfterEnter("(defn f []\n  (print \\))<caret>"))
+    }
+
+    // ---- The Code Style indent width ----
+
+    /** The width was hard-coded to two, so the Code Style page could show a number Enter ignored. */
+    fun testHonoursTheConfiguredIndentSize() {
+        val indentOptions = CodeStyle.getSettings(project).getCommonSettings(PhelLanguage).indentOptions!!
+        val original = indentOptions.INDENT_SIZE
+        try {
+            indentOptions.INDENT_SIZE = 4
+            assertEquals(8, indentAfterEnter("(defn f []\n  (when true<caret>"))
+        } finally {
+            indentOptions.INDENT_SIZE = original
+        }
     }
 }

--- a/src/test/kotlin/org/phellang/integration/editor/PhelFormattingModelBuilderTest.kt
+++ b/src/test/kotlin/org/phellang/integration/editor/PhelFormattingModelBuilderTest.kt
@@ -73,6 +73,25 @@ class PhelFormattingModelBuilderTest : PhelIntegrationTestCase() {
         assertEquals(source, reformatted(source))
     }
 
+    // ---- Every bracketed container indents, not only the four obvious ones ----
+
+    /**
+     * `#(...)` is a container like any other. `CONTAINERS` listed only LIST/VEC/MAP/SET, so an
+     * anonymous function's body stayed flush left while the Enter handler indented it — the two
+     * disagreeing about the same line.
+     */
+    fun testIndentsAnAnonymousFunctionBody() {
+        assertEquals("#(* %\n  2)\n", reformatted("#(* %\n2)\n"))
+    }
+
+    fun testIndentsAReaderConditionalBody() {
+        assertEquals("#?(:a 1\n  :b 2)\n", reformatted("#?(:a 1\n:b 2)\n"))
+    }
+
+    fun testIndentsASplicingReaderConditionalBody() {
+        assertEquals("#?@(:a 1\n  :b 2)\n", reformatted("#?@(:a 1\n:b 2)\n"))
+    }
+
     // ---- Code Style options the formatter honours ----
 
     private fun reformattedWith(text: String, configure: (com.intellij.psi.codeStyle.CommonCodeStyleSettings) -> Unit): String {

--- a/src/test/kotlin/org/phellang/integration/editor/PhelPareditActionGroupTest.kt
+++ b/src/test/kotlin/org/phellang/integration/editor/PhelPareditActionGroupTest.kt
@@ -1,0 +1,63 @@
+package org.phellang.integration.editor
+
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.DefaultActionGroup
+import com.intellij.openapi.actionSystem.impl.SimpleDataContext
+import com.intellij.testFramework.TestActionEvent
+import org.phellang.integration.PhelIntegrationTestCase
+
+/**
+ * The Paredit submenu is registered, and appears only in Phel files.
+ *
+ * The group used to have no `<add-to-group>`, so its nine actions had no menu entry anywhere and
+ * were reachable only by chord. Its own visibility check matters because a `popup="true"` group
+ * renders its entry whatever its children report, so without one "Phel Paredit" would show up in
+ * the right-click menu of every file type in the IDE.
+ */
+class PhelPareditActionGroupTest : PhelIntegrationTestCase() {
+
+    private fun action(id: String): AnAction =
+        requireNotNull(ActionManager.getInstance().getAction(id)) { "$id is not registered" }
+
+    private fun isVisibleIn(fileName: String, source: String): Boolean {
+        myFixture.configureByText(fileName, source)
+
+        val context = SimpleDataContext.builder()
+            .add(CommonDataKeys.PROJECT, project)
+            .add(CommonDataKeys.EDITOR, myFixture.editor)
+            .add(CommonDataKeys.PSI_FILE, myFixture.file)
+            .build()
+
+        val group = action(GROUP_ID)
+        val event = TestActionEvent.createTestEvent(group, context)
+        group.update(event)
+
+        return event.presentation.isVisible
+    }
+
+    fun testTheGroupIsShownInAPhelFile() {
+        assertTrue("Phel Paredit should be offered in a .phel file", isVisibleIn("a.phel", "(a<caret> b)"))
+    }
+
+    fun testTheGroupIsHiddenInAnotherLanguage() {
+        assertFalse("Phel Paredit must not appear in every file type", isVisibleIn("a.txt", "plain<caret> text"))
+    }
+
+    /** A submenu attached to no menu is what this fixed; the nine actions all hang off this group. */
+    fun testTheGroupIsAttachedToTheEditorPopupMenuAndKeepsItsActions() {
+        val popup = action(EDITOR_POPUP_ID) as DefaultActionGroup
+        val ids = popup.getChildren(null).map { ActionManager.getInstance().getId(it) }
+
+        assertTrue("expected $GROUP_ID in the editor popup, found $ids", ids.contains(GROUP_ID))
+
+        val pareditActions = (action(GROUP_ID) as DefaultActionGroup).getChildren(null)
+        assertEquals("all nine paredit actions should hang off the group", 9, pareditActions.size)
+    }
+
+    private companion object {
+        const val GROUP_ID = "Phel.Paredit"
+        const val EDITOR_POPUP_ID = "EditorPopupMenu"
+    }
+}

--- a/src/test/kotlin/org/phellang/integration/inspection/PhelUnusedLetBindingInspectionIntegrationTest.kt
+++ b/src/test/kotlin/org/phellang/integration/inspection/PhelUnusedLetBindingInspectionIntegrationTest.kt
@@ -44,6 +44,20 @@ class PhelUnusedLetBindingInspectionIntegrationTest : PhelIntegrationTestCase() 
         assertTrue("used binding should not be flagged: $warnings", warnings.isEmpty())
     }
 
+    /**
+     * `when-first` binds the head of a collection with `when-let`'s shape, and was the same omission
+     * a second time: absent from LET_LIKE, so nothing looked inside it either.
+     */
+    fun testUnusedBindingInAWhenFirstIsFlagged() {
+        val warnings = inspect("(ns app\\m)\n(defn f []\n  (when-first [unused [1 2]]\n    42))\n")
+        assertEquals(listOf("Binding 'unused' is never used."), warnings)
+    }
+
+    fun testUsedBindingInAWhenFirstIsNotFlagged() {
+        val warnings = inspect("(ns app\\m)\n(defn f []\n  (when-first [used [1 2]]\n    (println used)))\n")
+        assertTrue("used binding should not be flagged: $warnings", warnings.isEmpty())
+    }
+
     /** Either branch counts as usage: the binding is in scope for both. */
     fun testBindingUsedOnlyInTheElseBranchOfAnIfSomeIsNotFlagged() {
         val warnings = inspect("(ns app\\m)\n(defn f []\n  (if-some [v 1]\n    42\n    (println v)))\n")

--- a/src/test/kotlin/org/phellang/integration/registry/PhelPsiChangeListenerTest.kt
+++ b/src/test/kotlin/org/phellang/integration/registry/PhelPsiChangeListenerTest.kt
@@ -1,0 +1,66 @@
+package org.phellang.integration.registry
+
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiManager
+import com.intellij.testFramework.PlatformTestUtil
+import org.phellang.indexing.PhelProjectSymbolIndex
+import org.phellang.indexing.PhelPsiChangeListener
+import org.phellang.integration.PhelIntegrationTestCase
+import org.phellang.language.psi.files.PhelFile
+
+/**
+ * Live edits reach the symbol index, for every file edited rather than only the last one.
+ *
+ * The listener coalesces a typing burst into one pass on the EDT. It used to hold the pending file
+ * in a single slot, so a second file edited before the pass ran overwrote the first — and because
+ * the "already scheduled" flag was still set, no second pass was queued. The first file's symbols
+ * stayed stale indefinitely.
+ *
+ * The listener is registered here rather than relied on through [PhelProjectSymbolIndex]'s
+ * constructor: the light project is shared between test classes and the service is disposed in
+ * tearDown, so by the time this class runs the service's own listeners may already be detached.
+ */
+class PhelPsiChangeListenerTest : PhelIntegrationTestCase() {
+
+    fun testEveryEditedFileIsReindexed() {
+        val index = PhelProjectSymbolIndex.getInstance(project)
+
+        val first = myFixture.addFileToProject("src/first.phel", "(ns app\\first)\n") as PhelFile
+        val second = myFixture.addFileToProject("src/second.phel", "(ns app\\second)\n") as PhelFile
+
+        // Force the lazy full-project scan to completion *before* the edits, then start from empty.
+        // Otherwise the first read below would rebuild from disk and find both definitions whether
+        // the listener did its job or not, and the test would pass against the bug it guards.
+        index.getAllSymbols()
+        index.clear()
+
+        PsiManager.getInstance(project).addPsiTreeChangeListener(PhelPsiChangeListener(project), testRootDisposable)
+
+        // Both edits land before the scheduled pass runs, which is the case that used to lose one.
+        appendDefinitions(first to "alpha-fn", second to "beta-fn")
+        PlatformTestUtil.dispatchAllInvocationEventsInIdeEventQueue()
+
+        assertEquals(
+            "the first file's edit must survive a second file being edited in the same burst",
+            listOf("first"),
+            index.findByName("alpha-fn").map { it.shortNamespace },
+        )
+        assertEquals(
+            listOf("second"),
+            index.findByName("beta-fn").map { it.shortNamespace },
+        )
+    }
+
+    private fun appendDefinitions(vararg edits: Pair<PhelFile, String>) {
+        val documentManager = PsiDocumentManager.getInstance(project)
+
+        WriteCommandAction.runWriteCommandAction(project) {
+            for ((file, name) in edits) {
+                val document = documentManager.getDocument(file)!!
+                document.insertString(document.textLength, "(defn $name [] 1)\n")
+                documentManager.commitDocument(document)
+            }
+        }
+    }
+}

--- a/src/test/kotlin/org/phellang/integration/tools/ApiGeneratorIntegrationTest.kt
+++ b/src/test/kotlin/org/phellang/integration/tools/ApiGeneratorIntegrationTest.kt
@@ -2,6 +2,7 @@ package org.phellang.integration.tools
 
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -244,7 +245,7 @@ class ApiGeneratorIntegrationTest {
             )
 
             expectedNamespaces.forEach { namespace ->
-                assertTrue(NamespaceConfig.isSupported(namespace), "Namespace $namespace should be supported")
+                assertNotNull(NamespaceConfig.getInfo(namespace), "Namespace $namespace should be supported")
             }
         }
 

--- a/src/test/kotlin/org/phellang/unit/completion/PhelCompletionCharFilterTest.kt
+++ b/src/test/kotlin/org/phellang/unit/completion/PhelCompletionCharFilterTest.kt
@@ -1,53 +1,78 @@
 package org.phellang.unit.completion
 
-import org.junit.jupiter.api.Assertions.*
+import com.intellij.codeInsight.lookup.CharFilter
+import com.intellij.codeInsight.lookup.Lookup
+import com.intellij.openapi.fileTypes.FileType
+import com.intellij.openapi.fileTypes.PlainTextFileType
+import com.intellij.psi.PsiFile
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
 import org.phellang.completion.PhelCompletionCharFilter
+import org.phellang.language.infrastructure.PhelFileType
 
+/**
+ * Which keystrokes keep a lookup open.
+ *
+ * Character membership itself belongs to `PhelSymbolChars` and is pinned by `PhelSymbolCharsTest`;
+ * what is asserted here is the filter's own behaviour — the file-type gate, and that a symbol
+ * character extends the prefix rather than committing the lookup.
+ */
 class PhelCompletionCharFilterTest {
 
     private val charFilter = PhelCompletionCharFilter()
 
-    @Test
-    fun `special characters should be recognized as phel identifier characters`() {
-        val identifierChars = listOf('/', ':', '-', '_', '?', '!', '*', '+', '<', '>', '=', '&', '%', '$')
+    private fun acceptCharInPhelFile(c: Char): CharFilter.Result? =
+        charFilter.acceptChar(c, 0, lookupIn(PhelFileType.INSTANCE))
 
-        for (c in identifierChars) {
-            assertTrue(charFilter.isPhelIdentifierChar(c), "Character '$c' should be a valid Phel identifier character")
-        }
+    private fun lookupIn(fileType: FileType): Lookup {
+        val file = mock(PsiFile::class.java)
+        `when`(file.fileType).thenReturn(fileType)
+
+        val lookup = mock(Lookup::class.java)
+        `when`(lookup.psiFile).thenReturn(file)
+
+        return lookup
     }
 
     @ParameterizedTest
-    @ValueSource(chars = ['a', 'z', 'A', 'Z', '0', '9'])
-    fun `alphanumeric characters should be valid identifier chars`(c: Char) {
-        assertTrue(charFilter.isPhelIdentifierChar(c), "Character '$c' should be a valid Phel identifier character")
+    @ValueSource(chars = ['a', 'Z', '0', '/', ':', '-', '_', '?', '!', '*', '+', '<', '>', '=', '&', '%', '$'])
+    fun `a symbol character extends the prefix`(c: Char) {
+        assertEquals(CharFilter.Result.ADD_TO_PREFIX, acceptCharInPhelFile(c))
     }
 
+    /**
+     * The two the filter's own character list left out, so the lookup closed on the first keystroke
+     * of the very shorthands completion offers: `.method` / `.-field`, and `\DateTime` from `(:use)`.
+     */
     @ParameterizedTest
-    @ValueSource(chars = ['(', ')', '[', ']', '{', '}', ' ', '\n', '\t'])
-    fun `delimiter and whitespace characters should not be identifier chars`(c: Char) {
-        assertFalse(charFilter.isPhelIdentifierChar(c), "Character '$c' should NOT be a valid Phel identifier character")
+    @ValueSource(chars = ['.', '\\'])
+    fun `the interop shorthand characters keep the lookup open`(c: Char) {
+        assertEquals(CharFilter.Result.ADD_TO_PREFIX, acceptCharInPhelFile(c))
+    }
+
+    /** Null defers to the platform, which commits the lookup and types the character. */
+    @ParameterizedTest
+    @ValueSource(chars = ['(', ')', '[', ']', '{', '}', ' ', '\n', '\t', ',', '"', ';', '`', '@', '~', '^'])
+    fun `a delimiter defers to the platform`(c: Char) {
+        assertNull(acceptCharInPhelFile(c))
+    }
+
+    /** The filter is registered application-wide, so it must decline every other language. */
+    @Test
+    fun `a non-Phel file is left alone`() {
+        assertNull(charFilter.acceptChar('a', 0, lookupIn(PlainTextFileType.INSTANCE)))
     }
 
     @Test
-    fun `namespace separator usage in function names`() {
-        val namespacedFunctions = listOf(
-            "str/split",
-            "str/join",
-            "json/encode",
-            "json/decode",
-            "http/get",
-            "repl/require",
-            "php/->",
-            "php/::",
-            "mock/with-mock"
-        )
+    fun `a lookup with no file is left alone`() {
+        val lookup = mock(Lookup::class.java)
+        `when`(lookup.psiFile).thenReturn(null)
 
-        for (fn in namespacedFunctions) {
-            val allCharsValid = fn.all { charFilter.isPhelIdentifierChar(it) }
-            assertTrue(allCharsValid, "All characters in '$fn' should be valid")
-        }
+        assertNull(charFilter.acceptChar('a', 0, lookup))
     }
 }

--- a/src/test/kotlin/org/phellang/unit/editor/typing/pairing/PhelCharacterPairingTest.kt
+++ b/src/test/kotlin/org/phellang/unit/editor/typing/pairing/PhelCharacterPairingTest.kt
@@ -153,19 +153,6 @@ class PhelCharacterPairingTest {
     }
 
     @Test
-    fun `getAllPairableCharacters should return all pairable characters`() {
-        val pairableChars = PhelCharacterPairing.getAllPairableCharacters()
-
-        assertEquals(6, pairableChars.size)
-        assertTrue(pairableChars.contains('('))
-        assertTrue(pairableChars.contains('['))
-        assertTrue(pairableChars.contains('{'))
-        assertTrue(pairableChars.contains(')'))
-        assertTrue(pairableChars.contains(']'))
-        assertTrue(pairableChars.contains('}'))
-    }
-
-    @Test
     fun `pairing should be consistent across multiple calls`() {
         val result1 = PhelCharacterPairing.getClosingCharacter('(')
         val result2 = PhelCharacterPairing.getClosingCharacter('(')

--- a/src/test/kotlin/org/phellang/unit/language/psi/PhelSpecialFormsTest.kt
+++ b/src/test/kotlin/org/phellang/unit/language/psi/PhelSpecialFormsTest.kt
@@ -81,6 +81,58 @@ class PhelSpecialFormsTest {
             }
         }
 
+        /**
+         * Regression: `doseq` sat in [PhelSpecialForms.LET_LIKE] but not here, so `(doseq [x coll] …)`
+         * was hinted `seq-exprs:` / `body:` positionally.
+         *
+         * A form that binds a vector can never be read positionally, so the containment is now
+         * structural rather than two lists that happen to agree.
+         */
+        @Test
+        fun `every binding form is also a variadic head`() {
+            PhelSpecialForms.LET_LIKE.forEach { head ->
+                assertTrue(
+                    head in PhelSpecialForms.VARIADIC_HEADS,
+                    "'$head' introduces a binding vector, so it can never be read positionally",
+                )
+            }
+        }
+
+        /**
+         * Regression: `cond->` and `cond->>` were threading heads to the arity inspection's private
+         * copy but absent here, so the `cond->` call itself was arity-checked and hinted.
+         */
+        @Test
+        fun `every threading macro is also a variadic head`() {
+            PhelSpecialForms.THREADING.forEach { head ->
+                assertTrue(
+                    head in PhelSpecialForms.VARIADIC_HEADS,
+                    "'$head' shifts its arguments at expansion, so it can never be read positionally",
+                )
+            }
+        }
+    }
+
+    @Nested
+    inner class Threading {
+
+        @Test
+        fun `covers every threading macro, including the conditional pair`() {
+            val expected = setOf("->", "->>", "as->", "some->", "some->>", "cond->", "cond->>", "doto")
+
+            assertEquals(expected, PhelSpecialForms.THREADING)
+        }
+
+        @Test
+        fun `the conditional threading macros are real registry entries`() {
+            listOf("cond->", "cond->>").forEach { name ->
+                assertNotNull(
+                    PhelFunctionRegistry.getFunction(name),
+                    "'$name' is expected to resolve, which is why omitting it produced hints",
+                )
+            }
+        }
+
         /** Ordinary functions must stay out, or every real call loses its hints and arity check. */
         @Test
         fun `does not swallow ordinary functions`() {
@@ -101,13 +153,33 @@ class PhelSpecialFormsTest {
         @Test
         fun `contains the forms whose second element is a binding vector`() {
             val expected = setOf(
-                "let", "if-let", "when-let", "if-some", "when-some",
+                "let", "if-let", "when-let", "if-some", "when-some", "when-first",
                 "loop", "for", "foreach", "binding", "dofor", "doseq",
             )
 
             assertTrue(
                 PhelSpecialForms.LET_LIKE.containsAll(expected),
                 "LET_LIKE should cover every binding-vector form, found ${PhelSpecialForms.LET_LIKE}",
+            )
+        }
+
+        /**
+         * Regression: `when-first` was missing, so its binding was unresolved on go-to-definition,
+         * absent from local completion, never reported as unused or shadowed, and unrecognised by the
+         * parameter hints — all at once, the same way `if-some` and `when-some` once were.
+         *
+         * Its registry signature is the shape that decides membership, so pin that too: a future
+         * upstream change from `bindings` to something positional would make the entry wrong.
+         */
+        @Test
+        fun `treats when-first like when-let, whose signature it shares`() {
+            val whenFirst = PhelFunctionRegistry.getFunction("when-first")
+            assertNotNull(whenFirst, "`when-first` is expected to be a registry entry")
+            assertEquals("(when-first bindings & body)", whenFirst!!.signature)
+
+            assertEquals(
+                "when-let" in PhelSpecialForms.LET_LIKE,
+                "when-first" in PhelSpecialForms.LET_LIKE,
             )
         }
 

--- a/src/test/kotlin/org/phellang/unit/language/psi/PhelSymbolCharsTest.kt
+++ b/src/test/kotlin/org/phellang/unit/language/psi/PhelSymbolCharsTest.kt
@@ -1,0 +1,66 @@
+package org.phellang.unit.language.psi
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.phellang.language.psi.PhelSymbolChars
+
+class PhelSymbolCharsTest {
+
+    @ParameterizedTest
+    @ValueSource(chars = ['a', 'z', 'A', 'Z', '0', '9'])
+    fun `alphanumerics are symbol characters`(c: Char) {
+        assertTrue(PhelSymbolChars.isSymbolStart(c), "'$c' should be able to open a symbol")
+        assertTrue(PhelSymbolChars.isSymbolPart(c), "'$c' should be able to continue a symbol")
+    }
+
+    @ParameterizedTest
+    @ValueSource(chars = ['-', '_', '?', '!', '*', '+', '<', '>', '=', '&', '/', ':', '%', '$', '.', '\\'])
+    fun `the punctuation Phel symbols actually use is accepted`(c: Char) {
+        assertTrue(PhelSymbolChars.isSymbolStart(c), "'$c' should be able to open a symbol")
+        assertTrue(PhelSymbolChars.isSymbolPart(c), "'$c' should be able to continue a symbol")
+    }
+
+    @ParameterizedTest
+    @ValueSource(chars = ['(', ')', '[', ']', '{', '}', ' ', '\n', '\r', '\t', ',', '`', '@', ';', '~', '^', '"'])
+    fun `brackets, whitespace and sigils are never symbol characters`(c: Char) {
+        assertFalse(PhelSymbolChars.isSymbolStart(c), "'$c' should not open a symbol")
+        assertFalse(PhelSymbolChars.isSymbolPart(c), "'$c' should not continue a symbol")
+    }
+
+    /** `,` is whitespace in Phel, not punctuation. */
+    @Test
+    fun `comma is whitespace`() {
+        assertFalse(PhelSymbolChars.isSymbolPart(','))
+    }
+
+    /**
+     * `'` and `#` are the one asymmetry in the lexer's two classes: `ATOM_START` excludes them,
+     * `ATOM_CONT` does not.
+     */
+    @Test
+    fun `quote and hash may continue a symbol but not open one`() {
+        listOf('\'', '#').forEach { c ->
+            assertFalse(PhelSymbolChars.isSymbolStart(c), "'$c' is a reader sigil at the start of a symbol")
+            assertTrue(PhelSymbolChars.isSymbolPart(c), "'$c' is ordinary inside a symbol")
+        }
+    }
+
+    @Test
+    fun `every character of the names Phel really uses is accepted`() {
+        val names = listOf(
+            "str/split", "json/encode", "php/->", "php/::", "mock/with-mock",
+            "nil?", "set!", "<=", "*out*", "%", "%1",
+            ".method", ".-field", "DateTime.", "\\DateTimeImmutable", "\\Foo\\Bar",
+        )
+
+        names.forEach { name ->
+            assertTrue(
+                PhelSymbolChars.isSymbolStart(name.first()) && name.all(PhelSymbolChars::isSymbolPart),
+                "every character of '$name' should be a symbol character",
+            )
+        }
+    }
+}

--- a/src/test/kotlin/org/phellang/unit/refactoring/PhelNamesValidatorTest.kt
+++ b/src/test/kotlin/org/phellang/unit/refactoring/PhelNamesValidatorTest.kt
@@ -57,11 +57,50 @@ class PhelNamesValidatorTest {
         assertFalse(validator.isIdentifier("(foo)", null))
     }
 
+    /** `%` and `%1` are the anonymous-function parameters; the old character list rejected them. */
+    @Test
+    fun `accepts the anonymous-function parameters`() {
+        assertTrue(validator.isIdentifier("%", null))
+        assertTrue(validator.isIdentifier("%1", null))
+    }
+
+    @Test
+    fun `accepts interop shorthands and PHP class references`() {
+        assertTrue(validator.isIdentifier(".method", null))
+        assertTrue(validator.isIdentifier(".-field", null))
+        assertTrue(validator.isIdentifier("\\DateTimeImmutable", null))
+    }
+
     @Test
     fun `marks reserved words as keywords`() {
         assertTrue(validator.isKeyword("def", null))
         assertTrue(validator.isKeyword("defn", null))
         assertTrue(validator.isKeyword("ns", null))
         assertFalse(validator.isKeyword("foo", null))
+    }
+
+    /**
+     * The forms the hand-written reserved list had drifted away from. It carried `defstruct` but not
+     * `defstruct*`, and none of the binding or dispatch forms at all, so renaming a symbol to any of
+     * these was accepted in silence.
+     */
+    @Test
+    fun `marks the forms the old hand-written list was missing`() {
+        val previouslyMissing = listOf(
+            "defstruct*", "definterface*", "defexception*",
+            "defonce", "defenum", "defprotocol", "defrecord", "deftype", "defmulti", "deftest",
+            "if-let", "when-let", "case", "cond", "for", "foreach", "binding",
+        )
+
+        previouslyMissing.forEach { name ->
+            assertTrue(validator.isKeyword(name, null), "'$name' is a Phel form and must read as a keyword")
+        }
+    }
+
+    @Test
+    fun `still marks the literals as keywords`() {
+        listOf("true", "false", "nil").forEach { name ->
+            assertTrue(validator.isKeyword(name, null), "'$name' is a literal, not a free name")
+        }
     }
 }

--- a/src/test/kotlin/org/phellang/unit/run/PhelJUnitXmlParserTest.kt
+++ b/src/test/kotlin/org/phellang/unit/run/PhelJUnitXmlParserTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.phellang.run.test.PhelJUnitXmlParser
 import org.phellang.run.test.PhelTestCase
+import org.phellang.run.test.PhelTestSuite
 
 /**
  * The JUnit XML `phel test --reporter=junit-xml` writes.
@@ -123,14 +124,14 @@ class PhelJUnitXmlParserTest {
     /** A run that crashed before writing anything must not surface as a parse error. */
     @Test
     fun `empty input yields an empty report`() {
-        assertTrue(parse("").isEmpty)
-        assertTrue(parse("   ").isEmpty)
+        assertEquals(emptyList<PhelTestSuite>(), parse("").suites)
+        assertEquals(emptyList<PhelTestSuite>(), parse("   ").suites)
     }
 
     /** Half-written XML from a killed process is likelier than a malformed reporter. */
     @Test
     fun `malformed xml yields an empty report rather than throwing`() {
-        assertTrue(parse("<testsuite name=\"s\"><testcase ").isEmpty)
+        assertEquals(emptyList<PhelTestSuite>(), parse("<testsuite name=\"s\"><testcase ").suites)
     }
 
     @Test
@@ -138,7 +139,7 @@ class PhelJUnitXmlParserTest {
         val report = parse("""<testsuite name="empty-suite"></testsuite>""")
 
         assertEquals(listOf("empty-suite"), report.suites.map { it.name })
-        assertTrue(report.isEmpty)
+        assertEquals(emptyList<PhelTestCase>(), report.suites.single().cases)
     }
 
     @Test

--- a/src/test/kotlin/org/phellang/unit/syntax/classification/PhelTokenClassifierTest.kt
+++ b/src/test/kotlin/org/phellang/unit/syntax/classification/PhelTokenClassifierTest.kt
@@ -131,45 +131,6 @@ class PhelTokenClassifierTest {
     }
 
     @Test
-    fun `individual classification methods should work correctly`() {
-        // Test comment classification
-        assertTrue(PhelTokenClassifier.isComment(PhelTypes.LINE_COMMENT))
-        assertTrue(PhelTokenClassifier.isComment(PhelTypes.FORM_COMMENT))
-        assertFalse(PhelTokenClassifier.isComment(PhelTypes.STRING))
-
-        // Test string classification
-        assertTrue(PhelTokenClassifier.isString(PhelTypes.STRING))
-        assertFalse(PhelTokenClassifier.isString(PhelTypes.NUMBER))
-
-        // Test number classification
-        assertTrue(PhelTokenClassifier.isNumber(PhelTypes.NUMBER))
-        assertTrue(PhelTokenClassifier.isNumber(PhelTypes.HEXNUM))
-        assertTrue(PhelTokenClassifier.isNumber(PhelTypes.BINNUM))
-        assertTrue(PhelTokenClassifier.isNumber(PhelTypes.OCTNUM))
-        assertTrue(PhelTokenClassifier.isNumber(PhelTypes.RADIXNUM))
-        assertTrue(PhelTokenClassifier.isNumber(PhelTypes.SYMBOLIC_NUM))
-        assertTrue(PhelTokenClassifier.isNumber(PhelTypes.RATIO))
-        assertFalse(PhelTokenClassifier.isNumber(PhelTypes.STRING))
-
-        // Test boolean classification
-        assertTrue(PhelTokenClassifier.isBoolean(PhelTypes.BOOL))
-        assertFalse(PhelTokenClassifier.isBoolean(PhelTypes.NIL))
-
-        // Test delimiter classification
-        assertTrue(PhelTokenClassifier.isParentheses(PhelTypes.PAREN1))
-        assertTrue(PhelTokenClassifier.isParentheses(PhelTypes.PAREN2))
-        assertFalse(PhelTokenClassifier.isParentheses(PhelTypes.BRACKET1))
-
-        assertTrue(PhelTokenClassifier.isBrackets(PhelTypes.BRACKET1))
-        assertTrue(PhelTokenClassifier.isBrackets(PhelTypes.BRACKET2))
-        assertFalse(PhelTokenClassifier.isBrackets(PhelTypes.PAREN1))
-
-        assertTrue(PhelTokenClassifier.isBraces(PhelTypes.BRACE1))
-        assertTrue(PhelTokenClassifier.isBraces(PhelTypes.BRACE2))
-        assertFalse(PhelTokenClassifier.isBraces(PhelTypes.BRACKET1))
-    }
-
-    @Test
     fun `classification should be consistent across multiple calls`() {
         val testTokens = listOf(
             PhelTypes.LINE_COMMENT,
@@ -203,41 +164,36 @@ class PhelTokenClassifierTest {
         }
     }
 
+    /** Each token type belongs to exactly one category, which is what makes the map lookup valid. */
     @Test
-    fun `classification methods should be mutually exclusive for different token types`() {
-        val testToken = PhelTypes.STRING
+    fun `a token classifies into exactly one category`() {
+        val sampled = listOf(
+            PhelTypes.STRING, PhelTypes.LINE_COMMENT, PhelTypes.NUMBER, PhelTypes.BOOL,
+            PhelTypes.PAREN1, PhelTypes.BRACKET1, PhelTypes.BRACE1, PhelTypes.HASH_BRACE,
+            PhelTypes.KEYWORD, PhelTypes.SYM, PhelTypes.HAT, PhelTypes.DOT,
+        )
 
-        // A string token should only be classified as string, not as other types
-        assertTrue(PhelTokenClassifier.isString(testToken))
-        assertFalse(PhelTokenClassifier.isComment(testToken))
-        assertFalse(PhelTokenClassifier.isNumber(testToken))
-        assertFalse(PhelTokenClassifier.isBoolean(testToken))
-        assertFalse(PhelTokenClassifier.isNil(testToken))
-        assertFalse(PhelTokenClassifier.isNan(testToken))
-        assertFalse(PhelTokenClassifier.isCharacter(testToken))
-        assertFalse(PhelTokenClassifier.isParentheses(testToken))
-        assertFalse(PhelTokenClassifier.isBrackets(testToken))
-        assertFalse(PhelTokenClassifier.isBraces(testToken))
-        assertFalse(PhelTokenClassifier.isQuote(testToken))
-        assertFalse(PhelTokenClassifier.isSyntaxQuote(testToken))
-        assertFalse(PhelTokenClassifier.isUnquote(testToken))
-        assertFalse(PhelTokenClassifier.isUnquoteSplicing(testToken))
-        assertFalse(PhelTokenClassifier.isKeyword(testToken))
-        assertFalse(PhelTokenClassifier.isMetadata(testToken))
-        assertFalse(PhelTokenClassifier.isDotOperator(testToken))
-        assertFalse(PhelTokenClassifier.isSymbol(testToken))
-        assertFalse(PhelTokenClassifier.isBadCharacter(testToken))
+        sampled.forEach { token ->
+            val matches = TokenCategory.entries.filter { PhelTokenClassifier.classifyToken(token) == it }
+            assertEquals(1, matches.size, "$token should land in exactly one category, got $matches")
+        }
     }
 
+    /**
+     * `#{` opens a set, but for styling it is a brace like any other.
+     *
+     * There used to be a dedicated `isSetOpener` predicate alongside an `isBraces` that excluded
+     * `HASH_BRACE` — a second, disagreeing encoding of the category map. The map is the only answer
+     * now, and this pins the one it gives.
+     */
     @Test
-    fun `set opener has a dedicated check method`() {
-        // Compound tokens have semantic check methods
-        assertTrue(PhelTokenClassifier.isSetOpener(PhelTypes.HASH_BRACE), "isSetOpener should recognize #{")
-
-        // But it classifies as its visual equivalent for styling
+    fun `the set opener is styled as a brace`() {
         assertEquals(TokenCategory.BRACES, PhelTokenClassifier.classifyToken(PhelTypes.HASH_BRACE))
+    }
 
-        // And it's NOT a regular brace
-        assertFalse(PhelTokenClassifier.isBraces(PhelTypes.HASH_BRACE), "#{ is a set opener, not a regular brace")
+    /** An unmapped token falls through to UNKNOWN rather than to a wrong category. */
+    @Test
+    fun `an unmapped token is unknown`() {
+        assertEquals(TokenCategory.UNKNOWN, PhelTokenClassifier.classifyToken(TokenType.WHITE_SPACE))
     }
 }


### PR DESCRIPTION
Takes the 16 findings from #281 that are **fixes** — real bugs, rule sets that had drifted apart, and dead code. The 7 that are **new subsystems** (parameter info, import optimizer, TODO indexing, smart enter, SVG icons, `SMTestLocator`, `ResolveCache`, bundle extraction) are left for follow-up issues, since each needs its own design.

Nine commits, each one finding-group, each independently reviewable.

## What was wrong

**The editor contradicted itself about indentation.** `PhelLineAnalyzer` counted only `(` and `)`, so Enter was blind to binding vectors, maps and sets: `(let [x 1` put the next line at the `let`'s level rather than inside its bindings, and a top-level `[` or `{` indented nothing at all. In the other direction `PhelBlock.CONTAINERS` omitted `HASH_FN` and the reader conditionals, so Reformat left the body of a `#(...)` flush left while Enter — counting the `(` inside `#(` — indented it. `PhelBlock`'s own doc names that disagreement as the thing to avoid. Neither read the Code Style indent size, which was hard-coded to two spaces.

The scanner also miscounted `\(` and `\)`, which are character literals: the lexer's `CHARACTER` rule ends in a catch-all `.`.

**`PhelSpecialForms` exists to stop per-feature copies of language knowledge drifting** — its own comment says so — and four copies had escaped it:

- `when-first` was missing from `LET_LIKE`. Signature `(when-first bindings & body)`, the same shape as `when-let`, so its binding was unresolved on go-to-definition, absent from local completion, never reported as unused or shadowed, and unrecognised by the parameter hints, all at once. Exactly what happened to `if-some` / `when-some` before.
- `doseq` was in `LET_LIKE` but not `VARIADIC_HEADS`; `cond->` / `cond->>` were threading heads to the arity inspection's own copy but not to `VARIADIC_HEADS`. Both were read positionally and hinted.
- The interop prefix triple existed as four copies, two character for character, plus a fifth `php/` literal.
- `PhelNamesValidator.RESERVED` was a fourth special-form list: `defstruct` but not `defstruct*`, and no `defonce`, `defenum`, `defprotocol`, `defrecord`, `deftype`, `defmulti`, `deftest`, `if-let`, `when-let`, `case`, `cond`, `for`, `foreach` or `binding`.

**Two "what is a symbol character" allowlists disagreed**, both narrower than the language: the completion char filter allowed `%` but not `.` or `\`, the rename validator allowed `.` and `'` but not `%`, neither allowed `\`. So typing the `.` of `.method` or the `\` of `\DateTime` closed the lookup on the very shorthands completion offers.

**Two index mutators disagreed about locking.** `removeFile` mutated the three maps unsynchronised while `refreshFileFromPsi` did the same work under `refreshLock`, and two threads really do reach them. And the PSI listener held its pending file in a single slot, so editing file A then file B before the scheduled pass overwrote A — and the already-set flag meant no second pass was queued, leaving A stale indefinitely.

**`PhelReference.bindToElement` returned its own element unchanged**, telling the platform a rebind succeeded while nothing moved.

**The `Phel.Paredit` group had no `<add-to-group>`**, so nine registered actions were reachable only by chord or Find Action.

## Structural, not just corrective

Where a fix was "add the missing name", it is instead "make the omission impossible":

- `VARIADIC_HEADS` now folds in `LET_LIKE`, `FUNCTION_DEFINING` and a new `THREADING` set rather than re-listing their members. Spelling the names twice is how they drifted.
- `PhelArityCallSite` reads `PhelSpecialForms.THREADING` instead of keeping its own copy.
- `PhelSymbolChars` mirrors the lexer's `ATOM_START` / `ATOM_CONT` classes, which are the only real answer, rather than a third guess at them.
- `PhelNamesValidator` reads `PhelSpecialForms` for its reserved words.

Two invariant tests now guard the containments (`every binding form is also a variadic head`, `every threading macro is also a variadic head`), so a future omission fails the build rather than shipping.

## Correction to the issue

**C1 was wrong: `cachedPerPsi` is not dead** — it has 12 call sites in 5 files. The audit grep searched for the filename `PhelPsiCaches`, which never appears in an import of a Kotlin top-level function. Caught while implementing, [corrected on the issue](https://github.com/phel-lang/phel-intellij-plugin/issues/281#issuecomment-5083274459), helper kept. Every other deadness claim was re-verified with a per-name reference count over all of `src/main` before deleting.

**A5 is deliberately out of scope.** `PhelTestConfigurationProducer` does not exist on `main`; it arrives with #280, so the space-in-path bug is only live on that branch. Fixing it here would conflict on merge. Raising it on #280 instead.

The final `ref` pass found one thing (a stray blank line left by the pairing cleanup); it is its own commit.

## Test plan

`./gradlew test` green — full suite, run after every commit.

New coverage, all of it written before the fix:

| Guard | Test |
|---|---|
| Enter indents inside `[`, `{`, `#{`, `#(` | `PhelEnterIndentationTest` (6 cases) |
| `\(` / `\)` are literals, not brackets | `PhelEnterIndentationTest` (2 cases) |
| Enter follows Code Style `INDENT_SIZE` | `PhelEnterIndentationTest` |
| Reformat indents `#(...)`, `#?(...)`, `#?@(...)` | `PhelFormattingModelBuilderTest` (3 cases) |
| `when-first` binds like `when-let` | `PhelSpecialFormsTest`, `PhelLocalSymbolCompletionTest`, `PhelUnusedLetBindingInspectionIntegrationTest` |
| binding forms ⊆ variadic heads | `PhelSpecialFormsTest` |
| threading macros ⊆ variadic heads | `PhelSpecialFormsTest` |
| symbol-character definition | `PhelSymbolCharsTest` (new) |
| char filter behaviour incl. `.` and `\` | `PhelCompletionCharFilterTest` (rewritten onto `acceptChar`) |
| validator accepts `%`, interop, PHP classes; reserves the missing forms | `PhelNamesValidatorTest` |
| every edited file is reindexed | `PhelPsiChangeListenerTest` (new) |
| paredit menu visible only in Phel files | `PhelPareditActionGroupTest` (new) |

`PhelPsiChangeListenerTest` was verified to fail against the old single-slot listener before the fix was restored, so it genuinely catches the regression. It registers the listener itself and forces the lazy full-project scan to completion before editing — otherwise the first read would rebuild from disk and pass whether the listener worked or not.

Parameter hints have no test harness in this repo, so the `cond->` guard is at the set level rather than end to end.

Manual (`./gradlew runIde`):

- Enter inside `(let [x 1` and `{:a 1`; set Code Style indent to 4 and confirm Enter follows.
- Reformat a file with `#(...)` and `#?(...)`.
- `(when-first [x [1 2 3]] x)` — `x` resolves, completes, reports unused when it is.
- Type `.` and `\` mid-completion; the lookup stays open.
- Right-click a `.phel` file shows the Phel Paredit submenu; a `.txt` file does not.

No `.flex` / `.bnf` / `NamespaceConfig.kt` changes, so no generator re-runs and no `src/main/gen/` churn. `ArchitectureBoundaryTest` stays green unchanged, which is what checks the new `language/psi` placements.

## Follow-ups to file

D2 (`SMTestLocator` + rerun-failed tests), D3 (parameter info, import optimizer, TODO indexing, smart enter, extract/safe-delete), D4 (SVG icon + dark variant), D5 (cache `PhelCliLocator` off the EDT), D6 (program-arguments field), D7 (`ResolveCache` on `PhelReference`), D8 (extract strings to `PhelBundle`).

Closes #281
