### PR TITLE
feat(run): navigate from a test tree node to its deftest

### DIFF
--- a/src/main/kotlin/org/phellang/run/test/PhelTestConsoleProperties.kt
+++ b/src/main/kotlin/org/phellang/run/test/PhelTestConsoleProperties.kt
@@ -3,10 +3,12 @@ package org.phellang.run.test
 import com.intellij.execution.Executor
 import com.intellij.execution.configurations.RunConfiguration
 import com.intellij.execution.testframework.sm.runner.SMTRunnerConsoleProperties
+import com.intellij.execution.testframework.sm.runner.SMTestLocator
 
 /**
- * Plain properties: the tree is fed by service messages the process handler emits, which the
- * platform's default converter already parses, so nothing custom is needed here.
+ * The tree is fed by service messages the process handler emits, which the platform's default
+ * converter already parses, so the only thing supplied here is the locator that turns their
+ * `locationHint` back into a `deftest`.
  */
 class PhelTestConsoleProperties(
     configuration: RunConfiguration,
@@ -14,9 +16,12 @@ class PhelTestConsoleProperties(
 ) : SMTRunnerConsoleProperties(configuration, FRAMEWORK_NAME, executor) {
 
     init {
-        // The report carries no source locations, so a test node cannot navigate anywhere yet.
+        // Names, not generated ids: the location is resolved from the suite and test name, which are
+        // exactly what the report carries.
         isIdBasedTestTree = false
     }
+
+    override fun getTestLocator(): SMTestLocator = PhelTestLocator
 
     companion object {
         const val FRAMEWORK_NAME = "Phel"

--- a/src/main/kotlin/org/phellang/run/test/PhelTestLocator.kt
+++ b/src/main/kotlin/org/phellang/run/test/PhelTestLocator.kt
@@ -1,0 +1,84 @@
+package org.phellang.run.test
+
+import com.intellij.execution.Location
+import com.intellij.execution.PsiLocation
+import com.intellij.execution.testframework.sm.runner.SMTestLocator
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiManager
+import com.intellij.psi.search.FilenameIndex
+import com.intellij.psi.search.GlobalSearchScope
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelNamespaceUtils
+import org.phellang.language.psi.files.PhelFile
+import org.phellang.language.psi.utils.PhelPsiUtils
+
+/**
+ * Turns a `locationHint` from the test tree back into the `deftest` it came from.
+ *
+ * Without this a test node navigates nowhere: double-click does nothing, a failure cannot be jumped
+ * to, and the run gutter shows no state from the last run. The report itself carries no file or
+ * line — only a suite name and a test name — so the location is *resolved* rather than read, using
+ * the same two facts the producer already relies on: a suite is a Phel namespace, and
+ * [PhelTestDetection] knows a `deftest` when it sees one.
+ *
+ * `deftest` is deliberately absent from [org.phellang.indexing.PhelProjectSymbolIndex] — it names a
+ * test entry point no other namespace calls — so the lookup walks `.phel` files rather than asking
+ * the index.
+ */
+object PhelTestLocator : SMTestLocator {
+
+    /** The scheme in `locationHint='phel://<namespace>/<test>'`. */
+    const val PROTOCOL = "phel"
+
+    override fun getLocation(
+        protocol: String,
+        path: String,
+        project: Project,
+        scope: GlobalSearchScope,
+    ): List<Location<*>> {
+        if (protocol != PROTOCOL) return emptyList()
+
+        val target = resolve(project, scope, path) ?: return emptyList()
+
+        return listOf(PsiLocation.fromPsiElement(target))
+    }
+
+    /** `<namespace>` alone locates the file; `<namespace>/<test>` locates the `deftest` inside it. */
+    private fun resolve(project: Project, scope: GlobalSearchScope, path: String): PsiElement? {
+        // Last separator, not first: a Phel namespace holds backslashes, never a slash.
+        val namespace = path.substringBeforeLast('/', missingDelimiterValue = path)
+        val testName = path.substringAfterLast('/', missingDelimiterValue = "")
+
+        val file = findTestFile(project, scope, namespace) ?: return null
+        if (testName.isEmpty()) return file
+
+        return findDeftest(file, testName)
+    }
+
+    private fun findTestFile(project: Project, scope: GlobalSearchScope, namespace: String): PhelFile? {
+        val wanted = PhelNamespaceUtils.normalizeNamespace(namespace)
+        val psiManager = PsiManager.getInstance(project)
+
+        return FilenameIndex.getAllFilesByExt(project, PHEL_EXTENSION, scope)
+            .asSequence()
+            .filter { it.isValid }
+            .mapNotNull { psiManager.findFile(it) as? PhelFile }
+            .firstOrNull { declaredNamespaceOf(it) == wanted }
+    }
+
+    private fun declaredNamespaceOf(file: PhelFile): String? =
+        PhelNamespaceUtils.extractNamespaceFromFile(file)?.let(PhelNamespaceUtils::normalizeNamespace)
+
+    /**
+     * The name symbol rather than the whole form, so navigation lands on the test's name the way
+     * go-to-definition does.
+     */
+    private fun findDeftest(file: PhelFile, testName: String): PsiElement? =
+        file.children
+            .filterIsInstance<PhelList>()
+            .firstOrNull { PhelTestDetection.deftestName(it) == testName }
+            ?.let { PhelPsiUtils.asSymbol(PhelPsiUtils.activeForms(it).getOrNull(1)) }
+
+    private const val PHEL_EXTENSION = "phel"
+}

--- a/src/main/kotlin/org/phellang/run/test/PhelTestServiceMessages.kt
+++ b/src/main/kotlin/org/phellang/run/test/PhelTestServiceMessages.kt
@@ -13,20 +13,23 @@ object PhelTestServiceMessages {
     fun render(report: PhelTestReport): List<String> = buildList {
         for (suite in report.suites) {
             add(message("testSuiteStarted", "name" to suite.name, "locationHint" to locationOf(suite.name)))
-            for (case in suite.cases) addAll(render(suite, case))
+            for (case in suite.cases) addAll(render(suite.name, case))
             add(message("testSuiteFinished", "name" to suite.name))
         }
     }
 
     /**
+     * Where a tree node points, as `phel://<namespace>[/<test>]`.
+     *
      * The suite name is the Phel namespace, which is what makes a location resolvable at all: the
-     * report carries no file or line, so [PhelTestLocator] resolves the pair back to the `deftest`.
+     * report carries no file or line, so [PhelTestLocator] resolves these segments back to the
+     * `deftest` rather than reading a position out of the report.
      */
-    private fun locationOf(suiteName: String, testName: String? = null): String =
-        if (testName == null) "${PhelTestLocator.PROTOCOL}://$suiteName" else "${PhelTestLocator.PROTOCOL}://$suiteName/$testName"
+    private fun locationOf(vararg segments: String): String =
+        segments.joinToString("/", prefix = "${PhelTestLocator.PROTOCOL}://")
 
-    private fun render(suite: PhelTestSuite, case: PhelTestCase): List<String> = buildList {
-        add(message("testStarted", "name" to case.name, "locationHint" to locationOf(suite.name, case.name)))
+    private fun render(suiteName: String, case: PhelTestCase): List<String> = buildList {
+        add(message("testStarted", "name" to case.name, "locationHint" to locationOf(suiteName, case.name)))
 
         when (val outcome = case.outcome) {
             is PhelTestCase.Outcome.Passed -> Unit

--- a/src/main/kotlin/org/phellang/run/test/PhelTestServiceMessages.kt
+++ b/src/main/kotlin/org/phellang/run/test/PhelTestServiceMessages.kt
@@ -12,14 +12,21 @@ object PhelTestServiceMessages {
 
     fun render(report: PhelTestReport): List<String> = buildList {
         for (suite in report.suites) {
-            add(message("testSuiteStarted", "name" to suite.name))
-            for (case in suite.cases) addAll(render(case))
+            add(message("testSuiteStarted", "name" to suite.name, "locationHint" to locationOf(suite.name)))
+            for (case in suite.cases) addAll(render(suite, case))
             add(message("testSuiteFinished", "name" to suite.name))
         }
     }
 
-    private fun render(case: PhelTestCase): List<String> = buildList {
-        add(message("testStarted", "name" to case.name))
+    /**
+     * The suite name is the Phel namespace, which is what makes a location resolvable at all: the
+     * report carries no file or line, so [PhelTestLocator] resolves the pair back to the `deftest`.
+     */
+    private fun locationOf(suiteName: String, testName: String? = null): String =
+        if (testName == null) "${PhelTestLocator.PROTOCOL}://$suiteName" else "${PhelTestLocator.PROTOCOL}://$suiteName/$testName"
+
+    private fun render(suite: PhelTestSuite, case: PhelTestCase): List<String> = buildList {
+        add(message("testStarted", "name" to case.name, "locationHint" to locationOf(suite.name, case.name)))
 
         when (val outcome = case.outcome) {
             is PhelTestCase.Outcome.Passed -> Unit

--- a/src/test/kotlin/org/phellang/integration/run/PhelTestLocatorTest.kt
+++ b/src/test/kotlin/org/phellang/integration/run/PhelTestLocatorTest.kt
@@ -1,0 +1,78 @@
+package org.phellang.integration.run
+
+import com.intellij.psi.search.GlobalSearchScope
+import org.phellang.integration.PhelIntegrationTestCase
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.run.test.PhelTestLocator
+
+/**
+ * Turning a `locationHint` back into the `deftest` it names.
+ *
+ * The report carries no file or line, only a suite name and a test name, so navigation depends
+ * entirely on resolving that pair. Without it a test node in the tree goes nowhere.
+ */
+class PhelTestLocatorTest : PhelIntegrationTestCase() {
+
+    private val testFile = """
+        (ns app\core-test
+          (:require phel\test :refer [deftest is]))
+
+        (deftest adds
+          (is (= 2 (+ 1 1))))
+
+        (deftest subtracts
+          (is (= 0 (- 1 1))))
+    """.trimIndent()
+
+    private fun locate(path: String) =
+        PhelTestLocator.getLocation("phel", path, project, GlobalSearchScope.projectScope(project))
+
+    fun testLocatesADeftestByItsNamespaceAndName() {
+        myFixture.addFileToProject("tests/core_test.phel", testFile)
+
+        val locations = locate("app\\core-test/adds")
+
+        assertEquals(1, locations.size)
+        val element = locations.single().psiElement
+        assertInstanceOf(element, PhelSymbol::class.java)
+        assertEquals("adds", element.text)
+    }
+
+    /** The right test, not merely the first one in the file. */
+    fun testLocatesTheNamedTestRatherThanTheFirst() {
+        myFixture.addFileToProject("tests/core_test.phel", testFile)
+
+        assertEquals("subtracts", locate("app\\core-test/subtracts").single().psiElement?.text)
+    }
+
+    /** A suite node names only its namespace, and navigates to the file. */
+    fun testLocatesTheFileForASuiteWithNoTestName() {
+        val file = myFixture.addFileToProject("tests/core_test.phel", testFile)
+
+        val locations = locate("app\\core-test")
+
+        assertEquals(1, locations.size)
+        assertEquals(file, locations.single().psiElement)
+    }
+
+    fun testReturnsNothingForAnUnknownTest() {
+        myFixture.addFileToProject("tests/core_test.phel", testFile)
+
+        assertEmpty(locate("app\\core-test/never-written"))
+    }
+
+    fun testReturnsNothingForAnUnknownNamespace() {
+        myFixture.addFileToProject("tests/core_test.phel", testFile)
+
+        assertEmpty(locate("app\\nowhere/adds"))
+    }
+
+    /** The locator is registered for one protocol and must decline anything else. */
+    fun testDeclinesAnotherProtocol() {
+        myFixture.addFileToProject("tests/core_test.phel", testFile)
+
+        assertEmpty(
+            PhelTestLocator.getLocation("java", "app\\core-test/adds", project, GlobalSearchScope.projectScope(project))
+        )
+    }
+}

--- a/src/test/kotlin/org/phellang/unit/run/PhelTestServiceMessagesTest.kt
+++ b/src/test/kotlin/org/phellang/unit/run/PhelTestServiceMessagesTest.kt
@@ -31,12 +31,37 @@ class PhelTestServiceMessagesTest {
 
         assertEquals(
             listOf(
-                "##teamcity[testSuiteStarted name='core']",
-                "##teamcity[testStarted name='adds']",
+                "##teamcity[testSuiteStarted name='core' locationHint='phel://core']",
+                "##teamcity[testStarted name='adds' locationHint='phel://core/adds']",
                 "##teamcity[testFinished name='adds']",
                 "##teamcity[testSuiteFinished name='core']",
             ),
             messages,
+        )
+    }
+
+    /**
+     * The location hint is what makes a tree node navigable. The report carries no file or line, so
+     * the namespace and test name it does carry are handed to `PhelTestLocator` to resolve.
+     */
+    @Test
+    fun `a test carries a location hint naming its namespace and itself`() {
+        val messages = render(PhelTestReport(listOf(PhelTestSuite("app\\core-test", listOf(passing("adds"))))))
+
+        assertTrue(
+            messages.any { it.contains("locationHint='phel://app\\core-test/adds'") },
+            messages.toString(),
+        )
+    }
+
+    /** A suite locates its file, so the namespace node navigates too. */
+    @Test
+    fun `a suite carries a location hint naming its namespace`() {
+        val messages = render(PhelTestReport(listOf(PhelTestSuite("app\\core-test", emptyList()))))
+
+        assertTrue(
+            messages.first().contains("locationHint='phel://app\\core-test'"),
+            messages.toString(),
         )
     }
 
@@ -88,7 +113,10 @@ class PhelTestServiceMessagesTest {
     fun `escapes a namespace name`() {
         val messages = render(PhelTestReport(listOf(PhelTestSuite("app\\core-test", emptyList()))))
 
-        assertEquals("##teamcity[testSuiteStarted name='app\\core-test']", messages.first())
+        assertEquals(
+            "##teamcity[testSuiteStarted name='app\\core-test' locationHint='phel://app\\core-test']",
+            messages.first(),
+        )
     }
 
     @Test
@@ -124,7 +152,10 @@ class PhelTestServiceMessagesTest {
         val messages = render(PhelTestReport(listOf(PhelTestSuite("empty", emptyList()))))
 
         assertEquals(
-            listOf("##teamcity[testSuiteStarted name='empty']", "##teamcity[testSuiteFinished name='empty']"),
+            listOf(
+                "##teamcity[testSuiteStarted name='empty' locationHint='phel://empty']",
+                "##teamcity[testSuiteFinished name='empty']",
+            ),
             messages,
         )
     }


### PR DESCRIPTION
A test node in the tree went nowhere: double-click did nothing, a failure could not be jumped to, and the run gutter showed no state from the last run. `PhelTestConsoleProperties` said so in a comment — *"The report carries no source locations, so a test node cannot navigate anywhere yet."*

## Approach

The report genuinely carries no file or line. But it carries a suite name and a test name, and the suite name **is the Phel namespace** — which is enough to resolve the rest.

- `PhelTestServiceMessages` emits `locationHint='phel://<namespace>/<test>'` on each test, and `phel://<namespace>` on each suite so the namespace node navigates too.
- `PhelTestLocator` (new) resolves that back: find the file declaring the namespace, then the `deftest` inside it, using the same `PhelTestDetection` the run-configuration producer already relies on. It returns the *name symbol* rather than the whole form, so navigation lands where go-to-definition would.
- `PhelTestConsoleProperties` returns it from `getTestLocator()`.

`deftest` is deliberately excluded from `PhelProjectSymbolIndex` — it names a test entry point no other namespace calls by name, and the exclusion is documented on `SymbolType` — so the lookup walks `.phel` files rather than asking the index.

**A known characteristic, not optimised on purpose:** each `getLocation` call scans project `.phel` files for the matching namespace. I have not measured it as a problem and did not want to add a cache on a guess — the same discipline that led me to close #286 after measuring, and to do #288 after measuring. If a large suite makes tree population sluggish, that is the thing to profile.

## Test plan

`./gradlew test` green.

`PhelTestLocatorTest` (new, integration):

| Guard | Case |
|---|---|
| resolves a `deftest` from namespace + name | `testLocatesADeftestByItsNamespaceAndName` |
| picks the named test, not the first in the file | `testLocatesTheNamedTestRatherThanTheFirst` |
| a suite with no test name locates the file | `testLocatesTheFileForASuiteWithNoTestName` |
| unknown test / unknown namespace resolve to nothing | `testReturnsNothingForAnUnknownTest`, `...UnknownNamespace` |
| declines another protocol | `testDeclinesAnotherProtocol` |

`PhelTestServiceMessagesTest` gains hint coverage for both node kinds, including a real `app\core-test` namespace so the backslash escaping is exercised. Three existing tests that pin exact message text were updated for the new attribute.

Manual (`./gradlew runIde`): run a test file, double-click a node in the tree and confirm it opens the `deftest`; make one fail and confirm jump-to-failure lands on it.

Closes #283