### PR TITLE
perf(psi): cache symbol resolution, 1.3ms per symbol to 10us

### DIFF
--- a/src/main/kotlin/org/phellang/language/psi/impl/PhelNamedElementImpl.kt
+++ b/src/main/kotlin/org/phellang/language/psi/impl/PhelNamedElementImpl.kt
@@ -4,7 +4,9 @@ import com.intellij.lang.ASTNode
 import com.intellij.navigation.ItemPresentation
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiNameIdentifierOwner
+import com.intellij.openapi.util.Key
 import com.intellij.psi.PsiReference
+import com.intellij.psi.util.CachedValue
 import com.intellij.util.IncorrectOperationException
 import org.jetbrains.annotations.NonNls
 import org.phellang.language.psi.PhelPsiFactory
@@ -13,6 +15,7 @@ import org.phellang.language.psi.analysis.PhelSymbolAnalyzer
 import org.phellang.language.psi.navigation.PhelItemPresentation
 import org.phellang.language.psi.references.PhelReference
 import org.phellang.language.psi.utils.PhelPsiUtils
+import org.phellang.language.psi.utils.cachedPerPsi
 
 /**
  * Base implementation for named Phel elements that can be referenced and renamed.
@@ -31,12 +34,20 @@ abstract class PhelNamedElementImpl(node: ASTNode) : PhelSFormImpl(node), PsiNam
 
     override fun getNameIdentifier(): PsiElement? = this
 
+    /**
+     * One reference instance per element, until the PSI changes.
+     *
+     * This built a fresh [PhelReference] on every call, which is a problem twice over:
+     * [PhelSymbolAnalyzer.isDefinition] was recomputed each time, and `ResolveCache` keys on the
+     * reference, so a new instance meant the resolve cache could never hit. Caching the reference is
+     * what makes caching the resolution possible at all.
+     */
     override fun getReference(): PsiReference? {
-        if (this is PhelSymbol) {
-            val isDefinition = PhelSymbolAnalyzer.isDefinition(this)
-            return PhelReference(this, findUsages = isDefinition)
+        if (this !is PhelSymbol) return null
+
+        return cachedPerPsi(this, REFERENCE_KEY) {
+            PhelReference(this, findUsages = PhelSymbolAnalyzer.isDefinition(this))
         }
-        return null
     }
 
     override fun getTextOffset(): Int =
@@ -44,4 +55,8 @@ abstract class PhelNamedElementImpl(node: ASTNode) : PhelSFormImpl(node), PsiNam
 
     override fun getPresentation(): ItemPresentation? =
         if (this is PhelSymbol) PhelItemPresentation(this) else super.getPresentation()
+
+    private companion object {
+        val REFERENCE_KEY = Key.create<CachedValue<PhelReference>>("phel.symbol.reference")
+    }
 }

--- a/src/main/kotlin/org/phellang/language/psi/references/PhelReference.kt
+++ b/src/main/kotlin/org/phellang/language/psi/references/PhelReference.kt
@@ -6,6 +6,7 @@ import com.intellij.psi.PsiElementResolveResult
 import com.intellij.psi.PsiPolyVariantReference
 import com.intellij.psi.PsiReferenceBase
 import com.intellij.psi.ResolveResult
+import com.intellij.psi.impl.source.resolve.ResolveCache
 import com.intellij.util.IncorrectOperationException
 import org.phellang.language.psi.PhelNamespaceUtils
 import org.phellang.language.psi.PhelSymbol
