### PR TITLE
fix(run): keep a test path with a space in it intact

### DIFF
--- a/src/main/kotlin/org/phellang/run/PhelTestConfiguration.kt
+++ b/src/main/kotlin/org/phellang/run/PhelTestConfiguration.kt
@@ -33,7 +33,14 @@ class PhelTestConfiguration(
     name: String,
 ) : PhelCliRunConfiguration(project, factory, name) {
 
-    /** Space-separated paths, empty meaning the whole suite. */
+    /**
+     * Newline-separated paths, empty meaning the whole suite.
+     *
+     * One path per line rather than space-separated. The producer stores an *absolute* path, and on
+     * a project under `/Users/me/My Projects` splitting on spaces handed `phel test` two paths that
+     * do not exist. A path cannot contain a newline on any platform this targets, so a line break is
+     * the one separator that is always safe here.
+     */
     var testPaths: String = ""
 
     /**
@@ -69,7 +76,7 @@ class PhelTestConfiguration(
         return SMTestRunnerConnectionUtil.createConsole(properties.testFrameworkName, properties)
     }
 
-    fun paths(): List<String> = testPaths.split(' ', '\n').map(String::trim).filter(String::isNotEmpty)
+    fun paths(): List<String> = splitPaths(testPaths, '\n')
 
     /** File names rather than whole paths: the producer stores absolute ones, and the run widget is narrow. */
     override fun suggestedName(): String {
@@ -83,20 +90,42 @@ class PhelTestConfiguration(
 
     override fun writeExternal(element: Element) {
         super.writeExternal(element)
-        JDOMExternalizerUtil.writeField(element, TEST_PATHS_FIELD, testPaths)
+        JDOMExternalizerUtil.writeField(element, TEST_PATH_LINES_FIELD, testPaths)
         JDOMExternalizerUtil.writeField(element, TEST_NAME_FIELD, testName)
     }
 
+    /**
+     * The separator changed, so the key did too.
+     *
+     * A value under the old key was written when paths were space-separated, and is read with that
+     * rule: two paths typed into the old single-line field must keep meaning two paths rather than
+     * silently becoming one path with a space in it. Guessing from the value alone is not possible —
+     * `a.phel b.phel` and `/My Projects/a.phel` are the same shape — which is why this is a second
+     * key rather than a heuristic. Saving rewrites it in the new form.
+     */
     override fun readExternal(element: Element) {
         super.readExternal(element)
-        testPaths = JDOMExternalizerUtil.readField(element, TEST_PATHS_FIELD).orEmpty()
+
+        val lines = JDOMExternalizerUtil.readField(element, TEST_PATH_LINES_FIELD)
+        val legacy = JDOMExternalizerUtil.readField(element, LEGACY_SPACE_SEPARATED_PATHS_FIELD)
+
+        testPaths = when {
+            lines != null -> lines
+            legacy != null -> splitPaths(legacy, ' ', '\n').joinToString("\n")
+            else -> ""
+        }
+
         testName = JDOMExternalizerUtil.readField(element, TEST_NAME_FIELD).orEmpty()
     }
 
     private companion object {
         // Persisted in workspace.xml; append-only, so a configuration saved before TEST_NAME existed
         // still reads back as the whole-suite or whole-file run it was.
-        const val TEST_PATHS_FIELD = "TEST_PATHS"
+        const val TEST_PATH_LINES_FIELD = "TEST_PATH_LINES"
+        const val LEGACY_SPACE_SEPARATED_PATHS_FIELD = "TEST_PATHS"
         const val TEST_NAME_FIELD = "TEST_NAME"
     }
 }
+
+private fun splitPaths(value: String, vararg separators: Char): List<String> =
+    value.split(*separators).map(String::trim).filter(String::isNotEmpty)

--- a/src/main/kotlin/org/phellang/run/PhelTestConfiguration.kt
+++ b/src/main/kotlin/org/phellang/run/PhelTestConfiguration.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.options.SettingsEditor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.JDOMExternalizerUtil
+import com.intellij.util.execution.ParametersListUtil
 import org.jdom.Element
 import org.phellang.run.execution.PhelRunCommandLine
 import org.phellang.run.settings.PhelTestConfigurationEditor
@@ -34,12 +35,15 @@ class PhelTestConfiguration(
 ) : PhelCliRunConfiguration(project, factory, name) {
 
     /**
-     * Newline-separated paths, empty meaning the whole suite.
+     * The paths to run, empty meaning the whole suite, encoded as a parameter list.
      *
-     * One path per line rather than space-separated. The producer stores an *absolute* path, and on
-     * a project under `/Users/me/My Projects` splitting on spaces handed `phel test` two paths that
-     * do not exist. A path cannot contain a newline on any platform this targets, so a line break is
-     * the one separator that is always safe here.
+     * [ParametersListUtil] rather than a plain space-separated string: the producer stores an
+     * *absolute* path, and on a project under `/Users/me/My Projects` a bare space split handed
+     * `phel test` two paths that do not exist. `join` quotes what needs quoting and `parse` reads it
+     * back, which is the same encoding the platform's own program-arguments fields use.
+     *
+     * Values saved before the quoting existed still read correctly: `parse` treats an unquoted run
+     * of paths exactly as the old split did.
      */
     var testPaths: String = ""
 
@@ -76,7 +80,12 @@ class PhelTestConfiguration(
         return SMTestRunnerConnectionUtil.createConsole(properties.testFrameworkName, properties)
     }
 
-    fun paths(): List<String> = splitPaths(testPaths, '\n')
+    fun paths(): List<String> = ParametersListUtil.parse(testPaths)
+
+    /** Encodes [paths] into [testPaths], quoting any that need it. */
+    fun setPaths(paths: List<String>) {
+        testPaths = ParametersListUtil.join(paths)
+    }
 
     /** File names rather than whole paths: the producer stores absolute ones, and the run widget is narrow. */
     override fun suggestedName(): String {
@@ -90,42 +99,21 @@ class PhelTestConfiguration(
 
     override fun writeExternal(element: Element) {
         super.writeExternal(element)
-        JDOMExternalizerUtil.writeField(element, TEST_PATH_LINES_FIELD, testPaths)
+        JDOMExternalizerUtil.writeField(element, TEST_PATHS_FIELD, testPaths)
         JDOMExternalizerUtil.writeField(element, TEST_NAME_FIELD, testName)
     }
 
-    /**
-     * The separator changed, so the key did too.
-     *
-     * A value under the old key was written when paths were space-separated, and is read with that
-     * rule: two paths typed into the old single-line field must keep meaning two paths rather than
-     * silently becoming one path with a space in it. Guessing from the value alone is not possible —
-     * `a.phel b.phel` and `/My Projects/a.phel` are the same shape — which is why this is a second
-     * key rather than a heuristic. Saving rewrites it in the new form.
-     */
     override fun readExternal(element: Element) {
         super.readExternal(element)
-
-        val lines = JDOMExternalizerUtil.readField(element, TEST_PATH_LINES_FIELD)
-        val legacy = JDOMExternalizerUtil.readField(element, LEGACY_SPACE_SEPARATED_PATHS_FIELD)
-
-        testPaths = when {
-            lines != null -> lines
-            legacy != null -> splitPaths(legacy, ' ', '\n').joinToString("\n")
-            else -> ""
-        }
-
+        testPaths = JDOMExternalizerUtil.readField(element, TEST_PATHS_FIELD).orEmpty()
         testName = JDOMExternalizerUtil.readField(element, TEST_NAME_FIELD).orEmpty()
     }
 
     private companion object {
         // Persisted in workspace.xml; append-only, so a configuration saved before TEST_NAME existed
-        // still reads back as the whole-suite or whole-file run it was.
-        const val TEST_PATH_LINES_FIELD = "TEST_PATH_LINES"
-        const val LEGACY_SPACE_SEPARATED_PATHS_FIELD = "TEST_PATHS"
+        // still reads back as the whole-suite or whole-file run it was. The key survived the move to
+        // a quoted parameter list because `parse` reads the old unquoted values unchanged.
+        const val TEST_PATHS_FIELD = "TEST_PATHS"
         const val TEST_NAME_FIELD = "TEST_NAME"
     }
 }
-
-private fun splitPaths(value: String, vararg separators: Char): List<String> =
-    value.split(*separators).map(String::trim).filter(String::isNotEmpty)

--- a/src/main/kotlin/org/phellang/run/PhelTestConfigurationProducer.kt
+++ b/src/main/kotlin/org/phellang/run/PhelTestConfigurationProducer.kt
@@ -34,7 +34,9 @@ class PhelTestConfigurationProducer : LazyRunConfigurationProducer<PhelCliRunCon
         val testConfiguration = configuration as? PhelTestConfiguration ?: return false
         val location = locate(context) ?: return false
 
-        testConfiguration.testPaths = location.path
+        // Encoded, not assigned raw: an absolute path under a directory with a space in its name is
+        // ordinary, and the field holds a parameter list.
+        testConfiguration.setPaths(listOf(location.path))
         testConfiguration.testName = location.testName
         testConfiguration.workingDirectory = context.project.basePath.orEmpty()
         testConfiguration.setName(testConfiguration.suggestedName())
@@ -53,7 +55,9 @@ class PhelTestConfigurationProducer : LazyRunConfigurationProducer<PhelCliRunCon
         val testConfiguration = configuration as? PhelTestConfiguration ?: return false
         val location = locate(context) ?: return false
 
-        return testConfiguration.testPaths == location.path && testConfiguration.testName == location.testName
+        // Compared decoded, so a configuration saved before the quoting still matches its context.
+        return testConfiguration.paths() == listOf(location.path) &&
+                testConfiguration.testName == location.testName
     }
 
     private fun locate(context: ConfigurationContext): TestLocation? {

--- a/src/main/kotlin/org/phellang/run/settings/PhelTestConfigurationEditor.kt
+++ b/src/main/kotlin/org/phellang/run/settings/PhelTestConfigurationEditor.kt
@@ -1,10 +1,10 @@
 package org.phellang.run.settings
 
 import com.intellij.ui.components.JBLabel
-import com.intellij.ui.components.JBScrollPane
-import com.intellij.ui.components.JBTextArea
 import com.intellij.ui.components.JBTextField
+import com.intellij.ui.components.fields.ExpandableTextField
 import com.intellij.openapi.project.Project
+import com.intellij.util.execution.ParametersListUtil
 import com.intellij.util.ui.FormBuilder
 import org.phellang.run.PhelTestConfiguration
 import javax.swing.JPanel
@@ -13,11 +13,13 @@ class PhelTestConfigurationEditor(project: Project) :
     PhelWorkingDirectoryEditor<PhelTestConfiguration>(project, "Directory tests run in; defaults to the project root") {
 
     /**
-     * A text area rather than a single-line field: paths are separated by line breaks, so the user
-     * has to be able to type one. They used to be space-separated, which broke every path with a
-     * space in it.
+     * Expandable, and encoded as a parameter list.
+     *
+     * Collapsed it is one line with quoting; expanded it is one path per line, which is how a path
+     * containing a space can be typed at all. The same pairing the platform's own program-argument
+     * fields use, so the quoting the configuration stores and the quoting shown here cannot diverge.
      */
-    private val pathsField = JBTextArea(PATH_FIELD_ROWS, 0)
+    private val pathsField = ExpandableTextField(ParametersListUtil::parse, ParametersListUtil::join)
 
     /** Editable so a configuration created from a `deftest` gutter icon survives a trip through the dialog. */
     private val testNameField = JBTextField()
@@ -35,12 +37,8 @@ class PhelTestConfigurationEditor(project: Project) :
     }
 
     override fun buildPanel(): JPanel = FormBuilder.createFormBuilder()
-        .addLabeledComponent(JBLabel("Paths, one per line (blank runs everything):"), JBScrollPane(pathsField), true)
+        .addLabeledComponent(JBLabel("Paths (blank runs everything):"), pathsField, true)
         .addLabeledComponent(JBLabel("Test name (blank runs every test in scope):"), testNameField, true)
         .addLabeledComponent(JBLabel("Working directory:"), workingDirectoryField, true)
         .panel
-
-    private companion object {
-        const val PATH_FIELD_ROWS = 3
-    }
 }

--- a/src/main/kotlin/org/phellang/run/settings/PhelTestConfigurationEditor.kt
+++ b/src/main/kotlin/org/phellang/run/settings/PhelTestConfigurationEditor.kt
@@ -1,6 +1,8 @@
 package org.phellang.run.settings
 
 import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.components.JBTextArea
 import com.intellij.ui.components.JBTextField
 import com.intellij.openapi.project.Project
 import com.intellij.util.ui.FormBuilder
@@ -10,7 +12,12 @@ import javax.swing.JPanel
 class PhelTestConfigurationEditor(project: Project) :
     PhelWorkingDirectoryEditor<PhelTestConfiguration>(project, "Directory tests run in; defaults to the project root") {
 
-    private val pathsField = JBTextField()
+    /**
+     * A text area rather than a single-line field: paths are separated by line breaks, so the user
+     * has to be able to type one. They used to be space-separated, which broke every path with a
+     * space in it.
+     */
+    private val pathsField = JBTextArea(PATH_FIELD_ROWS, 0)
 
     /** Editable so a configuration created from a `deftest` gutter icon survives a trip through the dialog. */
     private val testNameField = JBTextField()
@@ -28,8 +35,12 @@ class PhelTestConfigurationEditor(project: Project) :
     }
 
     override fun buildPanel(): JPanel = FormBuilder.createFormBuilder()
-        .addLabeledComponent(JBLabel("Paths (blank runs everything):"), pathsField, true)
+        .addLabeledComponent(JBLabel("Paths, one per line (blank runs everything):"), JBScrollPane(pathsField), true)
         .addLabeledComponent(JBLabel("Test name (blank runs every test in scope):"), testNameField, true)
         .addLabeledComponent(JBLabel("Working directory:"), workingDirectoryField, true)
         .panel
+
+    private companion object {
+        const val PATH_FIELD_ROWS = 3
+    }
 }

--- a/src/test/kotlin/org/phellang/integration/run/PhelReplAndTestConfigurationTest.kt
+++ b/src/test/kotlin/org/phellang/integration/run/PhelReplAndTestConfigurationTest.kt
@@ -67,8 +67,8 @@ class PhelReplAndTestConfigurationTest : PhelIntegrationTestCase() {
         assertEquals("All tests", configuration.suggestedName())
     }
 
-    fun testTestConfigurationSplitsPathsOnWhitespace() {
-        val configuration = testConfiguration().apply { testPaths = "tests/a.phel   tests/b.phel" }
+    fun testTestConfigurationSplitsPathsOnLineBreaks() {
+        val configuration = testConfiguration().apply { testPaths = "tests/a.phel\ntests/b.phel" }
 
         assertEquals(listOf("tests/a.phel", "tests/b.phel"), configuration.paths())
     }
@@ -77,6 +77,28 @@ class PhelReplAndTestConfigurationTest : PhelIntegrationTestCase() {
         val configuration = testConfiguration().apply { testPaths = "  \n tests/a.phel \n " }
 
         assertEquals(listOf("tests/a.phel"), configuration.paths())
+    }
+
+    /**
+     * The bug: a path is one path however many spaces are in it.
+     *
+     * The producer stores an absolute path, so on a project under `/Users/me/My Projects` the
+     * space-separated split handed `phel test` two paths that do not exist.
+     */
+    fun testTestConfigurationKeepsAPathContainingSpacesIntact() {
+        val spaced = "/Users/me/My Projects/app/tests/html.phel"
+        val configuration = testConfiguration().apply { testPaths = spaced }
+
+        assertEquals(listOf(spaced), configuration.paths())
+        assertEquals("Tests: html.phel", configuration.suggestedName())
+    }
+
+    fun testTestConfigurationNamesItselfAfterSeveralSpacedPaths() {
+        val configuration = testConfiguration().apply {
+            testPaths = "/My Projects/app/tests/a.phel\n/My Projects/app/tests/b.phel"
+        }
+
+        assertEquals("Tests: a.phel b.phel", configuration.suggestedName())
     }
 
     /** File names, not whole paths: the producer stores absolute ones and the run widget is narrow. */
@@ -138,6 +160,50 @@ class PhelReplAndTestConfigurationTest : PhelIntegrationTestCase() {
 
         assertEquals("tests/a.phel", loaded.testPaths)
         assertEquals("", loaded.testName)
+    }
+
+    /**
+     * A configuration saved under the old space-separated key keeps meaning what it meant.
+     *
+     * Splitting on spaces is what this change removes, so the legacy key is read with the legacy
+     * rule rather than reinterpreted: two paths typed into the old single-line field must not
+     * silently become one path with a space in it.
+     */
+    fun testTestConfigurationMigratesLegacySpaceSeparatedPaths() {
+        val element = Element("configuration")
+        com.intellij.openapi.util.JDOMExternalizerUtil.writeField(
+            element, "TEST_PATHS", "tests/a.phel tests/b.phel"
+        )
+
+        val loaded = testConfiguration()
+        loaded.readExternal(element)
+
+        assertEquals(listOf("tests/a.phel", "tests/b.phel"), loaded.paths())
+    }
+
+    /** Once migrated, it is written back in the unambiguous form and never space-split again. */
+    fun testTestConfigurationRewritesLegacyPathsInTheNewForm() {
+        val legacy = Element("configuration")
+        com.intellij.openapi.util.JDOMExternalizerUtil.writeField(
+            legacy, "TEST_PATHS", "tests/a.phel tests/b.phel"
+        )
+        val migrated = testConfiguration().apply { readExternal(legacy) }
+
+        val resaved = Element("configuration")
+        migrated.writeExternal(resaved)
+
+        val reloaded = testConfiguration().apply { readExternal(resaved) }
+        assertEquals(listOf("tests/a.phel", "tests/b.phel"), reloaded.paths())
+    }
+
+    fun testTestConfigurationRoundTripsASpacedPathThroughXml() {
+        val spaced = "/Users/me/My Projects/app/tests/html.phel"
+        val element = Element("configuration")
+        testConfiguration().apply { testPaths = spaced }.writeExternal(element)
+
+        val loaded = testConfiguration().apply { readExternal(element) }
+
+        assertEquals(listOf(spaced), loaded.paths())
     }
 
     /** Neither can run without a binary, and both must say so before launching. */

--- a/src/test/kotlin/org/phellang/integration/run/PhelReplAndTestConfigurationTest.kt
+++ b/src/test/kotlin/org/phellang/integration/run/PhelReplAndTestConfigurationTest.kt
@@ -67,8 +67,8 @@ class PhelReplAndTestConfigurationTest : PhelIntegrationTestCase() {
         assertEquals("All tests", configuration.suggestedName())
     }
 
-    fun testTestConfigurationSplitsPathsOnLineBreaks() {
-        val configuration = testConfiguration().apply { testPaths = "tests/a.phel\ntests/b.phel" }
+    fun testTestConfigurationSplitsSeveralPaths() {
+        val configuration = testConfiguration().apply { setPaths(listOf("tests/a.phel", "tests/b.phel")) }
 
         assertEquals(listOf("tests/a.phel", "tests/b.phel"), configuration.paths())
     }
@@ -87,7 +87,7 @@ class PhelReplAndTestConfigurationTest : PhelIntegrationTestCase() {
      */
     fun testTestConfigurationKeepsAPathContainingSpacesIntact() {
         val spaced = "/Users/me/My Projects/app/tests/html.phel"
-        val configuration = testConfiguration().apply { testPaths = spaced }
+        val configuration = testConfiguration().apply { setPaths(listOf(spaced)) }
 
         assertEquals(listOf(spaced), configuration.paths())
         assertEquals("Tests: html.phel", configuration.suggestedName())
@@ -95,7 +95,7 @@ class PhelReplAndTestConfigurationTest : PhelIntegrationTestCase() {
 
     fun testTestConfigurationNamesItselfAfterSeveralSpacedPaths() {
         val configuration = testConfiguration().apply {
-            testPaths = "/My Projects/app/tests/a.phel\n/My Projects/app/tests/b.phel"
+            setPaths(listOf("/My Projects/app/tests/a.phel", "/My Projects/app/tests/b.phel"))
         }
 
         assertEquals("Tests: a.phel b.phel", configuration.suggestedName())
@@ -163,13 +163,12 @@ class PhelReplAndTestConfigurationTest : PhelIntegrationTestCase() {
     }
 
     /**
-     * A configuration saved under the old space-separated key keeps meaning what it meant.
+     * A value saved before the quoting existed still means what it meant.
      *
-     * Splitting on spaces is what this change removes, so the legacy key is read with the legacy
-     * rule rather than reinterpreted: two paths typed into the old single-line field must not
-     * silently become one path with a space in it.
+     * `parse` reads an unquoted run of paths exactly as the old space split did, which is what let
+     * the persistence key stay the same across the change.
      */
-    fun testTestConfigurationMigratesLegacySpaceSeparatedPaths() {
+    fun testTestConfigurationStillReadsUnquotedLegacyPaths() {
         val element = Element("configuration")
         com.intellij.openapi.util.JDOMExternalizerUtil.writeField(
             element, "TEST_PATHS", "tests/a.phel tests/b.phel"
@@ -181,25 +180,10 @@ class PhelReplAndTestConfigurationTest : PhelIntegrationTestCase() {
         assertEquals(listOf("tests/a.phel", "tests/b.phel"), loaded.paths())
     }
 
-    /** Once migrated, it is written back in the unambiguous form and never space-split again. */
-    fun testTestConfigurationRewritesLegacyPathsInTheNewForm() {
-        val legacy = Element("configuration")
-        com.intellij.openapi.util.JDOMExternalizerUtil.writeField(
-            legacy, "TEST_PATHS", "tests/a.phel tests/b.phel"
-        )
-        val migrated = testConfiguration().apply { readExternal(legacy) }
-
-        val resaved = Element("configuration")
-        migrated.writeExternal(resaved)
-
-        val reloaded = testConfiguration().apply { readExternal(resaved) }
-        assertEquals(listOf("tests/a.phel", "tests/b.phel"), reloaded.paths())
-    }
-
     fun testTestConfigurationRoundTripsASpacedPathThroughXml() {
         val spaced = "/Users/me/My Projects/app/tests/html.phel"
         val element = Element("configuration")
-        testConfiguration().apply { testPaths = spaced }.writeExternal(element)
+        testConfiguration().apply { setPaths(listOf(spaced)) }.writeExternal(element)
 
         val loaded = testConfiguration().apply { readExternal(element) }
 

--- a/src/test/kotlin/org/phellang/integration/run/PhelRunCommandLineTest.kt
+++ b/src/test/kotlin/org/phellang/integration/run/PhelRunCommandLineTest.kt
@@ -104,6 +104,15 @@ class PhelRunCommandLineTest : PhelIntegrationTestCase() {
         assertTrue(command.indexOf("--reporter=junit-xml") < command.indexOf("tests/a.phel"))
     }
 
+    /** A path with a space in it is still one argument, not two. */
+    fun testTestPassesASpacedPathAsASingleArgument() {
+        val spaced = "/Users/me/My Projects/app/tests/html.phel"
+
+        val command = PhelRunCommandLine.test(binary, listOf(spaced), workingDir).getCommandLineList(null)
+
+        assertEquals(listOf(binary.absolutePath, "test", spaced), command)
+    }
+
     fun testTestOmitsSelectorsWhenNoneAreGiven() {
         val command = PhelRunCommandLine.test(binary, listOf("tests/a.phel"), workingDir).getCommandLineList(null)
 

--- a/src/test/kotlin/org/phellang/integration/run/PhelTestConfigurationProducerTest.kt
+++ b/src/test/kotlin/org/phellang/integration/run/PhelTestConfigurationProducerTest.kt
@@ -47,7 +47,10 @@ class PhelTestConfigurationProducerTest : PhelIntegrationTestCase() {
     fun testATestFileProducesATestConfiguration() {
         val configuration = testConfigurationAt(testFile, "(ns")
 
-        assertTrue(configuration.testPaths.endsWith("html.phel"))
+        // Decoded: the field holds a parameter list, and the fixture's path may contain a space.
+        val paths = configuration.paths()
+        assertEquals(1, paths.size)
+        assertTrue("expected a single path ending in html.phel, got $paths", paths.single().endsWith("html.phel"))
     }
 
     /** Outside any `deftest`, the whole file runs, so no filter is set. */


### PR DESCRIPTION
A test run started from the gutter broke on any project whose path contains a space.

`PhelTestConfiguration.testPaths` was space-separated, and `PhelTestConfigurationProducer` writes an *absolute* path into it. On a project under `/Users/me/My Projects`, `paths()` yielded `["/Users/me/My", "Projects/app/tests/foo.phel"]` and `phel test` was handed two paths that do not exist. The run widget label was mangled the same way, since `suggestedName()` splits before taking `File(it).name`.

The space-separated storage predates the producer and was fine while a human typed the field. It stopped being round-trip safe the moment something began writing absolute paths into it automatically, which #280 introduced. Raised on that PR while it was open, merged before it was picked up, so it is live on `main`.

## Approach

Paths are now encoded with `ParametersListUtil` — the same encoding the platform's own program-argument fields use. `join` quotes what needs quoting, `parse` reads it back.

Two consequences worth calling out:

- **The persistence key is unchanged.** `parse` reads an unquoted legacy value exactly as the old space split did, so a saved configuration keeps meaning what it meant with no migration branch and no second key.
- **The editor stays a single-line field**, now `ExpandableTextField`, so a path with a space can be typed one per line in the expanded view while the collapsed view stays compact.

The producer encodes on write and `isConfigurationFromContext` compares decoded, so neither depends on the spelling — a configuration saved before the quoting still matches its context.

The first commit fixed this with a hand-rolled newline separator, a second persistence key and a migration branch. The refactor pass replaced all three with the platform utility; both commits are kept so the reasoning is visible.

## Test plan

`./gradlew test` green.

| Guard | Test |
|---|---|
| a spaced path stays one path | `PhelReplAndTestConfigurationTest.testTestConfigurationKeepsAPathContainingSpacesIntact` |
| the run widget label survives it | same test, plus `...NamesItselfAfterSeveralSpacedPaths` |
| it reaches `phel test` as one argument | `PhelRunCommandLineTest.testTestPassesASpacedPathAsASingleArgument` |
| it survives the XML round trip | `...RoundTripsASpacedPathThroughXml` |
| legacy unquoted values still parse | `...StillReadsUnquotedLegacyPaths` |
| the producer stores a single decoded path | `PhelTestConfigurationProducerTest.testATestFileProducesATestConfiguration` |

Manual (`./gradlew runIde`): open a project under a directory with a space in its name, click the gutter icon on a `deftest`, confirm the run succeeds and the test tree populates. Open the configuration, expand the Paths field, confirm the path shows intact on one line.

Closes #290