### PR TITLE
feat(refactoring): add Extract Variable

### DIFF
--- a/src/main/kotlin/org/phellang/refactoring/extract/PhelExtractVariable.kt
+++ b/src/main/kotlin/org/phellang/refactoring/extract/PhelExtractVariable.kt
@@ -1,0 +1,140 @@
+package org.phellang.refactoring.extract
+
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.language.psi.PhelForm
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelPsiFactory
+import org.phellang.language.psi.PhelSpecialForms
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.PhelVec
+import org.phellang.language.psi.utils.PhelPsiUtils
+
+/**
+ * Introduces a `let` binding for an expression.
+ *
+ * Where the binding goes is the decision this makes, in three cases, in order:
+ *
+ * 1. **Inside an existing `let` body** — append to that `let`'s binding vector. Nesting a second
+ *    `let` inside the first would say the same thing with more brackets.
+ * 2. **Inside a function body** — wrap the *whole body* in a new `let`. Wrapping only the expression
+ *    would produce `(let [x expr] x)`, a binding nothing else can reach.
+ * 3. **Anywhere else** — wrap the expression where it stands, which is all a `(def …)` value or a
+ *    bare top-level form allows.
+ *
+ * The rewrite is done on text and re-parsed rather than by PSI surgery. Lisp source is shaped like
+ * its tree, so building the new form as a string is both shorter and harder to get subtly wrong than
+ * splicing nodes, and the parser round-trips whatever it produces.
+ */
+internal object PhelExtractVariable {
+
+    /**
+     * Replaces [expression] with [name], bound to it. Returns the introduced binding's name symbol so
+     * the caller can offer to rename it; null when the expression cannot be extracted.
+     *
+     * The caller supplies the write action.
+     */
+    fun extract(expression: PhelForm, name: String): PhelSymbol? {
+        val plan = plan(expression, name) ?: return null
+
+        val rewritten = PhelPsiFactory.createList(expression.project, plan.text)
+        val replaced = plan.target.replace(rewritten) as? PhelList ?: return null
+
+        return bindingNamed(replaced, name)
+    }
+
+    /**
+     * True when [expression] is something this can introduce a binding for: a call.
+     *
+     * A plain `is PhelList` test, because in this grammar a list *is* a form — `form_upper` re-tags
+     * the inner rule rather than wrapping it, so there is no form node around the list to look
+     * through. [PhelPsiUtils.asSymbol] is the wrong question here for the opposite reason: it finds
+     * the symbol a form contains *anywhere*, so it answers "yes" for `(* 2 3)` on the strength of
+     * the `*`.
+     *
+     * A bare name is excluded because binding it to another name buys nothing.
+     */
+    fun canExtract(expression: PhelForm): Boolean = expression is PhelList
+
+    private class Plan(val target: PhelList, val text: String)
+
+    private fun plan(expression: PhelForm, name: String): Plan? {
+        if (!canExtract(expression)) return null
+
+        enclosingLetWithBodyContaining(expression)?.let { return appendToLet(it, expression, name) }
+        enclosingFunctionWithBodyContaining(expression)?.let { return wrapFunctionBody(it, expression, name) }
+
+        // Nowhere to hoist it to — a `(def …)` value or a bare top-level form. Binding it where it
+        // stands is all that is available, and still names the expression.
+        val itself = expression as? PhelList ?: return null
+
+        return Plan(itself, "(let [$name ${expression.text}] $name)")
+    }
+
+    /** `(let [a 1] … expr …)` becomes `(let [a 1 name expr] … name …)`. */
+    private fun appendToLet(letForm: PhelList, expression: PhelForm, name: String): Plan? {
+        val bindings = bindingVectorOf(letForm) ?: return null
+        val letStart = letForm.textRange.startOffset
+
+        val insertAt = bindings.textRange.endOffset - 1 - letStart
+        val expressionRange = expression.textRange.shiftLeft(letStart)
+        if (expressionRange.startOffset < insertAt) return null
+
+        val text = StringBuilder(letForm.text)
+        // Right to left, so the earlier offset is still valid when the later edit has been applied.
+        text.replace(expressionRange.startOffset, expressionRange.endOffset, name)
+        text.insert(insertAt, " $name ${expression.text}")
+
+        return Plan(letForm, text.toString())
+    }
+
+    /** `(defn f [x] body…)` becomes `(defn f [x] (let [name expr] body…))`. */
+    private fun wrapFunctionBody(function: PhelList, expression: PhelForm, name: String): Plan? {
+        val forms = PhelPsiUtils.activeForms(function)
+        val body = forms.drop(forms.indexOfFirst { it is PhelVec } + 1)
+        if (body.isEmpty()) return null
+
+        val functionStart = function.textRange.startOffset
+        val bodyStart = body.first().textRange.startOffset - functionStart
+        val bodyEnd = body.last().textRange.endOffset - functionStart
+
+        val bodyText = StringBuilder(function.text.substring(bodyStart, bodyEnd))
+        val expressionRange = expression.textRange.shiftLeft(functionStart + bodyStart)
+        bodyText.replace(expressionRange.startOffset, expressionRange.endOffset, name)
+
+        val text = StringBuilder(function.text)
+        text.replace(bodyStart, bodyEnd, "(let [$name ${expression.text}] $bodyText)")
+
+        return Plan(function, text.toString())
+    }
+
+    /** The nearest `let` whose *body* holds [expression] — not its binding vector. */
+    private fun enclosingLetWithBodyContaining(expression: PhelForm): PhelList? =
+        enclosingLists(expression).firstOrNull { list ->
+            val head = PhelPsiUtils.asSymbol(PhelPsiUtils.activeForms(list).firstOrNull())?.text
+            if (head !in PhelSpecialForms.LET_LIKE) return@firstOrNull false
+
+            val bindings = bindingVectorOf(list) ?: return@firstOrNull false
+            !bindings.textRange.contains(expression.textRange)
+        }
+
+    private fun enclosingFunctionWithBodyContaining(expression: PhelForm): PhelList? =
+        enclosingLists(expression).firstOrNull { list ->
+            val head = PhelPsiUtils.asSymbol(PhelPsiUtils.activeForms(list).firstOrNull())?.text
+            if (head !in PhelSpecialForms.FUNCTION_DEFINING) return@firstOrNull false
+
+            val parameters = bindingVectorOf(list) ?: return@firstOrNull false
+            !parameters.textRange.contains(expression.textRange)
+        }
+
+    /** The first vector in [list] — a `let`'s bindings, or a function's parameters. */
+    private fun bindingVectorOf(list: PhelList): PhelVec? =
+        PhelPsiUtils.activeForms(list).filterIsInstance<PhelVec>().firstOrNull()
+
+    private fun enclosingLists(from: PhelForm): Sequence<PhelList> =
+        generateSequence(PsiTreeUtil.getParentOfType(from, PhelList::class.java)) {
+            PsiTreeUtil.getParentOfType(it, PhelList::class.java)
+        }
+
+    private fun bindingNamed(form: PhelList, name: String): PhelSymbol? =
+        PsiTreeUtil.findChildrenOfType(form, PhelSymbol::class.java).firstOrNull { it.text == name }
+}

