### PR TITLE
fix(editor): stop a comment's paren pulling in a closing one

### DIFF
--- a/src/main/kotlin/org/phellang/editor/enter/PhelEnterHandlerParenthesisManager.kt
+++ b/src/main/kotlin/org/phellang/editor/enter/PhelEnterHandlerParenthesisManager.kt
@@ -1,12 +1,19 @@
 package org.phellang.editor.enter
 
 import com.intellij.openapi.editor.Document
+import org.phellang.editor.indentation.PhelLineAnalyzer
 
 class PhelEnterHandlerParenthesisManager {
 
+    /**
+     * True when the line ends on an opening paren that still wants closing.
+     *
+     * Asked of the line's *code*, not its raw text. Reading the text meant a line whose comment
+     * ended in `(` — `(println 1) ; ((((` — had a closing paren inserted into the code below it,
+     * closing nothing, and a line ending inside a string did the same.
+     */
     fun shouldAddClosingParenthesis(document: Document, caretPosition: Int, textBeforeCaret: String): Boolean {
-        val trimmedText = textBeforeCaret.trimEnd()
-        if (!trimmedText.endsWith('(')) {
+        if (PhelLineAnalyzer(document).lastCodeCharacter(textBeforeCaret) != '(') {
             return false
         }
 

--- a/src/main/kotlin/org/phellang/editor/indentation/PhelLineAnalyzer.kt
+++ b/src/main/kotlin/org/phellang/editor/indentation/PhelLineAnalyzer.kt
@@ -39,13 +39,23 @@ class PhelLineAnalyzer(private val document: Document) {
      * the note — and appending at the comment's `;` would leave `(inc 1) )`, a space the author did
      * not write. A `;` inside a string or after a `\` is not a comment and does not count.
      */
-    fun activeCodeLength(text: String): Int {
-        var commentStart = text.length
-        forEachCodeCharacter(text) { index, char ->
-            if (char == ';' && commentStart == text.length) commentStart = index
-        }
+    fun activeCodeLength(text: String): Int = lastCodeCharacterIndex(text) + 1
 
-        return text.substring(0, commentStart).trimEnd().length
+    /**
+     * The last character of [text] that is really code, or null when the line is all comment,
+     * whitespace or empty.
+     *
+     * The Enter handler asks this to decide whether a line ends on an opening bracket. It used to
+     * read the raw text, so a line whose *comment* ended in `(` — `(println 1) ; ((((` — had a stray
+     * closing paren inserted into the code below it, and so did one ending inside a string.
+     */
+    fun lastCodeCharacter(text: String): Char? = lastCodeCharacterIndex(text).takeIf { it >= 0 }?.let(text::get)
+
+    private fun lastCodeCharacterIndex(text: String): Int {
+        var last = -1
+        forEachCodeCharacter(text) { index, char -> if (!char.isWhitespace()) last = index }
+
+        return last
     }
 
     /**
@@ -93,7 +103,14 @@ class PhelLineAnalyzer(private val document: Document) {
                 // CHARACTER rule ends in a catch-all `.`, so whatever follows the backslash is part
                 // of the literal. Inside a string the same backslash escapes the next character. Both
                 // cases consume the pair, which is also what keeps `"\""` from ending the string.
-                char == '\\' -> i++
+                //
+                // Reported once, at the pair's *last* index but carrying the backslash: it is code,
+                // so the code does not end before it, and reporting the escaped character instead
+                // would make `\(` look like an open bracket.
+                char == '\\' -> {
+                    i++
+                    if (!inString) onCode(minOf(i, text.length - 1), char)
+                }
 
                 char == '"' -> {
                     inString = !inString
@@ -102,10 +119,11 @@ class PhelLineAnalyzer(private val document: Document) {
 
                 inString -> Unit
 
-                else -> {
-                    if (char == ';') inComment = true
-                    onCode(i, char)
-                }
+                // The `;` opens the comment and is not itself code, so it is not reported: a line
+                // ending in one must not read as ending on a `;`.
+                char == ';' -> inComment = true
+
+                else -> onCode(i, char)
             }
 
             i++

--- a/src/test/kotlin/org/phellang/integration/editor/PhelEnterClosingParenTest.kt
+++ b/src/test/kotlin/org/phellang/integration/editor/PhelEnterClosingParenTest.kt
@@ -1,0 +1,54 @@
+package org.phellang.integration.editor
+
+import org.phellang.integration.PhelIntegrationTestCase
+
+/**
+ * Enter adds a closing paren only when the line's *code* ends on an opening one.
+ *
+ * The predicate used to read the line's raw text, so a `(` that was only part of a comment — or of a
+ * string — pulled a closing paren into the code below it, closing nothing.
+ */
+class PhelEnterClosingParenTest : PhelIntegrationTestCase() {
+
+    private var fileIndex = 0
+
+    private fun afterEnter(source: String): String {
+        myFixture.configureByText("ecp${fileIndex++}.phel", source)
+        myFixture.type('\n')
+
+        return myFixture.editor.document.text
+    }
+
+    /** The behaviour being preserved: a genuinely open paren still gets its closer. */
+    fun testStillClosesAGenuinelyOpenParen() {
+        val text = afterEnter("(defn f []\n  (<caret>")
+
+        assertTrue("an open paren should still be closed: $text", text.contains(")"))
+    }
+
+    fun testDoesNotCloseAParenThatOnlyEndsAComment() {
+        val text = afterEnter("(println 1) ; ((((<caret>")
+
+        assertFalse("the parens are prose, nothing is open: $text", text.contains(")\n") || text.trimEnd().endsWith(")"))
+    }
+
+    fun testDoesNotCloseAParenInsideAString() {
+        val text = afterEnter("(def s \"an open paren: (<caret>")
+
+        assertEquals("the paren is inside a string literal: $text", 0, text.count { it == ')' })
+    }
+
+    /** A comment after real code does not change what the code ends on. */
+    fun testIgnoresATrailingCommentWhenTheCodeIsBalanced() {
+        val text = afterEnter("(println 1) ; note<caret>")
+
+        assertEquals("nothing is open: $text", 1, text.count { it == ')' })
+    }
+
+    /** And still closes when the code ends on `(` despite a trailing comment. */
+    fun testClosesWhenCodeEndsOnAParenBeforeAComment() {
+        val text = afterEnter("(defn f []\n  (println ( ; note<caret>")
+
+        assertTrue("the second paren is open: $text", text.count { it == ')' } >= 1)
+    }
+}


### PR DESCRIPTION
Found while adding the smart-enter processor (#304) and filed as #303 rather than fixed there.

`PhelEnterHandlerParenthesisManager.shouldAddClosingParenthesis` read the line's raw text:

```kotlin
val trimmedText = textBeforeCaret.trimEnd()
if (!trimmedText.endsWith('(')) return false
```

So *any* line ending in `(` triggered it, including one where the `(` was inside a comment or a string. Pressing Enter after

```phel
(println 1) ; ((((
```

inserted a `)` into the code below, closing nothing. Same for a line ending inside a string.

## Fix

It asks `PhelLineAnalyzer.lastCodeCharacter` instead — the same string, comment and character-literal handling the rest of the Enter handler already used. This one predicate was the only place reading the text directly, which is why it was the only place that got it wrong.

## One thing the scanner had to learn

`forEachCodeCharacter` skipped the whole `\(` pair. That was right while only brackets mattered — a character literal is not a bracket — but it made the code look like it *ended* before the literal, which broke smart enter's `\(` case as soon as `activeCodeLength` was derived from the same walk.

The pair is now reported once, at its last index but carrying the backslash: it counts as code, and it can never be mistaken for an open bracket. `activeCodeLength` is now `lastCodeCharacterIndex + 1`, so the two functions cannot disagree about where a line ends.

## Test plan

`./gradlew test` green.

`PhelEnterClosingParenTest` (new):

| Guard | Case |
|---|---|
| a genuinely open paren still closes | `testStillClosesAGenuinelyOpenParen` |
| a paren that only ends a comment does not | `testDoesNotCloseAParenThatOnlyEndsAComment` |
| nor one inside a string | `testDoesNotCloseAParenInsideAString` |
| a trailing comment does not change balanced code | `testIgnoresATrailingCommentWhenTheCodeIsBalanced` |
| code ending on `(` before a comment still closes | `testClosesWhenCodeEndsOnAParenBeforeAComment` |

**Three of the five fail against the pre-fix predicate**, which I verified by restoring it — so they catch the bug rather than passing by construction. `PhelSmartEnterTest` and `PhelEnterIndentationTest` cover the scanner change.

Manual (`./gradlew runIde`): press Enter at the end of `(println 1) ; ((((` and confirm no paren appears.

Closes #303