### PR TITLE
feat(editor): remove unused requires on Optimize Imports

### DIFF
--- a/src/main/kotlin/org/phellang/editor/imports/PhelImportOptimizer.kt
+++ b/src/main/kotlin/org/phellang/editor/imports/PhelImportOptimizer.kt
@@ -1,0 +1,57 @@
+package org.phellang.editor.imports
+
+import com.intellij.lang.ImportOptimizer
+import com.intellij.psi.PsiFile
+import com.intellij.psi.SmartPointerManager
+import com.intellij.psi.SmartPsiElementPointer
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.language.psi.PhelNamespaceUtils
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.analysis.PhelUnusedImportFinder
+import org.phellang.language.psi.files.PhelFile
+import org.phellang.language.psi.utils.PhelImportRemoval
+
+/**
+ * Removes every unused `(:require …)` from a file on Optimize Imports.
+ *
+ * The two halves already existed and are unchanged: [PhelUnusedImportFinder] decides what is unused
+ * — the same judgement `PhelUnusedImportInspection` reports one at a time — and [PhelImportRemoval]
+ * deletes one entry, the same code both quick fixes call. This only does them together, so the
+ * action and the inspection can never disagree about what counts as unused.
+ *
+ * It removes and does not reorder. Sorting the surviving clauses is a separate decision with its own
+ * failure mode (a diff on every file the first time anyone runs it), and nothing yet asks for it.
+ */
+class PhelImportOptimizer : ImportOptimizer {
+
+    override fun supports(file: PsiFile): Boolean = file is PhelFile
+
+    /**
+     * Collected here, deleted in the returned [Runnable].
+     *
+     * The platform calls this outside a write action and runs the result inside one, so nothing may
+     * be mutated yet. Smart pointers rather than elements because the PSI can be reparsed in
+     * between, which would leave plain references invalid by the time the deletion runs.
+     */
+    override fun processFile(file: PsiFile): Runnable {
+        val unused = unusedImportsIn(file).map {
+            SmartPointerManager.getInstance(file.project).createSmartPsiElementPointer(it)
+        }
+
+        return Runnable { unused.forEach { pointer -> pointer.element?.let(PhelImportRemoval::removeEnclosingImport) } }
+    }
+
+    /**
+     * Only symbols inside a `(:require …)` form, for the reason the inspection gives: a
+     * namespace-shaped symbol can appear in ordinary code, and the declaration's *own* name is
+     * namespace-shaped and never used as a qualifier in its own file.
+     */
+    private fun unusedImportsIn(file: PsiFile): List<PhelSymbol> {
+        val phelFile = file as? PhelFile ?: return emptyList()
+        val declaration = PhelNamespaceUtils.findNamespaceDeclaration(phelFile) ?: return emptyList()
+
+        return PhelNamespaceUtils.findRequireForms(declaration)
+            .flatMap { PsiTreeUtil.findChildrenOfType(it, PhelSymbol::class.java) }
+            .filter(PhelUnusedImportFinder::isUnusedImport)
+    }
+}

--- a/src/main/kotlin/org/phellang/inspection/PhelUnusedImportInspection.kt
+++ b/src/main/kotlin/org/phellang/inspection/PhelUnusedImportInspection.kt
@@ -5,7 +5,7 @@ import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.PsiElementVisitor
 import com.intellij.psi.util.PsiTreeUtil
-import org.phellang.inspection.analysis.PhelUnusedImportFinder
+import org.phellang.language.psi.analysis.PhelUnusedImportFinder
 import org.phellang.inspection.quickfixes.PhelRemoveUnusedImportQuickFix
 import org.phellang.language.psi.PhelNamespaceUtils
 import org.phellang.language.psi.PhelSymbol

--- a/src/main/kotlin/org/phellang/language/psi/analysis/PhelUnusedImportFinder.kt
+++ b/src/main/kotlin/org/phellang/language/psi/analysis/PhelUnusedImportFinder.kt
@@ -1,4 +1,4 @@
-package org.phellang.inspection.analysis
+package org.phellang.language.psi.analysis
 
 import com.intellij.openapi.util.Key
 import com.intellij.psi.util.CachedValue