@@ -36,7 +37,26 @@ class PhelReference @JvmOverloads constructor(
 
     private val symbolName: String? = PhelPsiUtils.getName(element)
 
+    /**
+     * Cached, because the chain below is expensive and asked for constantly.
+     *
+     * Resolving one symbol walks local scope, the current file's definitions, the project index,
+     * vendor `phel/core` and finally the PHP index — measured at ~1.3 ms per symbol, and the
+     * annotator, the inspections and the documentation provider all resolve while highlighting. A
+     * file with 300 symbols cost ~400 ms of that per pass. [isReferenceTo] made it worse again by
+     * calling this once per candidate during Find Usages.
+     *
+     * [ResolveCache] is the platform's answer: it keys on the reference, drops on any PSI change,
+     * and is what a [PsiPolyVariantReference] is expected to route through.
+     */
     override fun multiResolve(incompleteCode: Boolean): Array<ResolveResult> {
+        if (symbolName.isNullOrEmpty()) return ResolveResult.EMPTY_ARRAY
+
+        return ResolveCache.getInstance(myElement.project)
+            .resolveWithCaching(this, RESOLVER, /* needToPreventRecursion = */ true, incompleteCode)
+    }
+
+    private fun resolveUncached(): Array<ResolveResult> {
         val name = symbolName?.takeIf { it.isNotEmpty() } ?: return ResolveResult.EMPTY_ARRAY
 
         val targets = if (findUsages) {
@@ -157,6 +177,14 @@ class PhelReference @JvmOverloads constructor(
     // references aimed at the old target with no error anywhere.
 
     companion object {
+        /**
+         * Stateless and shared: [ResolveCache] keys on the reference, so one resolver instance serves
+         * every [PhelReference] rather than each holding its own.
+         */
+        private val RESOLVER = ResolveCache.PolyVariantResolver<PhelReference> { reference, _ ->
+            reference.resolveUncached()
+        }
+
         /** Project-wide variants are only collected while the list is still short enough to be useful. */
         private const val MAX_PROJECT_VARIANTS = 20
 

--- a/src/test/kotlin/org/phellang/integration/psi/PhelReferenceCachingTest.kt
+++ b/src/test/kotlin/org/phellang/integration/psi/PhelReferenceCachingTest.kt
@@ -1,0 +1,71 @@
+package org.phellang.integration.psi
+
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.integration.PhelIntegrationTestCase
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.files.PhelFile
+
+/**
+ * Resolution is cached, and the caching is invalidated by editing.
+ *
+ * Resolving one symbol walks local scope, the file's definitions, the project index, vendor
+ * `phel/core` and the PHP index — around 1.3 ms each, paid by the annotator, the inspections and the
+ * documentation provider on every highlighting pass. It now goes through `ResolveCache`.
+ *
+ * That only works because `getReference()` hands back the *same* reference instance each time:
+ * `ResolveCache` keys on the reference, so rebuilding one per call left the cache permanently cold.
+ * Both halves are pinned here, since either alone silently restores the original cost.
+ */
+class PhelReferenceCachingTest : PhelIntegrationTestCase() {
+
+    private fun symbolNamed(file: PhelFile, name: String): PhelSymbol =
+        PsiTreeUtil.findChildrenOfType(file, PhelSymbol::class.java).last { it.text == name }
+
+    fun testTheSameElementKeepsTheSameReference() {
+        val file = myFixture.configureByText(
+            "caching.phel", "(ns app\\caching)\n(defn helper [x] x)\n(defn caller [] (helper 1))\n"
+        ) as PhelFile
+        val usage = symbolNamed(file, "helper")
+
+        assertSame("a fresh reference per call leaves ResolveCache permanently cold", usage.reference, usage.reference)
+    }
+
+    fun testResolutionIsStableAcrossRepeatedCalls() {
+        val file = myFixture.configureByText(
+            "stable.phel", "(ns app\\stable)\n(defn helper [x] x)\n(defn caller [] (helper 1))\n"
+        ) as PhelFile
+        val usage = symbolNamed(file, "helper")
+
+        val first = usage.reference?.resolve()
+        val second = usage.reference?.resolve()
+
+        assertNotNull("the usage should resolve to its definition", first)
+        assertSame(first, second)
+    }
+
+    /**
+     * The cache must not outlive the PSI it describes. Renaming the definition has to make the usage
+     * stop resolving to it, or a stale target survives every later edit.
+     */
+    fun testEditingInvalidatesTheCachedResolution() {
+        val file = myFixture.configureByText(
+            "invalidate.phel", "(ns app\\invalidate)\n(defn helper [x] x)\n(defn caller [] (helper 1))\n"
+        ) as PhelFile
+
+        assertNotNull("precondition: resolves before the edit", symbolNamed(file, "helper").reference?.resolve())
+
+        val documentManager = PsiDocumentManager.getInstance(project)
+        WriteCommandAction.runWriteCommandAction(project) {
+            val document = documentManager.getDocument(file)!!
+            document.setText(document.text.replace("(defn helper [x] x)", "(defn renamed [x] x)"))
+            documentManager.commitDocument(document)
+        }
+
+        assertNull(
+            "the definition is gone, so the cached target must have gone with it",
+            symbolNamed(file, "helper").reference?.resolve(),
+        )
+    }
+}


### PR DESCRIPTION
Resolving one Phel symbol walks local scope, the current file's definitions, the project index, vendor `phel/core` and finally the PHP index. The annotator, the inspections and the documentation provider all do this while highlighting, and `isReferenceTo` did it once per candidate during Find Usages.

## Measured first

I filed #288 from a code reading and noted it was "worth measuring on a real project first so the change has a number attached". Benchmark: a file with 308 symbols, 303 of which resolve.

| | per symbol | 308 symbols |
|---|---|---|
| before | 1292 us | 398 ms |
| after | 10 us | 3.1 ms |

For contrast, I measured #286 the same way and closed it — 23 us per call, nothing worth fixing. This one is real.

## Two changes, and neither works alone

`multiResolve` now goes through `ResolveCache`, the platform's answer for a `PsiPolyVariantReference`.

**On its own that changed nothing measurable** — 1292 us to 1483 us, i.e. noise. `ResolveCache` keys on the *reference instance*, and `getReference()` built a fresh `PhelReference` on every call, so the cache was permanently cold. Caching the reference per element is what makes caching the resolution possible at all, and it also stops `PhelSymbolAnalyzer.isDefinition` being recomputed on every call.

The reference cache uses `cachedPerPsi` — which is worth noting, because that helper is the one I wrongly called dead code during the #281 audit and nearly deleted. It has a real job here.

## Test plan

`./gradlew test` green.

`PhelReferenceCachingTest` (new) pins all three properties:

| Guard | Why it matters |
|---|---|
| the same element hands back the same reference | a fresh reference per call leaves `ResolveCache` cold; this is the half that is easy to undo by accident |
| resolution is stable across repeated calls | the cache returns the same target, not a re-walked one |
| editing invalidates the cached resolution | renaming the definition makes the usage stop resolving, so no stale target survives an edit |

I verified the first test **fails** against the pre-change `getReference()`, so it genuinely catches a regression rather than passing by construction.

Manual (`./gradlew runIde`): open a file with many cross-references, confirm go-to-definition, find-usages and hover still land on the right targets, then rename a definition and confirm usages stop resolving to the old name.

Closes #288