--- a/src/main/kotlin/org/phellang/refactoring/extract/PhelIntroduceVariableHandler.kt
+++ b/src/main/kotlin/org/phellang/refactoring/extract/PhelIntroduceVariableHandler.kt
@@ -1,0 +1,94 @@
+package org.phellang.refactoring.extract
+
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.refactoring.RefactoringActionHandler
+import com.intellij.refactoring.util.CommonRefactoringUtil
+import org.phellang.language.psi.PhelForm
+import org.phellang.language.psi.files.PhelFile
+
+/**
+ * Extract Variable: binds the selected expression to a `let` name.
+ *
+ * The expression is whichever form the selection covers, or the form under the caret when nothing is
+ * selected — so the refactoring works from a bare caret the way the rest of the IDE's introduce
+ * actions do.
+ *
+ * A generated name is used, unique against what is already in scope, and the caret lands on it so it
+ * can be typed over immediately. Only the selected occurrence is replaced; replacing every identical
+ * one needs a prompt to be anything but surprising, and that is a separate decision.
+ */
+class PhelIntroduceVariableHandler : RefactoringActionHandler {
+
+    override fun invoke(project: Project, editor: Editor?, file: PsiFile?, dataContext: DataContext?) {
+        if (editor == null || file !is PhelFile) return
+
+        val expression = expressionAt(editor, file)
+        if (expression == null || !PhelExtractVariable.canExtract(expression)) {
+            CommonRefactoringUtil.showErrorHint(
+                project, editor, CANNOT_EXTRACT, REFACTORING_NAME, null,
+            )
+            return
+        }
+
+        val name = uniqueNameNear(expression)
+        val introduced = WriteCommandAction.writeCommandAction(project, file)
+            .withName(REFACTORING_NAME)
+            .compute<PsiElement?, RuntimeException> { PhelExtractVariable.extract(expression, name) }
+
+        introduced?.let { editor.caretModel.moveToOffset(it.textRange.startOffset) }
+    }
+
+    /** Extract Variable is a caret/selection refactoring; the element-array entry point is not it. */
+    override fun invoke(project: Project, elements: Array<out PsiElement>, dataContext: DataContext?) = Unit
+
+    /**
+     * The selection's outermost covering form, or the innermost form at the caret.
+     *
+     * `findCommonParent` over the selection ends on whatever node spans it, which for a partial
+     * selection is the enclosing form — the nearest thing to what the user meant that is still a
+     * valid expression.
+     */
+    private fun expressionAt(editor: Editor, file: PhelFile): PhelForm? {
+        val selection = editor.selectionModel
+        if (selection.hasSelection()) {
+            val start = file.findElementAt(selection.selectionStart) ?: return null
+            val end = file.findElementAt(selection.selectionEnd - 1) ?: return null
+            val common = PsiTreeUtil.findCommonParent(start, end) ?: return null
+
+            return common as? PhelForm ?: PsiTreeUtil.getParentOfType(common, PhelForm::class.java)
+        }
+
+        val at = file.findElementAt(editor.caretModel.offset) ?: return null
+
+        return PsiTreeUtil.getParentOfType(at, PhelForm::class.java)
+    }
+
+    /**
+     * A name the enclosing top-level form does not already mention.
+     *
+     * Deliberately blunt — any whole-word occurrence disqualifies a candidate, not just a binding.
+     * The name is a placeholder the user types over, so over-avoiding costs nothing, while shadowing
+     * a binding the extracted expression itself depends on would silently change what it means.
+     */
+    private fun uniqueNameNear(expression: PhelForm): String {
+        val scope = generateSequence(expression as PsiElement) { it.parent }
+            .takeWhile { it !is PhelFile }
+            .lastOrNull()?.text.orEmpty()
+
+        return generateSequence(1) { it + 1 }
+            .map { if (it == 1) BASE_NAME else "$BASE_NAME$it" }
+            .first { candidate -> !Regex("(?<![\\w-])${Regex.escape(candidate)}(?![\\w-])").containsMatchIn(scope) }
+    }
+
+    private companion object {
+        const val REFACTORING_NAME = "Extract Variable"
+        const val CANNOT_EXTRACT = "Select an expression to extract."
+        const val BASE_NAME = "x"
+    }
+}