@@ -15,12 +15,16 @@ import org.phellang.language.psi.utils.cachedPerPsi
 /**
  * Decides whether a required namespace is never used in the file that requires it.
  *
- * Moved here from `annotator/validators/PhelImportValidator`, which still owns the two problems
- * that are genuinely annotator concerns (a duplicate import, and one that does not resolve). This
- * one became an inspection so it can be switched off or re-levelled from Settings; the annotator no
- * longer reports it, or every unused import would be flagged twice.
+ * Started in `annotator/validators/PhelImportValidator`, which still owns the two problems that are
+ * genuinely annotator concerns (a duplicate import, and one that does not resolve), then moved to
+ * `inspection/analysis` so it could be switched off or re-levelled from Settings.
+ *
+ * Now in `language` for the reason [org.phellang.language.psi.utils.PhelImportRemoval] is: a second
+ * feature package needs it. `PhelUnusedImportInspection` reports these one at a time and
+ * `editor.imports.PhelImportOptimizer` removes them all at once, and a feature package may not reach
+ * into another's internals. Detection and removal now sit side by side, one layer down.
  */
-internal object PhelUnusedImportFinder {
+object PhelUnusedImportFinder {
 
     private val USED_QUALIFIERS_KEY: Key<CachedValue<Set<String>>> =
         Key.create("phel.usedNamespaceQualifiers")

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -72,6 +72,9 @@
                 implementationClass="org.phellang.editor.commenting.PhelCommenter"/>
         <indexPatternBuilder
                 implementation="org.phellang.language.todo.PhelTodoIndexPatternBuilder"/>
+        <lang.importOptimizer
+                language="Phel"
+                implementationClass="org.phellang.editor.imports.PhelImportOptimizer"/>
         <lang.braceMatcher
                 language="Phel"
                 implementationClass="org.phellang.editor.matching.PhelBraceMatcher"/>

--- a/src/test/kotlin/org/phellang/integration/editor/PhelImportOptimizerTest.kt
+++ b/src/test/kotlin/org/phellang/integration/editor/PhelImportOptimizerTest.kt
@@ -1,0 +1,87 @@
+package org.phellang.integration.editor
+
+import com.intellij.codeInsight.actions.OptimizeImportsProcessor
+import org.phellang.integration.PhelIntegrationTestCase
+
+/**
+ * Optimize Imports over a `.phel` file.
+ *
+ * Driven through [OptimizeImportsProcessor], the action's own entry point, so the registration is
+ * exercised rather than the optimizer called directly.
+ *
+ * What counts as unused is `PhelUnusedImportFinder`, shared with `PhelUnusedImportInspection`, so
+ * the cases here are about *removing several at once* and about leaving the file valid — the
+ * judgement itself is already covered by `PhelUnusedImportTest`.
+ */
+class PhelImportOptimizerTest : PhelIntegrationTestCase() {
+
+    private var fileIndex = 0
+
+    private fun optimized(source: String): String {
+        val file = myFixture.configureByText("opt${fileIndex++}.phel", source)
+        OptimizeImportsProcessor(project, file).run()
+
+        return file.text
+    }
+
+    fun testRemovesAnUnusedRequire() {
+        val optimized = optimized(
+            "(ns app\\m\n  (:require phel\\str :as str))\n\n(defn f [] 1)\n"
+        )
+
+        assertFalse("the unused require should be gone: $optimized", optimized.contains("phel\\str"))
+    }
+
+    fun testKeepsARequireThatIsUsed() {
+        val source = "(ns app\\m\n  (:require phel\\str :as str))\n\n(defn f [] (str/join \",\" []))\n"
+
+        assertEquals(source, optimized(source))
+    }
+
+    /** The whole point of the action over the per-import quick fix: several go in one pass. */
+    fun testRemovesEveryUnusedRequireInOnePass() {
+        val optimized = optimized(
+            "(ns app\\m\n" +
+                "  (:require phel\\str :as str)\n" +
+                "  (:require phel\\json :as json)\n" +
+                "  (:require phel\\html :as html))\n\n" +
+                "(defn f [] 1)\n"
+        )
+
+        assertFalse(optimized, optimized.contains("phel\\str"))
+        assertFalse(optimized, optimized.contains("phel\\json"))
+        assertFalse(optimized, optimized.contains("phel\\html"))
+    }
+
+    fun testKeepsTheUsedOnesWhileRemovingTheRest() {
+        val optimized = optimized(
+            "(ns app\\m\n" +
+                "  (:require phel\\str :as str)\n" +
+                "  (:require phel\\json :as json))\n\n" +
+                "(defn f [] (json/encode {}))\n"
+        )
+
+        assertTrue("the used require must survive: $optimized", optimized.contains("phel\\json"))
+        assertFalse("the unused one must go: $optimized", optimized.contains("phel\\str"))
+    }
+
+    /** A `:refer` pulls names in unqualified, so no qualifier ever appears for it. */
+    fun testKeepsAReferRequire() {
+        val source = "(ns app\\m\n  (:require phel\\test :refer [deftest is]))\n\n(defn f [] 1)\n"
+
+        assertEquals(source, optimized(source))
+    }
+
+    fun testLeavesAFileWithNoRequiresAlone() {
+        val source = "(ns app\\m)\n\n(defn f [] 1)\n"
+
+        assertEquals(source, optimized(source))
+    }
+
+    /** The namespace's own name is namespace-shaped and never a qualifier in its own file. */
+    fun testNeverRemovesTheNamespaceDeclarationItself() {
+        val optimized = optimized("(ns app\\m\n  (:require phel\\str :as str))\n\n(defn f [] 1)\n")
+
+        assertTrue("the ns declaration must survive: $optimized", optimized.contains("(ns app\\m"))
+    }
+}

--- a/src/test/kotlin/org/phellang/integration/inspection/PhelUnusedImportTest.kt
+++ b/src/test/kotlin/org/phellang/integration/inspection/PhelUnusedImportTest.kt
@@ -1,7 +1,7 @@
 package org.phellang.integration.inspection
 
 import com.intellij.psi.util.PsiTreeUtil
-import org.phellang.inspection.analysis.PhelUnusedImportFinder
+import org.phellang.language.psi.analysis.PhelUnusedImportFinder
 import org.phellang.integration.PhelIntegrationTestCase
 import org.phellang.language.psi.PhelList
 import org.phellang.language.psi.PhelSymbol


### PR DESCRIPTION
Second of the five split out of #284.

`Code > Optimize Imports` did nothing in a `.phel` file — no `lang.importOptimizer` was registered.

## Almost no new logic

Both halves already existed and are unchanged:

- `PhelUnusedImportFinder` decides what is unused — the same judgement `PhelUnusedImportInspection` reports one at a time.
- `PhelImportRemoval.removeEnclosingImport` deletes one entry — the same code both quick fixes call.

The optimizer only does them together, which is what keeps the action and the inspection from ever disagreeing about what counts as unused.

## One move

`PhelUnusedImportFinder` goes from `inspection/analysis/` down to `language/psi/analysis/`, for exactly the reason `PhelImportRemoval` is already in `language`: a second feature package needs it, and `ArchitectureBoundaryTest` forbids a feature package reaching into another's internals. Detection and removal now sit side by side one layer down. It imported nothing from `inspection`, so the move is a package line and two import updates.

## Scope decision

**Removes, does not reorder** — the question the issue raised. Sorting the surviving clauses has its own failure mode, a diff on every file the first time anyone runs it, and nothing yet asks for it.

## Test plan

`./gradlew test` green, including `ArchitectureBoundaryTest`, which is what checks the move landed legally.

`PhelImportOptimizerTest` (new) drives `OptimizeImportsProcessor`, the action's own entry point, so the registration is exercised rather than the optimizer called directly. The cases cover removing several at once and leaving the file valid; what counts as unused is already covered by `PhelUnusedImportTest`.

| Guard | Case |
|---|---|
| an unused require goes | `testRemovesAnUnusedRequire` |
| a used one stays | `testKeepsARequireThatIsUsed` |
| several go in one pass | `testRemovesEveryUnusedRequireInOnePass` |
| mixed file keeps the right ones | `testKeepsTheUsedOnesWhileRemovingTheRest` |
| `:refer` is never removed | `testKeepsAReferRequire` |
| a file with no requires is untouched | `testLeavesAFileWithNoRequiresAlone` |
| the `ns` declaration survives | `testNeverRemovesTheNamespaceDeclarationItself` |

Manual (`./gradlew runIde`): add two unused requires, run Optimize Imports, confirm both go and the used ones stay.

Closes #296