### PR TITLE
feat(editor): close open brackets on Complete Current Statement

### DIFF
--- a/src/main/kotlin/org/phellang/editor/indentation/PhelLineAnalyzer.kt
+++ b/src/main/kotlin/org/phellang/editor/indentation/PhelLineAnalyzer.kt
@@ -25,6 +25,60 @@ class PhelLineAnalyzer(private val document: Document) {
      */
     fun bracketBalance(text: String): Int {
         var balance = 0
+        forEachBracket(text) { _, char -> if (char in OPENERS) balance++ else balance-- }
+
+        return balance
+    }
+
+    /**
+     * Where [text]'s code ends: before any trailing `;` comment, and before the whitespace in front
+     * of it.
+     *
+     * Anything appending to a line has to stop here rather than at the end. `(println (inc 1) ; note`
+     * ends inside a comment, so a closing paren added at the end would be commented out along with
+     * the note — and appending at the comment's `;` would leave `(inc 1) )`, a space the author did
+     * not write. A `;` inside a string or after a `\` is not a comment and does not count.
+     */
+    fun activeCodeLength(text: String): Int {
+        var commentStart = text.length
+        forEachCodeCharacter(text) { index, char ->
+            if (char == ';' && commentStart == text.length) commentStart = index
+        }
+
+        return text.substring(0, commentStart).trimEnd().length
+    }
+
+    /**
+     * The brackets [text] leaves open, outermost first.
+     *
+     * Where [bracketBalance] answers *how deep*, this answers *which* — `(let [x` leaves `['(', '[']`,
+     * so a caller completing the form knows to close the vector before the list. A closer with no
+     * matching opener is dropped rather than going negative: there is nothing to complete for it.
+     */
+    fun unclosedOpeners(text: String): List<Char> {
+        val open = ArrayDeque<Char>()
+        forEachBracket(text) { _, char -> if (char in OPENERS) open.addLast(char) else open.removeLastOrNull() }
+
+        return open.toList()
+    }
+
+    private inline fun forEachBracket(text: String, onBracket: (Int, Char) -> Unit) {
+        forEachCodeCharacter(text) { index, char ->
+            if (char in OPENERS || char in CLOSERS) onBracket(index, char)
+        }
+    }
+
+    /**
+     * Walks [text], reporting only the characters that are really code.
+     *
+     * Every public function here runs this rather than carrying its own scan. The skipping is the
+     * part that is easy to get subtly wrong — strings, `;` comments and `\(` character literals —
+     * and a second copy would be a second chance to drift.
+     *
+     * The `;` that opens a comment is reported, since one caller needs to know where that is; the
+     * rest of the comment is not.
+     */
+    private inline fun forEachCodeCharacter(text: String, onCode: (Int, Char) -> Unit) {
         var inString = false
         var inComment = false
         var i = 0
@@ -33,7 +87,7 @@ class PhelLineAnalyzer(private val document: Document) {
             val char = text[i]
 
             when {
-                inComment -> Unit
+                inComment -> if (char == '\n') inComment = false
 
                 // Outside a string `\(` is a character literal, not an opening paren: the lexer's
                 // CHARACTER rule ends in a catch-all `.`, so whatever follows the backslash is part
@@ -41,21 +95,21 @@ class PhelLineAnalyzer(private val document: Document) {
                 // cases consume the pair, which is also what keeps `"\""` from ending the string.
                 char == '\\' -> i++
 
-                char == '"' -> inString = !inString
+                char == '"' -> {
+                    inString = !inString
+                    onCode(i, char)
+                }
 
                 inString -> Unit
 
-                char == ';' -> inComment = true
-
-                char in OPENERS -> balance++
-
-                char in CLOSERS -> balance--
+                else -> {
+                    if (char == ';') inComment = true
+                    onCode(i, char)
+                }
             }
 
             i++
         }
-
-        return balance
     }
 
     private companion object {

--- a/src/main/kotlin/org/phellang/editor/smartenter/PhelSmartEnterProcessor.kt
+++ b/src/main/kotlin/org/phellang/editor/smartenter/PhelSmartEnterProcessor.kt
@@ -1,0 +1,57 @@
+package org.phellang.editor.smartenter
+
+import com.intellij.codeInsight.editorActions.smartEnter.SmartEnterProcessor
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiFile
+import org.phellang.editor.indentation.PhelLineAnalyzer
+import org.phellang.language.psi.files.PhelFile
+
+/**
+ * Complete Current Statement: closes every bracket the current line leaves open.
+ *
+ * For a Lisp that is what "finish this statement" means — `(defn f [x` becomes `(defn f [x])` with
+ * the caret after it — and it is the one editor action a paren-heavy language most wants.
+ *
+ * Which brackets are open comes from [PhelLineAnalyzer.unclosedOpeners], the same scanner the Enter
+ * handler indents from, so the two cannot disagree about what a bracket is: both skip strings, `;`
+ * comments and `\(` character literals alike.
+ *
+ * It balances what is open and stops there. Adding a newline and an indent afterwards is Enter's
+ * job, and doing it here would make one keystroke do two things a user may not want together.
+ */
+class PhelSmartEnterProcessor : SmartEnterProcessor() {
+
+    override fun process(project: Project, editor: Editor, psiFile: PsiFile): Boolean {
+        if (psiFile !is PhelFile) return false
+
+        val document = editor.document
+        val analyzer = PhelLineAnalyzer(document)
+
+        val line = document.getLineNumber(editor.caretModel.offset)
+        val lineStart = document.getLineStartOffset(line)
+        val lineEnd = document.getLineEndOffset(line)
+
+        // Before any trailing comment, not at the end of the line: `(println (inc 1) ; note` ends
+        // inside a comment, and a paren appended there would be commented out along with the note.
+        val insertAt = lineStart + analyzer.activeCodeLength(document.getText(TextRange(lineStart, lineEnd)))
+
+        // Scanned to the insertion point rather than to the caret: the statement being completed is
+        // the line, so a caret sitting mid-line still closes what the whole line leaves open.
+        val open = analyzer.unclosedOpeners(document.getText(TextRange(0, insertAt)))
+        if (open.isEmpty()) return false
+
+        val closers = open.reversed().map(::closerFor).joinToString("")
+        document.insertString(insertAt, closers)
+        editor.caretModel.moveToOffset(insertAt + closers.length)
+
+        return true
+    }
+
+    private fun closerFor(opener: Char): Char = when (opener) {
+        '[' -> ']'
+        '{' -> '}'
+        else -> ')'
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -96,6 +96,9 @@
                 implementationClass="org.phellang.editor.structure.PhelStructureViewFactory"/>
         <enterHandlerDelegate
                 implementation="org.phellang.editor.enter.PhelEnterHandlerDelegate"/>
+        <lang.smartEnterProcessor
+                language="Phel"
+                implementationClass="org.phellang.editor.smartenter.PhelSmartEnterProcessor"/>
         <moveLeftRightHandler
                 language="Phel"
                 implementationClass="org.phellang.editor.paredit.PhelMoveElementLeftRightHandler"/>

--- a/src/test/kotlin/org/phellang/integration/editor/PhelSmartEnterTest.kt
+++ b/src/test/kotlin/org/phellang/integration/editor/PhelSmartEnterTest.kt
@@ -1,0 +1,83 @@
+package org.phellang.integration.editor
+
+import org.phellang.integration.PhelIntegrationTestCase
+
+/**
+ * Complete Current Statement closes what the line leaves open.
+ *
+ * Driven through the real action id, so the registration is exercised rather than the processor
+ * called directly.
+ */
+class PhelSmartEnterTest : PhelIntegrationTestCase() {
+
+    private var fileIndex = 0
+
+    private fun completed(source: String): String {
+        myFixture.configureByText("se${fileIndex++}.phel", source)
+        myFixture.performEditorAction("EditorCompleteStatement")
+
+        return myFixture.editor.document.text
+    }
+
+    fun testClosesAnOpenList() {
+        assertEquals("(println 1)", completed("(println 1<caret>"))
+    }
+
+    /** Innermost first: the vector closes before the list that holds it. */
+    fun testClosesNestedBracketsInTheRightOrder() {
+        assertEquals("(defn f [x])", completed("(defn f [x<caret>"))
+    }
+
+    fun testClosesAMapAndItsEnclosingList() {
+        assertEquals("(def m {:a 1})", completed("(def m {:a 1<caret>"))
+    }
+
+    fun testClosesASet() {
+        assertEquals("(def s #{1 2})", completed("(def s #{1 2<caret>"))
+    }
+
+    fun testClosesAnAnonymousFunction() {
+        assertEquals("(map #(inc %))", completed("(map #(inc %<caret>"))
+    }
+
+    /**
+     * Nothing to close, so the processor declines and the platform's default runs — which inserts a
+     * line break. That fall-through is the point: declining must leave the action still useful.
+     */
+    fun testLeavesAnAlreadyBalancedLineAlone() {
+        assertEquals("(println 1)\n", completed("(println 1)<caret>"))
+    }
+
+    /** A bracket inside a string is text, not structure. */
+    fun testIgnoresBracketsInsideAString() {
+        assertEquals("(println \"(unclosed\")", completed("(println \"(unclosed\"<caret>"))
+    }
+
+    /** Brackets in a comment are prose: one list is open here, not five. */
+    fun testIgnoresBracketsInAComment() {
+        assertEquals("(println (inc 1)) ; ((((", completed("(println (inc 1) ; ((((<caret>"))
+    }
+
+    /** And the closer goes before the comment, or it would be commented out along with the note. */
+    fun testInsertsBeforeATrailingComment() {
+        assertEquals("(println (inc 1)) ; note", completed("(println (inc 1) ; note<caret>"))
+    }
+
+    /** `\(` is a character literal. */
+    fun testIgnoresACharacterLiteralBracket() {
+        assertEquals("(println \\()", completed("(println \\(<caret>"))
+    }
+
+    /** The caret sits after everything it just inserted, ready to keep typing. */
+    fun testLeavesTheCaretAfterTheInsertedBrackets() {
+        myFixture.configureByText("se-caret.phel", "(defn f [x<caret>")
+        myFixture.performEditorAction("EditorCompleteStatement")
+
+        assertEquals(myFixture.editor.document.textLength, myFixture.editor.caretModel.offset)
+    }
+
+    /** Completing the whole line, not the caret position: text after the caret still counts. */
+    fun testClosesWhatFollowsTheCaretToo() {
+        assertEquals("(println (inc 1))", completed("(println <caret>(inc 1"))
+    }
+}


### PR DESCRIPTION
Third of the five split out of #284.

`Shift+Cmd+Enter` / `Ctrl+Shift+Enter` did nothing in a `.phel` file — no `lang.smartEnterProcessor` was registered. For a Lisp, finishing the statement means closing what the line leaves open: `(defn f [x` becomes `(defn f [x])`, caret after it.

## Reuses the scanner rather than adding a second one

Which brackets are open comes from `PhelLineAnalyzer`, the same scanner the Enter handler indents from, so the two cannot disagree about what counts as a bracket — both skip strings, `;` comments and `\(` character literals.

It grew two functions on top of the walk it already did:

- `unclosedOpeners` — *which* brackets are open, where `bracketBalance` says *how many*. `(let [x` gives `['(', '[']`, so the vector closes before the list.
- `activeCodeLength` — where a line's code ends.

The string/comment/char-literal skipping now lives in one private walker that all three run, rather than being copied per function. That is the specific thing that had already drifted once in this codebase, so it seemed worth not repeating.

## Two decisions

**Closers go before any trailing comment.** Appending at the end of `(println (inc 1) ; note` would comment the paren out along with the note; appending at the `;` would leave `(inc 1) )`, a space the author did not write.

**It balances and stops** — the question the issue raised. Adding a newline and indent afterwards is Enter's job, and doing both on one keystroke takes the choice away. When there is nothing to close the processor declines, and the platform's default line break runs, so the action stays useful either way.

## A pre-existing bug this surfaced

Writing the comment test exposed #303: `PhelEnterHandlerParenthesisManager.shouldAddClosingParenthesis` reads the raw text before the caret, so plain Enter after a line whose *comment* ends in `(` inserts a stray closing paren into code. Unrelated to this change and left alone; filed separately with a suggested fix that reuses `activeCodeLength`.

## Test plan

`./gradlew test` green.

`PhelSmartEnterTest` (new) drives the real `EditorCompleteStatement` action, so the registration is exercised:

| Guard | Case |
|---|---|
| closes a list | `testClosesAnOpenList` |
| innermost first | `testClosesNestedBracketsInTheRightOrder` |
| maps, sets, `#(` | `testClosesAMapAndItsEnclosingList`, `testClosesASet`, `testClosesAnAnonymousFunction` |
| brackets in strings, comments and `\(` are not structure | three cases |
| the closer goes before a trailing comment | `testInsertsBeforeATrailingComment` |
| caret ends after the insertion | `testLeavesTheCaretAfterTheInsertedBrackets` |
| text after the caret still counts | `testClosesWhatFollowsTheCaretToo` |
| nothing to close falls through to the default | `testLeavesAnAlreadyBalancedLineAlone` |

Manual (`./gradlew runIde`): type `(defn f [x` and press Shift+Cmd+Enter.

Closes #299