### PR TITLE
feat(refactoring): add Safe Delete for top-level definitions

### DIFF
--- a/src/main/kotlin/org/phellang/refactoring/PhelRefactoringSupportProvider.kt
+++ b/src/main/kotlin/org/phellang/refactoring/PhelRefactoringSupportProvider.kt
@@ -3,6 +3,7 @@ package org.phellang.refactoring
 import com.intellij.lang.refactoring.RefactoringSupportProvider
 import com.intellij.psi.PsiElement
 import org.phellang.language.psi.PhelSymbol
+import org.phellang.refactoring.safedelete.PhelSafeDeleteTarget
 
 class PhelRefactoringSupportProvider : RefactoringSupportProvider() {
 
@@ -13,4 +14,12 @@ class PhelRefactoringSupportProvider : RefactoringSupportProvider() {
     override fun isInplaceRenameAvailable(element: PsiElement, context: PsiElement?): Boolean {
         return element is PhelSymbol
     }
+
+    /**
+     * Offered for a top-level definition's name, which is what [PhelSafeDeleteProcessor] can remove
+     * whole. Deciding it here and in the processor from the same helper keeps the menu entry from
+     * appearing where the refactoring would only half-work.
+     */
+    override fun isSafeDeleteAvailable(element: PsiElement): Boolean =
+        PhelSafeDeleteTarget.enclosingFormOf(element) != null
 }

--- a/src/main/kotlin/org/phellang/refactoring/safedelete/PhelSafeDeleteProcessor.kt
+++ b/src/main/kotlin/org/phellang/refactoring/safedelete/PhelSafeDeleteProcessor.kt
@@ -1,0 +1,88 @@
+package org.phellang.refactoring.safedelete
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.search.searches.ReferencesSearch
+import com.intellij.refactoring.safeDelete.NonCodeUsageSearchInfo
+import com.intellij.refactoring.safeDelete.SafeDeleteProcessorDelegate
+import com.intellij.refactoring.safeDelete.usageInfo.SafeDeleteReferenceSimpleDeleteUsageInfo
+import com.intellij.usageView.UsageInfo
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Condition
+
+/**
+ * Safe Delete for a Phel name: finds what still refers to it, and removes the whole form.
+ *
+ * The usage search is `ReferencesSearch`, which reaches `PhelReference` — so what counts as a usage
+ * here is exactly what Find Usages and the unused-definition inspections already agree on, and it is
+ * cheap now that resolution is cached.
+ *
+ * What gets deleted is the enclosing *definition form*, not the name alone. Deleting the name of
+ * `(defn greet [name] …)` and stopping there would leave `(defn  [name] …)`, which is not what
+ * anyone means by deleting a function. [PhelSafeDeleteTarget] works out that form.
+ */
+class PhelSafeDeleteProcessor : SafeDeleteProcessorDelegate {
+
+    /**
+     * Exactly what [PhelSafeDeleteTarget] can delete, so the action is never offered for a name it
+     * would then only half-remove.
+     */
+    override fun handlesElement(element: PsiElement): Boolean = PhelSafeDeleteTarget.enclosingFormOf(element) != null
+
+    /**
+     * A usage that sits inside something already being deleted is not a reason to stop.
+     *
+     * The whole definition form goes, so its own body refers to a name that is on its way out with
+     * it — a recursive `defn` is the obvious case, and without this it would always report itself as
+     * a blocking usage.
+     */
+    override fun findUsages(
+        element: PsiElement,
+        allElementsToDelete: Array<out PsiElement>,
+        result: MutableList<in UsageInfo>,
+    ): NonCodeUsageSearchInfo {
+        val insideDeleted = Condition<PsiElement> { candidate ->
+            allElementsToDelete.any { it.isValid && it.textRange.contains(candidate.textRange) }
+        }
+
+        ReferencesSearch.search(element).forEach { reference ->
+            val usage = reference.element
+            result.add(SafeDeleteReferenceSimpleDeleteUsageInfo(usage, element, insideDeleted.value(usage)))
+        }
+
+        return NonCodeUsageSearchInfo(insideDeleted, element)
+    }
+
+    override fun getElementsToSearch(
+        element: PsiElement,
+        allElementsToDelete: MutableCollection<out PsiElement>,
+    ): MutableCollection<out PsiElement> = mutableListOf(element)
+
+    /**
+     * The rest of the form goes with the name.
+     *
+     * Returned as *additional* elements rather than deleted here: the platform owns the write action
+     * and the undo entry, and doing it early would invalidate the name before it had been searched.
+     */
+    override fun getAdditionalElementsToDelete(
+        element: PsiElement,
+        allElementsToDelete: MutableCollection<out PsiElement>,
+        askUser: Boolean,
+    ): MutableCollection<PsiElement>? {
+        val form = PhelSafeDeleteTarget.enclosingFormOf(element) ?: return null
+
+        return mutableListOf(form)
+    }
+
+    override fun preprocessUsages(project: Project, usages: Array<out UsageInfo>): Array<UsageInfo> =
+        @Suppress("UNCHECKED_CAST") (usages as Array<UsageInfo>)
+
+    override fun prepareForDeletion(element: PsiElement) = Unit
+
+    override fun isToSearchInComments(element: PsiElement?): Boolean = false
+
+    override fun setToSearchInComments(element: PsiElement?, enabled: Boolean) = Unit
+
+    override fun isToSearchForTextOccurrences(element: PsiElement?): Boolean = false
+
+    override fun setToSearchForTextOccurrences(element: PsiElement?, enabled: Boolean) = Unit
+}

--- a/src/main/kotlin/org/phellang/refactoring/safedelete/PhelSafeDeleteProcessor.kt
+++ b/src/main/kotlin/org/phellang/refactoring/safedelete/PhelSafeDeleteProcessor.kt
@@ -73,6 +73,19 @@ class PhelSafeDeleteProcessor : SafeDeleteProcessorDelegate {
         return mutableListOf(form)
     }
 
+    /**
+     * No conflicts of its own: a name that is still referenced is reported through [findUsages], and
+     * a Phel definition has no members or overrides that could conflict separately.
+     *
+     * Implemented explicitly even though newer platforms give it a default. It is still *abstract* on
+     * 2024.3, the oldest release this plugin supports, so omitting it compiles against 2025.2 and
+     * throws `AbstractMethodError` there — which is what the plugin verifier caught.
+     */
+    override fun findConflicts(
+        element: PsiElement,
+        allElementsToDelete: Array<out PsiElement>,
+    ): MutableCollection<String>? = null
+
     override fun preprocessUsages(project: Project, usages: Array<out UsageInfo>): Array<UsageInfo> =
         @Suppress("UNCHECKED_CAST") (usages as Array<UsageInfo>)
 

--- a/src/main/kotlin/org/phellang/refactoring/safedelete/PhelSafeDeleteTarget.kt
+++ b/src/main/kotlin/org/phellang/refactoring/safedelete/PhelSafeDeleteTarget.kt
@@ -1,0 +1,43 @@
+package org.phellang.refactoring.safedelete
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelSpecialForms
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.files.PhelFile
+import org.phellang.language.psi.utils.PhelPsiUtils
+
+/**
+ * What actually disappears when a Phel name is safe-deleted.
+ *
+ * A name is not a standalone thing in a Lisp: it is the second element of the form that introduces
+ * it. Deleting `greet` out of `(defn greet [name] …)` leaves `(defn  [name] …)`, so the form is the
+ * unit of deletion.
+ *
+ * Only *top-level definitions* qualify. A `let` binding or a function parameter also passes
+ * `PhelSymbolAnalyzer.isDefinition`, but removing one means editing a binding vector or a parameter
+ * list in place and repairing the pairs around it — a different operation with its own failure
+ * modes, and one the unused-binding quick fixes already cover for the case that matters.
+ */
+internal object PhelSafeDeleteTarget {
+
+    /** The top-level definition form [element] names, or null when it does not name one. */
+    fun enclosingFormOf(element: PsiElement): PhelList? {
+        val symbol = element as? PhelSymbol ?: return null
+        val form = PsiTreeUtil.getParentOfType(symbol, PhelList::class.java) ?: return null
+
+        // Top level only: a nested list is a `let`, a body form, or something else entirely.
+        if (form.parent !is PhelFile) return null
+
+        val forms = PhelPsiUtils.activeForms(form)
+        val head = PhelPsiUtils.asSymbol(forms.firstOrNull())?.text ?: return null
+        if (head !in PhelSpecialForms.DEFINITION_FORMS) return null
+
+        // The name being deleted has to be *this* form's name, not something inside its body.
+        val name = PhelPsiUtils.asSymbol(forms.getOrNull(1)) ?: return null
+        if (name !== symbol) return null
+
+        return form
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -211,6 +211,8 @@
         <lang.refactoringSupport
                 language="Phel"
                 implementationClass="org.phellang.refactoring.PhelRefactoringSupportProvider"/>
+        <refactoring.safeDeleteProcessor
+                implementation="org.phellang.refactoring.safedelete.PhelSafeDeleteProcessor"/>
         <lang.namesValidator
                 language="Phel"
                 implementationClass="org.phellang.refactoring.PhelNamesValidator"/>

--- a/src/test/kotlin/org/phellang/integration/refactoring/PhelSafeDeleteTest.kt
+++ b/src/test/kotlin/org/phellang/integration/refactoring/PhelSafeDeleteTest.kt
@@ -1,0 +1,117 @@
+package org.phellang.integration.refactoring
+
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.refactoring.BaseRefactoringProcessor
+import com.intellij.refactoring.safeDelete.SafeDeleteProcessor
+import org.phellang.indexing.PhelProjectSymbolIndex
+import org.phellang.integration.PhelIntegrationTestCase
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.files.PhelFile
+import org.phellang.refactoring.PhelRefactoringSupportProvider
+
+/**
+ * Safe Delete over a Phel definition.
+ *
+ * Two properties matter. It removes the *whole form*, because a name is not a standalone thing in a
+ * Lisp — deleting `greet` out of `(defn greet [name] …)` and stopping would leave `(defn  [name] …)`.
+ * And it refuses when something still refers to the name, which is the "safe" part.
+ */
+class PhelSafeDeleteTest : PhelIntegrationTestCase() {
+
+    private var fileIndex = 0
+
+    private fun configure(source: String): PhelFile {
+        val file = myFixture.configureByText("sd${fileIndex++}.phel", source) as PhelFile
+        // PhelReference resolves project-wide through the index; without priming, whether a usage is
+        // found would depend on which test ran first.
+        PhelProjectSymbolIndex.getInstance(project).refreshFileFromPsi(file)
+
+        return file
+    }
+
+    private fun definitionNamed(file: PhelFile, name: String): PhelSymbol =
+        PsiTreeUtil.findChildrenOfType(file, PhelSymbol::class.java).first { it.text == name }
+
+    private fun safeDelete(file: PhelFile, name: String) {
+        val target = definitionNamed(file, name)
+        SafeDeleteProcessor.createInstance(project, null, arrayOf(target), false, false, true).run()
+    }
+
+    // ---- availability ----
+
+    private val provider = PhelRefactoringSupportProvider()
+
+    fun testOfferedForATopLevelDefinition() {
+        val file = configure("(ns app\\m)\n(defn greet [name] name)\n")
+
+        assertTrue(provider.isSafeDeleteAvailable(definitionNamed(file, "greet")))
+    }
+
+    /**
+     * Not offered for a `let` binding or a parameter. Both are definitions to
+     * `PhelSymbolAnalyzer`, but removing one means editing a binding vector in place — a different
+     * operation, and one the unused-binding quick fixes already cover.
+     */
+    fun testNotOfferedForALetBinding() {
+        val file = configure("(ns app\\m)\n(defn f [] (let [x 1] x))\n")
+
+        assertFalse(provider.isSafeDeleteAvailable(definitionNamed(file, "x")))
+    }
+
+    fun testNotOfferedForAFunctionParameter() {
+        val file = configure("(ns app\\m)\n(defn f [param] param)\n")
+
+        assertFalse(provider.isSafeDeleteAvailable(definitionNamed(file, "param")))
+    }
+
+    /** A name used inside a body is not that form's own name. */
+    fun testNotOfferedForACallInsideABody() {
+        val file = configure("(ns app\\m)\n(defn helper [] 1)\n(defn f [] (helper))\n")
+
+        val usage = PsiTreeUtil.findChildrenOfType(file, PhelSymbol::class.java).last { it.text == "helper" }
+        assertFalse(provider.isSafeDeleteAvailable(usage))
+    }
+
+    // ---- deletion ----
+
+    fun testDeletesTheWholeDefinitionForm() {
+        val file = configure("(ns app\\m)\n(defn unused [x] x)\n(defn kept [] 1)\n")
+
+        safeDelete(file, "unused")
+
+        assertEquals("(ns app\\m)\n(defn kept [] 1)\n", file.text)
+    }
+
+    fun testDeletesADefRatherThanJustItsName() {
+        val file = configure("(ns app\\m)\n(def answer 42)\n(defn kept [] 1)\n")
+
+        safeDelete(file, "answer")
+
+        assertEquals("(ns app\\m)\n(defn kept [] 1)\n", file.text)
+    }
+
+    /** A recursive call is inside the form being removed, so it must not block the deletion. */
+    fun testDeletesARecursiveFunction() {
+        val file = configure("(ns app\\m)\n(defn countdown [n] (if (= n 0) 0 (countdown (- n 1))))\n")
+
+        safeDelete(file, "countdown")
+
+        assertEquals("(ns app\\m)\n", file.text)
+    }
+
+    // ---- safety ----
+
+    /** The point of the refactoring: a live usage stops it. */
+    fun testRefusesWhenTheNameIsStillUsed() {
+        val file = configure("(ns app\\m)\n(defn helper [] 1)\n(defn caller [] (helper))\n")
+
+        try {
+            safeDelete(file, "helper")
+            fail("expected safe delete to report the remaining usage, file is now: ${file.text}")
+        } catch (expected: BaseRefactoringProcessor.ConflictsInTestsException) {
+            assertTrue(expected.messages.toString(), expected.messages.isNotEmpty())
+        }
+
+        assertTrue("nothing should have been deleted: ${file.text}", file.text.contains("(defn helper [] 1)"))
+    }
+}


### PR DESCRIPTION
First of the three in #300, in the order that issue records — Safe Delete leans almost entirely on machinery that already exists.

`PhelRefactoringSupportProvider` implemented only in-place rename, so Safe Delete did nothing in a `.phel` file.

## Two decisions

**It deletes the whole form, not the name.** A name is not a standalone thing in a Lisp: deleting `greet` out of `(defn greet [name] …)` and stopping leaves `(defn  [name] …)`. `PhelSafeDeleteTarget` works out the form, and both the processor and `isSafeDeleteAvailable` ask it — so the menu entry can never appear where the refactoring would only half-work.

**Only top-level definitions qualify.** A `let` binding and a function parameter also pass `PhelSymbolAnalyzer.isDefinition`, but removing one means editing a binding vector or a parameter list *in place* and repairing the pairs around it. That is a different operation with its own failure modes, and the unused-binding quick fixes already cover the case that matters.

## Reused, not reinvented

Usages come from `ReferencesSearch`, which reaches `PhelReference` — so what blocks a deletion is exactly what Find Usages and the unused-definition inspections already agree on. It is also cheap now that resolution is cached (#293).

The `insideDeletedCondition` matters more than it looks: the whole form goes, so its body refers to a name on its way out with it. Without it a recursive `defn` would always report itself as a blocking usage.

## Test plan

`./gradlew test` green.

`PhelSafeDeleteTest` (new), driving the real `SafeDeleteProcessor`:

| Guard | Case |
|---|---|
| offered for a top-level definition | `testOfferedForATopLevelDefinition` |
| not for a `let` binding or a parameter | `testNotOfferedForALetBinding`, `...FunctionParameter` |
| not for a call inside a body | `testNotOfferedForACallInsideABody` |
| the whole `defn` form goes | `testDeletesTheWholeDefinitionForm` |
| and the whole `def` form | `testDeletesADefRatherThanJustItsName` |
| a recursive function is not blocked by itself | `testDeletesARecursiveFunction` |
| a live usage stops it, and nothing is deleted | `testRefusesWhenTheNameIsStillUsed` |

The tests prime the symbol index with `refreshFileFromPsi`, since `PhelReference` resolves project-wide through it and a `configureByText` file is not in it until something indexes it.

Manual (`./gradlew runIde`): Safe Delete an unused `defn`, then one that is still called.

Related to #300 — Extract Variable and Extract Function follow.