### PR TITLE
feat(language): find TODO and FIXME in Phel comments

### DIFF
--- a/src/main/kotlin/org/phellang/language/todo/PhelTodoIndexPatternBuilder.kt
+++ b/src/main/kotlin/org/phellang/language/todo/PhelTodoIndexPatternBuilder.kt
@@ -1,0 +1,43 @@
+package org.phellang.language.todo
+
+import com.intellij.lexer.Lexer
+import com.intellij.psi.PsiFile
+import com.intellij.psi.impl.search.IndexPatternBuilder
+import com.intellij.psi.tree.IElementType
+import com.intellij.psi.tree.TokenSet
+import org.phellang.language.lexer.PhelLexerAdapter
+import org.phellang.language.psi.PhelTypes
+import org.phellang.language.psi.files.PhelFile
+
+/**
+ * Lets the platform find `TODO` and `FIXME` inside Phel comments.
+ *
+ * Without this a note in a `.phel` file reaches nothing: not the TODO tool window, not the commit
+ * dialog's TODO check, not the gutter. The platform does the pattern matching itself; all it needs
+ * is a lexer and the set of tokens whose text counts as prose.
+ *
+ * Only `;` line comments participate. `#_` discards the *form* that follows it, so a note inside one
+ * is commented-out code rather than a message to the reader — and the `FORM_COMMENT` token is only
+ * the two-character `#_` marker anyway, with the discarded form left in the tree beside it, so
+ * including it would scan no prose at all.
+ */
+class PhelTodoIndexPatternBuilder : IndexPatternBuilder {
+
+    override fun getIndexingLexer(file: PsiFile): Lexer? = if (file is PhelFile) PhelLexerAdapter() else null
+
+    override fun getCommentTokenSet(file: PsiFile): TokenSet? = if (file is PhelFile) LINE_COMMENTS else null
+
+    /**
+     * Zero: the whole token, `;` included, is handed to the pattern.
+     *
+     * A delta exists to skip a delimiter that would otherwise be read as part of the text. `;` is not
+     * a word character, so it cannot run into the `TODO` the pattern is anchored on.
+     */
+    override fun getCommentStartDelta(tokenType: IElementType?): Int = 0
+
+    override fun getCommentEndDelta(tokenType: IElementType?): Int = 0
+
+    private companion object {
+        val LINE_COMMENTS: TokenSet = TokenSet.create(PhelTypes.LINE_COMMENT)
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -70,6 +70,8 @@
         <lang.commenter
                 language="Phel"
                 implementationClass="org.phellang.editor.commenting.PhelCommenter"/>
+        <indexPatternBuilder
+                implementation="org.phellang.language.todo.PhelTodoIndexPatternBuilder"/>
         <lang.braceMatcher
                 language="Phel"
                 implementationClass="org.phellang.editor.matching.PhelBraceMatcher"/>

--- a/src/test/kotlin/org/phellang/integration/language/PhelTodoIndexPatternBuilderTest.kt
+++ b/src/test/kotlin/org/phellang/integration/language/PhelTodoIndexPatternBuilderTest.kt
@@ -1,0 +1,64 @@
+package org.phellang.integration.language
+
+import com.intellij.psi.search.PsiTodoSearchHelper
+import org.phellang.integration.PhelIntegrationTestCase
+
+/**
+ * `TODO` and `FIXME` in a Phel comment reach the platform's TODO index.
+ *
+ * Driven through [PsiTodoSearchHelper], the same entry point the TODO tool window and the commit
+ * dialog's check use, so the registration is exercised rather than the builder called directly.
+ */
+class PhelTodoIndexPatternBuilderTest : PhelIntegrationTestCase() {
+
+    private fun todosIn(source: String): List<String> {
+        val file = myFixture.configureByText("todo.phel", source)
+
+        return PsiTodoSearchHelper.getInstance(project)
+            .findTodoItems(file)
+            .map { file.text.substring(it.textRange.startOffset, it.textRange.endOffset) }
+    }
+
+    fun testFindsATodoInALineComment() {
+        val todos = todosIn("(ns app\\m)\n; TODO tidy this up\n(defn f [] 1)\n")
+
+        assertEquals(listOf("TODO tidy this up"), todos)
+    }
+
+    fun testFindsAFixme() {
+        val todos = todosIn("(ns app\\m)\n; FIXME broken on empty input\n(defn f [] 1)\n")
+
+        assertEquals(listOf("FIXME broken on empty input"), todos)
+    }
+
+    fun testFindsATrailingTodoAfterCode() {
+        val todos = todosIn("(ns app\\m)\n(defn f [] 1) ; TODO memoize\n")
+
+        assertEquals(listOf("TODO memoize"), todos)
+    }
+
+    /** Compared as a set: `findTodoItems` does not promise document order, and does not return it. */
+    fun testFindsEveryTodoInAFile() {
+        val todos = todosIn("(ns app\\m)\n; TODO first\n(defn f [] 1)\n; TODO second\n")
+
+        assertEquals(setOf("TODO first", "TODO second"), todos.toSet())
+    }
+
+    /** Ordinary prose is not a note. */
+    fun testIgnoresACommentWithNoPattern() {
+        assertEmpty(todosIn("(ns app\\m)\n; just explaining the next form\n(defn f [] 1)\n"))
+    }
+
+    /** Code is not a comment, however much it looks like one. */
+    fun testIgnoresTodoInAString() {
+        assertEmpty(todosIn("(ns app\\m)\n(defn f [] \"TODO not a comment\")\n"))
+    }
+
+    /**
+     * `#_` discards the form after it, so a note inside one is commented-out code rather than a
+     * message to the reader — and the token itself is only the `#_` marker, carrying no prose.
+     */
+    fun testIgnoresATodoInsideADiscardedForm() {
+        assertEmpty(todosIn("(ns app\\m)\n(list #_(def TODO 1) 2)\n"))
+    }
+}


### PR DESCRIPTION
First of the five split out of #284.

A `; TODO` or `; FIXME` in a `.phel` file reached nothing — not the TODO tool window, not the commit dialog's TODO check, not the gutter. No `indexPatternBuilder` was registered, and the platform needs one to know which tokens carry prose.

## Scope decision

**Only `;` line comments participate**, which the issue flagged as the thing to decide.

`#_` discards the *form* after it, so a note inside one is commented-out code rather than a message to the reader. It is also moot in practice: `FORM_COMMENT` is only the two-character `#_` marker, with the discarded form left beside it in the tree, so including that token would scan no prose at all. `PhelTokenSets.LINE_COMMENT` bundles both, so this builder declares its own single-token set rather than reusing it.

`getCommentStartDelta` is 0 — a delta exists to skip a delimiter that would otherwise run into the text, and `;` is not a word character, so it cannot interfere with the pattern's `\bTODO\b`.

## Test plan

`./gradlew test` green.

`PhelTodoIndexPatternBuilderTest` (new) drives `PsiTodoSearchHelper`, the same entry point the TODO tool window and the commit check use, so the **registration** is exercised rather than the builder called directly:

| Guard | Case |
|---|---|
| a TODO in a line comment is found | `testFindsATodoInALineComment` |
| FIXME too | `testFindsAFixme` |
| a trailing comment after code | `testFindsATrailingTodoAfterCode` |
| every note in the file | `testFindsEveryTodoInAFile` |
| ordinary prose is not a note | `testIgnoresACommentWithNoPattern` |
| `"TODO"` in a string is code, not a comment | `testIgnoresTodoInAString` |
| a note inside `#_(...)` is not indexed | `testIgnoresATodoInsideADiscardedForm` |

`findTodoItems` does not promise document order and does not return it, so the multi-note case compares as a set.

Manual (`./gradlew runIde`): add `; TODO check me` to a `.phel` file and confirm it appears in the TODO tool window and in the commit dialog.

Closes #297