### PR TITLE
feat(parameterinfo): show every arity in the Ctrl+P popup

### DIFF
--- a/src/main/kotlin/org/phellang/parameterinfo/PhelParameterInfoHandler.kt
+++ b/src/main/kotlin/org/phellang/parameterinfo/PhelParameterInfoHandler.kt
@@ -1,0 +1,118 @@
+package org.phellang.parameterinfo
+
+import com.intellij.lang.parameterInfo.CreateParameterInfoContext
+import com.intellij.lang.parameterInfo.ParameterInfoHandler
+import com.intellij.lang.parameterInfo.ParameterInfoUIContext
+import com.intellij.lang.parameterInfo.UpdateParameterInfoContext
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.indexing.PhelArityResolver
+import org.phellang.language.psi.PhelInteropShorthands
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelSpecialForms
+import org.phellang.language.psi.analysis.PhelLocalBindingScope
+import org.phellang.language.psi.utils.PhelPsiUtils
+import org.phellang.registry.PhelArity
+
+/**
+ * The Ctrl+P popup: every arity of the called function, with the current parameter in bold.
+ *
+ * Distinct from the inlay hints, which label one argument each and can only ever show the arity that
+ * already matched. This is what answers "what else could I pass?" — for a multi-arity function the
+ * popup lists all of them and highlights the one the current argument count selects.
+ *
+ * Both features skip the same heads for the same reason, so both ask [PhelSpecialForms.VARIADIC_HEADS]
+ * and [PhelInteropShorthands.isInteropCall] rather than keeping their own idea of what is positional.
+ */
+class PhelParameterInfoHandler : ParameterInfoHandler<PhelList, PhelArity> {
+
+    override fun findElementForParameterInfo(context: CreateParameterInfoContext): PhelList? {
+        val call = callAt(context) ?: return null
+        val arities = aritiesOf(call) ?: return null
+
+        context.itemsToShow = arities.toTypedArray()
+
+        return call
+    }
+
+    override fun showParameterInfo(element: PhelList, context: CreateParameterInfoContext) {
+        context.showHint(element, element.textRange.startOffset, this)
+    }
+
+    override fun findElementForUpdatingParameterInfo(context: UpdateParameterInfoContext): PhelList? = callAt(context)
+
+    override fun updateParameterInfo(parameterOwner: PhelList, context: UpdateParameterInfoContext) {
+        context.setCurrentParameter(argumentIndexAt(parameterOwner, context.offset))
+    }
+
+    /**
+     * One line per arity. An arity that cannot accept the current argument count is greyed out, so a
+     * two-arity function shows at a glance which one is in play.
+     */
+    override fun updateUI(p: PhelArity?, context: ParameterInfoUIContext) {
+        if (p == null) return
+
+        val names = p.params.mapIndexed { index, name -> if (p.variadic && index == p.fixedCount) "& $name" else name }
+        if (names.isEmpty()) {
+            context.setupUIComponentPresentation("<no parameters>", -1, -1, true, false, false, context.defaultParameterColor)
+            return
+        }
+
+        val current = context.currentParameterIndex
+        val highlighted = highlightedIndex(p, current)
+        val text = names.joinToString(", ")
+        val start = if (highlighted < 0) -1 else names.take(highlighted).sumOf { it.length + 2 }
+        val end = if (highlighted < 0) -1 else start + names[highlighted].length
+
+        context.setupUIComponentPresentation(
+            text,
+            start,
+            end,
+            /* isDisabled = */ !accepts(p, current),
+            false,
+            false,
+            context.defaultParameterColor,
+        )
+    }
+
+    /** Past the fixed parameters of a variadic arity every further argument belongs to the rest one. */
+    private fun highlightedIndex(arity: PhelArity, argumentIndex: Int): Int = when {
+        argumentIndex < 0 -> -1
+        argumentIndex < arity.params.size -> argumentIndex
+        arity.variadic -> arity.params.size - 1
+        else -> -1
+    }
+
+    private fun accepts(arity: PhelArity, argumentIndex: Int): Boolean {
+        if (argumentIndex < 0) return true
+
+        return if (arity.variadic) true else argumentIndex < arity.params.size
+    }
+
+    private fun callAt(context: com.intellij.lang.parameterInfo.ParameterInfoContext): PhelList? {
+        val at = context.file.findElementAt(context.offset) ?: return null
+
+        return generateSequence(PsiTreeUtil.getParentOfType(at, PhelList::class.java)) {
+            PsiTreeUtil.getParentOfType(it, PhelList::class.java)
+        }.firstOrNull { aritiesOf(it) != null }
+    }
+
+    /** Null whenever the head is not a plain positional call, which is the same rule the hints use. */
+    private fun aritiesOf(call: PhelList): List<PhelArity>? {
+        val forms = PhelPsiUtils.activeForms(call)
+        val head = PhelPsiUtils.asSymbol(forms.firstOrNull()) ?: return null
+        val name = head.text ?: return null
+
+        if (name in PhelSpecialForms.VARIADIC_HEADS) return null
+        if (PhelInteropShorthands.isInteropCall(name)) return null
+        if (PhelLocalBindingScope.resolvesToLocalBinding(head, name)) return null
+
+        return PhelArityResolver.resolve(head.project, name)?.takeIf { it.isNotEmpty() }
+    }
+
+    /** Which argument the caret sits in: 0 for the first, counting the head as -1. */
+    private fun argumentIndexAt(call: PhelList, offset: Int): Int {
+        val forms = PhelPsiUtils.activeForms(call)
+
+        return forms.drop(1).indexOfLast { it.textRange.startOffset <= offset }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -67,6 +67,9 @@
         <lang.documentationProvider
                 language="Phel"
                 implementationClass="org.phellang.documentation.PhelDocumentationProvider"/>
+        <codeInsight.parameterInfo
+                language="Phel"
+                implementationClass="org.phellang.parameterinfo.PhelParameterInfoHandler"/>
         <lang.commenter
                 language="Phel"
                 implementationClass="org.phellang.editor.commenting.PhelCommenter"/>

--- a/src/test/kotlin/org/phellang/integration/parameterinfo/PhelParameterInfoHandlerTest.kt
+++ b/src/test/kotlin/org/phellang/integration/parameterinfo/PhelParameterInfoHandlerTest.kt
@@ -1,0 +1,98 @@
+package org.phellang.integration.parameterinfo
+
+import com.intellij.testFramework.utils.parameterInfo.MockCreateParameterInfoContext
+import com.intellij.testFramework.utils.parameterInfo.MockUpdateParameterInfoContext
+import org.phellang.indexing.PhelProjectSymbolIndex
+import org.phellang.integration.PhelIntegrationTestCase
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.files.PhelFile
+import org.phellang.parameterinfo.PhelParameterInfoHandler
+import org.phellang.registry.PhelArity
+
+/**
+ * The Ctrl+P popup over a Phel call.
+ *
+ * What it shows is every arity of the callee, which is the thing the inlay hints cannot do — they
+ * label one argument each and only ever reflect the arity that already matched.
+ */
+class PhelParameterInfoHandlerTest : PhelIntegrationTestCase() {
+
+    private val handler = PhelParameterInfoHandler()
+    private var fileIndex = 0
+
+    /**
+     * Primed before asking: `PhelArityResolver` consults the project symbol index for a project
+     * function, and a file created by `configureByText` is not in it until something indexes it.
+     * Without this the result depends on which test ran first.
+     */
+    private fun aritiesAt(source: String): List<PhelArity>? {
+        val file = myFixture.configureByText("pi${fileIndex++}.phel", source) as PhelFile
+        PhelProjectSymbolIndex.getInstance(project).refreshFileFromPsi(file)
+        val context = MockCreateParameterInfoContext(myFixture.editor, myFixture.file)
+
+        handler.findElementForParameterInfo(context) ?: return null
+
+        return context.itemsToShow?.map { it as PhelArity }
+    }
+
+    private fun currentParameterAt(source: String): Int {
+        val file = myFixture.configureByText("pi${fileIndex++}.phel", source) as PhelFile
+        PhelProjectSymbolIndex.getInstance(project).refreshFileFromPsi(file)
+        val create = MockCreateParameterInfoContext(myFixture.editor, myFixture.file)
+        val call = handler.findElementForParameterInfo(create) as PhelList
+
+        val update = MockUpdateParameterInfoContext(myFixture.editor, myFixture.file)
+        handler.updateParameterInfo(call, update)
+
+        return update.currentParameter
+    }
+
+    /** A stdlib function, resolved from the registry rather than the project index. */
+    fun testOffersTheAritiesOfAStdlibFunction() {
+        val arities = aritiesAt("(ns app\\m)\n(defn f [] (map <caret>))\n")
+
+        assertNotNull("map should resolve to at least one arity", arities)
+        assertTrue(arities.toString(), arities!!.isNotEmpty())
+    }
+
+    fun testOffersTheAritiesOfAProjectFunction() {
+        val arities = aritiesAt("(ns app\\m)\n(defn greet [name greeting] 1)\n(defn f [] (greet <caret>))\n")
+
+        assertNotNull(arities)
+        assertEquals(listOf("name", "greeting"), arities!!.single().params)
+    }
+
+    /** The caret moves through the arguments, and the popup follows it. */
+    fun testTracksWhichArgumentTheCaretIsIn() {
+        val source = "(ns app\\m)\n(defn greet [name greeting] 1)\n(defn f [] (greet \"a\"<caret> \"b\"))\n"
+
+        assertEquals(0, currentParameterAt(source))
+    }
+
+    fun testTracksTheSecondArgument() {
+        val source = "(ns app\\m)\n(defn greet [name greeting] 1)\n(defn f [] (greet \"a\" \"b\"<caret>))\n"
+
+        assertEquals(1, currentParameterAt(source))
+    }
+
+    /**
+     * The same heads the inlay hints skip, for the same reason: their arguments are not positional,
+     * so a parameter list would be a lie rather than a help.
+     */
+    fun testDeclinesASpecialForm() {
+        assertNull(aritiesAt("(ns app\\m)\n(defn f [] (let [<caret>] 1))\n"))
+    }
+
+    fun testDeclinesInterop() {
+        assertNull(aritiesAt("(ns app\\m)\n(defn f [] (php/strlen <caret>))\n"))
+    }
+
+    /** A local binding shadowing a known name is a different function entirely. */
+    fun testDeclinesALocalBindingThatShadowsAKnownName() {
+        assertNull(aritiesAt("(ns app\\m)\n(defn f [] (let [map (fn [x] x)] (map <caret>)))\n"))
+    }
+
+    fun testDeclinesAnUnknownName() {
+        assertNull(aritiesAt("(ns app\\m)\n(defn f [] (no-such-function-anywhere <caret>))\n"))
+    }
+}

--- a/src/test/kotlin/org/phellang/unit/architecture/ArchitectureBoundaryTest.kt
+++ b/src/test/kotlin/org/phellang/unit/architecture/ArchitectureBoundaryTest.kt
@@ -199,7 +199,7 @@ class ArchitectureBoundaryTest {
 
         private val FEATURE_PACKAGES = listOf(
             "annotator", "completion", "editor", "inspection",
-            "documentation", "actions", "inlay", "navigation", "refactoring", "run", "syntax",
+            "documentation", "actions", "inlay", "navigation", "parameterinfo", "refactoring", "run", "syntax",
         ).map { "$ROOT.$it" }
 
         private val MAIN_ROOT = File("src/main/kotlin")


### PR DESCRIPTION
Fourth of the five split out of #284.

`Ctrl+P` / `Cmd+P` showed nothing in a `.phel` call — no `codeInsight.parameterInfo` was registered.

## Why the inlay hints were not already enough

They label one argument each, and can only ever reflect the arity that *already matched*. Parameter info answers a different question — "what else could I pass?" — so for a multi-arity function the popup lists every arity, greys out the ones the current argument count cannot satisfy, and bolds the parameter the caret is in. The registry already carries the data: `PhelArity.parseAll` returns them all.

## Shared judgement, not a second copy

Which calls qualify is not new logic. Special forms, interop and a local binding shadowing a known name are skipped by asking the same `PhelSpecialForms.VARIADIC_HEADS` and `PhelInteropShorthands.isInteropCall` the hints provider asks — the sets that #282 unified precisely so a second consumer could not drift from the first.

`parameterinfo` is a new feature package, so it is added to `ArchitectureBoundaryTest.FEATURE_PACKAGES` and is policed like the rest.

## Test plan

`./gradlew test` green.

`PhelParameterInfoHandlerTest` (new) drives the handler through `MockCreateParameterInfoContext` / `MockUpdateParameterInfoContext`:

| Guard | Case |
|---|---|
| a stdlib function resolves | `testOffersTheAritiesOfAStdlibFunction` |
| a project function resolves, with its real parameter names | `testOffersTheAritiesOfAProjectFunction` |
| the popup follows the caret between arguments | `testTracksWhichArgumentTheCaretIsIn`, `testTracksTheSecondArgument` |
| a special form is declined | `testDeclinesASpecialForm` |
| interop is declined | `testDeclinesInterop` |
| a shadowing local is declined | `testDeclinesALocalBindingThatShadowsAKnownName` |
| an unknown name is declined | `testDeclinesAnUnknownName` |

Two things worth noting, both found by the tests failing first:

- The project-function cases **prime the symbol index** with `refreshFileFromPsi`. `PhelArityResolver` consults it, and a `configureByText` file is not in it until something indexes it — the order-sensitivity this repo has hit before.
- My first draft asserted on `str/join`, which does not resolve without its `(:require)`. Swapped for `map`, so the stdlib case tests the registry path rather than the alias path.

Manual (`./gradlew runIde`): press Ctrl+P inside `(map )` and inside a call to a local multi-arity `defn`.

Closes #298