--- a/src/test/kotlin/org/phellang/integration/refactoring/PhelExtractVariableTest.kt
+++ b/src/test/kotlin/org/phellang/integration/refactoring/PhelExtractVariableTest.kt
@@ -1,0 +1,109 @@
+package org.phellang.integration.refactoring
+
+import com.intellij.refactoring.util.CommonRefactoringUtil
+import org.phellang.integration.PhelIntegrationTestCase
+import org.phellang.refactoring.extract.PhelIntroduceVariableHandler
+
+/**
+ * Extract Variable, driven through the handler so selection handling is exercised too.
+ *
+ * The interesting part is *where the binding goes*, and there are three answers: append to an
+ * enclosing `let`, wrap a function body, or wrap the expression where it stands. Each is a separate
+ * case below.
+ */
+class PhelExtractVariableTest : PhelIntegrationTestCase() {
+
+    private val handler = PhelIntroduceVariableHandler()
+    private var fileIndex = 0
+
+    /** `<selection>`/`</selection>` marks the expression; a bare `<caret>` uses the form at the caret. */
+    private fun extracted(source: String): String {
+        myFixture.configureByText("ev${fileIndex++}.phel", source)
+        handler.invoke(project, myFixture.editor, myFixture.file, null)
+
+        return myFixture.editor.document.text
+    }
+
+    // ---- 1. append to an enclosing let ----
+
+    /** Nesting a second `let` inside the first would say the same thing with more brackets. */
+    fun testAppendsToAnEnclosingLet() {
+        val extracted = extracted("(ns app\\m)\n(defn f [] (let [a 1] (+ a <selection>(* 2 3)</selection>)))\n")
+
+        assertEquals("(ns app\\m)\n(defn f [] (let [a 1 x (* 2 3)] (+ a x)))\n", extracted)
+    }
+
+    fun testAppendsAfterSeveralExistingBindings() {
+        val extracted = extracted("(ns app\\m)\n(defn f [] (let [a 1 b 2] <selection>(+ a b)</selection>))\n")
+
+        assertEquals("(ns app\\m)\n(defn f [] (let [a 1 b 2 x (+ a b)] x))\n", extracted)
+    }
+
+    /** An expression in the *bindings* is not in the body, so that `let` is not the target. */
+    fun testDoesNotAppendToALetWhoseBindingsHoldTheExpression() {
+        val extracted = extracted("(ns app\\m)\n(defn f [] (let [a <selection>(* 2 3)</selection>] a))\n")
+
+        assertEquals("(ns app\\m)\n(defn f [] (let [x (* 2 3)] (let [a x] a)))\n", extracted)
+    }
+
+    // ---- 2. wrap a function body ----
+
+    /** Wrapping only the expression would give `(let [x expr] x)`, a binding nothing can reach. */
+    fun testWrapsAFunctionBody() {
+        val extracted = extracted("(ns app\\m)\n(defn f [] (+ 1 <selection>(* 2 3)</selection>))\n")
+
+        assertEquals("(ns app\\m)\n(defn f [] (let [x (* 2 3)] (+ 1 x)))\n", extracted)
+    }
+
+    fun testWrapsEveryBodyFormNotJustTheOneHoldingTheExpression() {
+        val extracted = extracted("(ns app\\m)\n(defn f [] (println 1) (+ 1 <selection>(* 2 3)</selection>))\n")
+
+        assertEquals("(ns app\\m)\n(defn f [] (let [x (* 2 3)] (println 1) (+ 1 x)))\n", extracted)
+    }
+
+    /** A parameter vector is not a body, so the expression must be past it. */
+    fun testWrapsTheBodyOfAFunctionWithParameters() {
+        val extracted = extracted("(ns app\\m)\n(defn f [n] (+ n <selection>(* 2 3)</selection>))\n")
+
+        assertEquals("(ns app\\m)\n(defn f [n] (let [x (* 2 3)] (+ n x)))\n", extracted)
+    }
+
+    // ---- 3. wrap where it stands ----
+
+    /** A `def` value is not a body; wrapping in place is all it allows. */
+    fun testWrapsADefValueWhereItStands() {
+        val extracted = extracted("(ns app\\m)\n(def answer <selection>(+ 1 2)</selection>)\n")
+
+        assertEquals("(ns app\\m)\n(def answer (let [x (+ 1 2)] x))\n", extracted)
+    }
+
+    // ---- naming ----
+
+    /** The placeholder must not shadow something the expression itself depends on. */
+    fun testAvoidsANameAlreadyInUse() {
+        val extracted = extracted("(ns app\\m)\n(defn f [x] (+ x <selection>(* 2 3)</selection>))\n")
+
+        assertEquals("(ns app\\m)\n(defn f [x] (let [x2 (* 2 3)] (+ x x2)))\n", extracted)
+    }
+
+    // ---- declining ----
+
+    /**
+     * A bare name is already a name; binding it to another buys nothing. The user is told rather
+     * than left wondering why nothing happened.
+     */
+    fun testDeclinesASymbolAndSaysWhy() {
+        try {
+            extracted("(ns app\\m)\n(defn f [n] (+ n <selection>n</selection>))\n")
+            fail("expected the refactoring to decline a bare symbol")
+        } catch (expected: CommonRefactoringUtil.RefactoringErrorHintException) {
+            assertEquals("Select an expression to extract.", expected.message)
+        }
+    }
+
+    fun testUsesTheFormAtTheCaretWhenNothingIsSelected() {
+        val extracted = extracted("(ns app\\m)\n(defn f [] (+ 1 (* 2<caret> 3)))\n")
+
+        assertEquals("(ns app\\m)\n(defn f [] (let [x (* 2 3)] (+ 1 x)))\n", extracted)
+    }
+}


