### PR TITLE
feat(run): pass program arguments to the script

### DIFF
--- a/src/main/kotlin/org/phellang/run/PhelRunConfiguration.kt
+++ b/src/main/kotlin/org/phellang/run/PhelRunConfiguration.kt
@@ -7,6 +7,7 @@ import com.intellij.execution.configurations.RuntimeConfigurationError
 import com.intellij.openapi.options.SettingsEditor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.JDOMExternalizerUtil
+import com.intellij.util.execution.ParametersListUtil
 import org.jdom.Element
 import org.phellang.run.execution.PhelRunCommandLine
 import org.phellang.run.settings.PhelRunConfigurationEditor
@@ -21,10 +22,21 @@ class PhelRunConfiguration(
 
     var scriptPath: String = ""
 
+    /**
+     * Arguments passed to the script, encoded as a parameter list.
+     *
+     * `phel run` forwards these to the script, where they arrive as `*argv*`. Encoded rather than
+     * split on spaces so an argument may contain one, the same way [PhelTestConfiguration] holds its
+     * paths.
+     */
+    var programArguments: String = ""
+
+    fun arguments(): List<String> = ParametersListUtil.parse(programArguments)
+
     override fun getConfigurationEditor(): SettingsEditor<out RunConfiguration> = PhelRunConfigurationEditor(project)
 
     override fun commandLine(binary: File): GeneralCommandLine =
-        PhelRunCommandLine.run(binary, scriptPath, effectiveWorkingDirectory())
+        PhelRunCommandLine.run(binary, scriptPath, effectiveWorkingDirectory(), arguments())
 
     override fun checkConfiguration() {
         if (scriptPath.isBlank()) {
@@ -41,14 +53,19 @@ class PhelRunConfiguration(
     override fun writeExternal(element: Element) {
         super.writeExternal(element)
         JDOMExternalizerUtil.writeField(element, SCRIPT_PATH_FIELD, scriptPath)
+        JDOMExternalizerUtil.writeField(element, PROGRAM_ARGUMENTS_FIELD, programArguments)
     }
 
     override fun readExternal(element: Element) {
         super.readExternal(element)
         scriptPath = JDOMExternalizerUtil.readField(element, SCRIPT_PATH_FIELD).orEmpty()
+        programArguments = JDOMExternalizerUtil.readField(element, PROGRAM_ARGUMENTS_FIELD).orEmpty()
     }
 
     private companion object {
+        // Persisted in workspace.xml; append-only, so a configuration saved before PROGRAM_ARGUMENTS
+        // existed still reads back as the plain script run it was.
         const val SCRIPT_PATH_FIELD = "SCRIPT_PATH"
+        const val PROGRAM_ARGUMENTS_FIELD = "PROGRAM_ARGUMENTS"
     }
 }

--- a/src/main/kotlin/org/phellang/run/execution/PhelRunCommandLine.kt
+++ b/src/main/kotlin/org/phellang/run/execution/PhelRunCommandLine.kt
@@ -18,8 +18,24 @@ import java.nio.charset.StandardCharsets
  */
 object PhelRunCommandLine {
 
-    fun run(binary: File, scriptPath: String, workingDirectory: String): GeneralCommandLine =
-        command(binary, "run", listOf(scriptPath), workingDirectory)
+    /**
+     * `phel run [options] [--] <path> [<argv>...]`, so [arguments] follow the script.
+     *
+     * The `--` is emitted only when there are arguments, and it is what makes them safe: an argument
+     * of `-v` would otherwise be read as an option to `phel` itself rather than passed through to the
+     * script. With no arguments there is nothing to guard, and the command stays as short as the one
+     * a user already reads in the console.
+     */
+    fun run(
+        binary: File,
+        scriptPath: String,
+        workingDirectory: String,
+        arguments: List<String> = emptyList(),
+    ): GeneralCommandLine {
+        val positional = if (arguments.isEmpty()) listOf(scriptPath) else listOf(END_OF_OPTIONS, scriptPath) + arguments
+
+        return command(binary, "run", positional, workingDirectory)
+    }
 
     fun repl(binary: File, workingDirectory: String): GeneralCommandLine =
         command(binary, "repl", emptyList(), workingDirectory)
@@ -84,6 +100,9 @@ object PhelRunCommandLine {
     const val OUTPUT_OPTION = "--output="
 
     private const val FILTER_OPTION = "--filter="
+
+    /** Everything after this is positional, whatever it starts with. */
+    private const val END_OF_OPTIONS = "--"
 
     private fun command(
         binary: File,

--- a/src/main/kotlin/org/phellang/run/settings/PhelRunConfigurationEditor.kt
+++ b/src/main/kotlin/org/phellang/run/settings/PhelRunConfigurationEditor.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
 import com.intellij.openapi.options.SettingsEditor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
+import com.intellij.ui.RawCommandLineEditor
 import com.intellij.ui.components.JBLabel
 import com.intellij.util.ui.FormBuilder
 import org.phellang.run.PhelRunConfiguration
@@ -21,6 +22,13 @@ class PhelRunConfigurationEditor(private val project: Project) : SettingsEditor<
         )
     }
 
+    /**
+     * The platform's own program-arguments component: a single line that expands, parsing and
+     * quoting with the same [com.intellij.util.execution.ParametersListUtil] encoding the
+     * configuration stores, so what is typed and what is stored cannot diverge.
+     */
+    private val programArgumentsField = RawCommandLineEditor()
+
     private val workingDirectoryField = TextFieldWithBrowseButton().apply {
         addBrowseFolderListener(
             "Working Directory",
@@ -32,11 +40,13 @@ class PhelRunConfigurationEditor(private val project: Project) : SettingsEditor<
 
     override fun resetEditorFrom(configuration: PhelRunConfiguration) {
         scriptPathField.text = configuration.scriptPath
+        programArgumentsField.text = configuration.programArguments
         workingDirectoryField.text = configuration.workingDirectory
     }
 
     override fun applyEditorTo(configuration: PhelRunConfiguration) {
         configuration.scriptPath = scriptPathField.text.trim()
+        configuration.programArguments = programArgumentsField.text.trim()
         configuration.workingDirectory = workingDirectoryField.text.trim()
     }
 
@@ -44,6 +54,7 @@ class PhelRunConfigurationEditor(private val project: Project) : SettingsEditor<
 
     private val panel: JPanel = FormBuilder.createFormBuilder()
         .addLabeledComponent(JBLabel("Phel file:"), scriptPathField, true)
+        .addLabeledComponent(JBLabel("Program arguments:"), programArgumentsField, true)
         .addLabeledComponent(JBLabel("Working directory:"), workingDirectoryField, true)
         .panel
 }

--- a/src/test/kotlin/org/phellang/integration/run/PhelRunCommandLineTest.kt
+++ b/src/test/kotlin/org/phellang/integration/run/PhelRunCommandLineTest.kt
@@ -25,6 +25,31 @@ class PhelRunCommandLineTest : PhelIntegrationTestCase() {
         assertEquals(listOf(binary.absolutePath, "run", script), command)
     }
 
+    /**
+     * `phel run [options] [--] <path> [<argv>...]`, so arguments follow the script.
+     *
+     * The `--` guards them: an argument of `-v` would otherwise be read as an option to `phel`
+     * itself rather than passed through to the script.
+     */
+    fun testInvokesRunWithProgramArguments() {
+        val command = PhelRunCommandLine.run(binary, script, workingDir, listOf("alpha", "-v")).getCommandLineList(null)
+
+        assertEquals(listOf(binary.absolutePath, "run", "--", script, "alpha", "-v"), command)
+    }
+
+    /** No arguments, no separator: the command a user reads in the console stays as short as it was. */
+    fun testInvokesRunWithoutASeparatorWhenThereAreNoArguments() {
+        val command = PhelRunCommandLine.run(binary, script, workingDir, emptyList()).getCommandLineList(null)
+
+        assertEquals(listOf(binary.absolutePath, "run", script), command)
+    }
+
+    fun testProgramArgumentsKeepSpacesInsideOneArgument() {
+        val command = PhelRunCommandLine.run(binary, script, workingDir, listOf("two words")).getCommandLineList(null)
+
+        assertEquals(listOf(binary.absolutePath, "run", "--", script, "two words"), command)
+    }
+
     fun testRunsInTheGivenWorkingDirectory() {
         val commandLine = PhelRunCommandLine.run(binary, script, workingDir)
 

--- a/src/test/kotlin/org/phellang/integration/run/PhelRunConfigurationTest.kt
+++ b/src/test/kotlin/org/phellang/integration/run/PhelRunConfigurationTest.kt
@@ -38,6 +38,55 @@ class PhelRunConfigurationTest : PhelIntegrationTestCase() {
 
         assertEquals("", loaded.scriptPath)
         assertEquals("", loaded.workingDirectory)
+        assertEmpty(loaded.arguments())
+    }
+
+    // ---- program arguments ----
+
+    fun testPassesNoArgumentsByDefault() {
+        assertEmpty(newConfiguration().arguments())
+    }
+
+    fun testSplitsProgramArguments() {
+        val configuration = newConfiguration().apply { programArguments = "alpha beta" }
+
+        assertEquals(listOf("alpha", "beta"), configuration.arguments())
+    }
+
+    /** Quoted, so an argument is one argument however many spaces are in it. */
+    fun testKeepsAQuotedArgumentWhole() {
+        val configuration = newConfiguration().apply { programArguments = "\"two words\" beta" }
+
+        assertEquals(listOf("two words", "beta"), configuration.arguments())
+    }
+
+    fun testRoundTripsProgramArgumentsThroughXml() {
+        val saved = newConfiguration().apply {
+            scriptPath = "/project/src/main.phel"
+            programArguments = "\"two words\" -v"
+        }
+        val element = Element("configuration")
+        saved.writeExternal(element)
+
+        val loaded = newConfiguration()
+        loaded.readExternal(element)
+
+        assertEquals(listOf("two words", "-v"), loaded.arguments())
+    }
+
+    /**
+     * The key is append-only: a configuration saved before program arguments existed must load as
+     * the plain script run it was, rather than failing to read.
+     */
+    fun testLoadsAnElementSavedBeforeProgramArgumentsExisted() {
+        val element = Element("configuration")
+        com.intellij.openapi.util.JDOMExternalizerUtil.writeField(element, "SCRIPT_PATH", "/project/src/main.phel")
+
+        val loaded = newConfiguration()
+        loaded.readExternal(element)
+
+        assertEquals("/project/src/main.phel", loaded.scriptPath)
+        assertEmpty(loaded.arguments())
     }
 
     fun testRejectsAnUnsetScript() {


### PR DESCRIPTION
`phel run [options] [--] <path> [<argv>...]` forwards arguments to the script, where they arrive as `*argv*` — a real registry binding. The run configuration exposed only a script path and a working directory, so there was no way to pass any from the IDE.

## Approach

`programArguments` is encoded as a parameter list with `ParametersListUtil`, the same encoding test paths moved to in #291, so an argument may contain a space. The editor uses `RawCommandLineEditor`, the platform's own component for this field, which parses and quotes with that same encoding — so what is typed and what is stored cannot diverge.

The `--` separator is emitted **only when there are arguments**. It is what makes them safe: an argument of `-v` would otherwise be read as an option to `phel` itself rather than passed through. With no arguments there is nothing to guard, and the command stays as short as the one a user already reads in the console — which also keeps the existing command shape untouched for every current configuration.

`PROGRAM_ARGUMENTS` is a new persistence key, append-only, so a configuration saved before it existed still loads as the plain script run it was.

The mandatory refactor pass over the touched files surfaced nothing to change, so there is no `ref` commit on this branch.

## Test plan

`./gradlew test` green.

| Guard | Test |
|---|---|
| arguments follow the script, after `--` | `PhelRunCommandLineTest.testInvokesRunWithProgramArguments` |
| no arguments means no separator | `...testInvokesRunWithoutASeparatorWhenThereAreNoArguments` |
| a quoted argument stays one argument | `...testProgramArgumentsKeepSpacesInsideOneArgument`, `PhelRunConfigurationTest.testKeepsAQuotedArgumentWhole` |
| plain splitting still works | `PhelRunConfigurationTest.testSplitsProgramArguments` |
| survives the XML round trip | `...testRoundTripsProgramArgumentsThroughXml` |
| configurations saved before the field load fine | `...testLoadsAnElementSavedBeforeProgramArgumentsExisted` |
| default is no arguments | `...testPassesNoArgumentsByDefault` |

**Worth checking manually**, since there is no `phel` binary in CI: the `--` handling is taken from the grammar recorded in `PhelRunCommandLine`'s doc comment (`run [options] [--] <path> [<argv>...]`, from https://phel-lang.org/documentation/tooling/cli-commands/), not from running the CLI. In `./gradlew runIde`, set Program arguments to `alpha "two words" -v` on a script that prints `*argv*`, and confirm all three arrive intact and `phel` does not try to interpret `-v` itself.

Closes #287