### PR DESCRIPTION
Second of the three in #300. Stacked conceptually on #307 (Safe Delete) but touches different files, so it merges independently.

## The decision this makes

Binding the selected expression to a `let` name is easy; deciding *where the binding goes* is the refactoring. Three answers, tried in order:

| Situation | Result |
|---|---|
| inside an existing `let` body | append to its binding vector — `(let [a 1] (+ a (* 2 3)))` → `(let [a 1 x (* 2 3)] (+ a x))` |
| inside a function body | wrap the **whole body** — `(defn f [] (+ 1 (* 2 3)))` → `(defn f [] (let [x (* 2 3)] (+ 1 x)))` |
| anywhere else | wrap where it stands — all a `(def …)` value allows |

Nesting a second `let` inside the first would say the same thing with more brackets. Wrapping only the expression would give `(let [x expr] x)`, a binding nothing else can reach.

Note the `let` case is gated on the expression being in the **body**, not the binding vector: extracting out of `(let [a (* 2 3)] a)` cannot append to the very vector it sits in, so it falls through to wrapping.

## Approach

The rewrite builds the new form as **text** and re-parses it rather than splicing PSI. Lisp source is shaped like its tree, so the string is shorter and harder to get subtly wrong, and the parser round-trips whatever it produces.

The placeholder name avoids anything the enclosing top-level form already mentions — deliberately blunt, since the name is typed over immediately and shadowing a binding the expression depends on would silently change its meaning. `(defn f [x] …)` therefore extracts to `x2`.

Only the selected occurrence is replaced. Replacing every identical one needs a prompt to be anything but surprising, and that is a separate decision.

## Two things the tests corrected

Worth recording, because both were wrong assumptions about the PSI rather than bugs in the logic:

- **A list *is* a form in this grammar.** `upper form_upper ::= form_inner {elementType=form}` re-tags the inner rule rather than wrapping it, so there is no form node around a `PhelList` to look through. My first draft went hunting for one.
- **`PhelPsiUtils.asSymbol` is the wrong question for "is this a bare name".** It resolves a form to the symbol it contains *anywhere*, so it answered yes for `(* 2 3)` on the strength of the `*` — which rejected every expression worth extracting.

## Test plan

`./gradlew test` green.

`PhelExtractVariableTest` (new), driven through the handler so selection handling is exercised: three cases for each placement rule, plus a parameterised function body, multi-form bodies, the naming collision, a bare `<caret>` with no selection, and a declined bare symbol that asserts the user is *told* rather than left with nothing happening.

Manual (`./gradlew runIde`): select `(* 2 3)` inside a `defn` and inside a `let`, and check the result in both.

Related to #300 — Extract Function follows.