### PR TITLE
feat(refactoring): add Extract Function

### DIFF
--- a/src/main/kotlin/org/phellang/refactoring/PhelExtractFunctionAction.kt
+++ b/src/main/kotlin/org/phellang/refactoring/PhelExtractFunctionAction.kt
@@ -1,0 +1,36 @@
+package org.phellang.refactoring
+
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import org.phellang.language.psi.files.PhelFile
+import org.phellang.refactoring.extract.PhelExtractFunctionHandler
+
+/**
+ * The Refactor menu entry for Extract Function.
+ *
+ * An action of its own because the platform has no language-agnostic extract-method extension point:
+ * `RefactoringSupportProvider` offers hooks for introducing variables, constants, fields and
+ * parameters, but the Extract Method action is Java's. Registering here gives Phel the same menu
+ * position without pretending to be that.
+ */
+class PhelExtractFunctionAction : AnAction() {
+
+    private val handler = PhelExtractFunctionHandler()
+
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
+
+    override fun update(e: AnActionEvent) {
+        e.presentation.isEnabledAndVisible = e.getData(CommonDataKeys.PSI_FILE) is PhelFile &&
+                e.getData(CommonDataKeys.EDITOR) != null
+    }
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.getData(CommonDataKeys.PROJECT) ?: return
+        val editor = e.getData(CommonDataKeys.EDITOR) ?: return
+        val file = e.getData(CommonDataKeys.PSI_FILE) ?: return
+
+        handler.invoke(project, editor, file, e.dataContext)
+    }
+}

--- a/src/main/kotlin/org/phellang/refactoring/extract/PhelExtractFunctionHandler.kt
+++ b/src/main/kotlin/org/phellang/refactoring/extract/PhelExtractFunctionHandler.kt
@@ -1,0 +1,116 @@
+package org.phellang.refactoring.extract
+
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.refactoring.RefactoringActionHandler
+import com.intellij.refactoring.util.CommonRefactoringUtil
+import org.phellang.language.psi.PhelForm
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelPsiFactory
+import org.phellang.language.psi.files.PhelFile
+
+/**
+ * Extract Function: lifts the selected expression into a new top-level `defn` and calls it.
+ *
+ * The parameter list is derived, not asked for: [PhelFreeVariables] works out which locals the
+ * expression uses but does not bind, and those become the parameters, in the order they appear.
+ * Everything else it references — globals, stdlib, `(:require)`d names — resolves the same from the
+ * new function's position, so it needs no help.
+ *
+ * The new `defn` goes immediately before the top-level form the expression came from, which is where
+ * a reader looks for it and keeps the diff local.
+ */
+class PhelExtractFunctionHandler : RefactoringActionHandler {
+
+    override fun invoke(project: Project, editor: Editor?, file: PsiFile?, dataContext: DataContext?) {
+        if (editor == null || file !is PhelFile) return
+
+        val expression = expressionAt(editor, file)
+        if (expression == null || expression !is PhelList) {
+            CommonRefactoringUtil.showErrorHint(project, editor, CANNOT_EXTRACT, REFACTORING_NAME, null)
+            return
+        }
+
+        val enclosing = topLevelFormOf(expression)
+        if (enclosing == null || enclosing === expression) {
+            CommonRefactoringUtil.showErrorHint(project, editor, NOTHING_TO_LIFT, REFACTORING_NAME, null)
+            return
+        }
+
+        val name = uniqueNameIn(file)
+        val parameters = PhelFreeVariables.of(expression)
+
+        val call = WriteCommandAction.writeCommandAction(project, file)
+            .withName(REFACTORING_NAME)
+            .compute<PsiElement?, RuntimeException> { extract(file, enclosing, expression, name, parameters) }
+
+        call?.let { editor.caretModel.moveToOffset(it.textRange.startOffset) }
+    }
+
+    override fun invoke(project: Project, elements: Array<out PsiElement>, dataContext: DataContext?) = Unit
+
+    private fun extract(
+        file: PhelFile,
+        enclosing: PhelList,
+        expression: PhelList,
+        name: String,
+        parameters: List<String>,
+    ): PsiElement {
+        val definition = PhelPsiFactory.createList(
+            file.project,
+            "(defn $name [${parameters.joinToString(" ")}]\n  ${expression.text})",
+        )
+
+        // The call replaces the expression first: adding the definition above shifts every offset
+        // below it, and the expression's own node is what is being swapped out.
+        val callText = if (parameters.isEmpty()) "($name)" else "($name ${parameters.joinToString(" ")})"
+        val call = expression.replace(PhelPsiFactory.createList(file.project, callText))
+
+        file.addBefore(definition, enclosing)
+        file.addBefore(PhelPsiFactory.createWhitespace(file.project, "\n\n"), enclosing)
+
+        return call
+    }
+
+    /** The outermost list the expression sits in — the `defn` or `def` it belongs to. */
+    private fun topLevelFormOf(expression: PhelForm): PhelList? =
+        generateSequence(PsiTreeUtil.getParentOfType(expression, PhelList::class.java, false)) {
+            PsiTreeUtil.getParentOfType(it, PhelList::class.java)
+        }.lastOrNull { it.parent is PhelFile }
+
+    private fun expressionAt(editor: Editor, file: PhelFile): PhelForm? {
+        val selection = editor.selectionModel
+        if (selection.hasSelection()) {
+            val start = file.findElementAt(selection.selectionStart) ?: return null
+            val end = file.findElementAt(selection.selectionEnd - 1) ?: return null
+            val common = PsiTreeUtil.findCommonParent(start, end) ?: return null
+
+            return common as? PhelForm ?: PsiTreeUtil.getParentOfType(common, PhelForm::class.java)
+        }
+
+        val at = file.findElementAt(editor.caretModel.offset) ?: return null
+
+        return PsiTreeUtil.getParentOfType(at, PhelForm::class.java)
+    }
+
+    /** A name the file does not already mention, so the new `defn` cannot collide with one. */
+    private fun uniqueNameIn(file: PhelFile): String {
+        val text = file.text
+
+        return generateSequence(1) { it + 1 }
+            .map { if (it == 1) BASE_NAME else "$BASE_NAME$it" }
+            .first { candidate -> !Regex("(?<![\\w-])${Regex.escape(candidate)}(?![\\w-])").containsMatchIn(text) }
+    }
+
+    private companion object {
+        const val REFACTORING_NAME = "Extract Function"
+        const val CANNOT_EXTRACT = "Select an expression to extract into a function."
+        const val NOTHING_TO_LIFT = "This expression is already a top-level form."
+        const val BASE_NAME = "extracted"
+    }
+}

--- a/src/main/kotlin/org/phellang/refactoring/extract/PhelFreeVariables.kt
+++ b/src/main/kotlin/org/phellang/refactoring/extract/PhelFreeVariables.kt
@@ -1,0 +1,99 @@
+package org.phellang.refactoring.extract
+
+import com.intellij.psi.util.PsiTreeUtil
+import org.phellang.language.psi.PhelForm
+import org.phellang.language.psi.PhelList
+import org.phellang.language.psi.PhelSpecialForms
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.PhelVec
+import org.phellang.language.psi.analysis.PhelLocalBindingScope
+import org.phellang.language.psi.utils.PhelPsiUtils
+
+/**
+ * The locals an expression uses but does not itself bind — the parameter list a function extracted
+ * from it must take.
+ *
+ * A name qualifies when it resolves to a local binding *and* nothing inside the expression binds it.
+ * The first half is [PhelLocalBindingScope], which is what already decides that a shadowing local is
+ * a different function from the stdlib name it shadows; the second is what keeps a `let` written
+ * inside the selection from being passed in as an argument to itself.
+ *
+ * Globals, stdlib names and `(:require)`d functions are not free variables: they resolve the same
+ * from anywhere in the file, so the extracted function reaches them without help.
+ */
+internal object PhelFreeVariables {
+
+    /** In first-appearance order, so the generated parameter list reads like the expression does. */
+    fun of(expression: PhelForm): List<String> {
+        val boundInside = boundWithin(expression)
+        val free = LinkedHashSet<String>()
+
+        for (symbol in PsiTreeUtil.findChildrenOfType(expression, PhelSymbol::class.java)) {
+            val name = symbol.text ?: continue
+            if (name in boundInside) continue
+            if (isBindingSite(symbol)) continue
+            if (!PhelLocalBindingScope.resolvesToLocalBinding(symbol, name)) continue
+
+            free.add(name)
+        }
+
+        return free.toList()
+    }
+
+    /**
+     * Every name introduced by a binding vector inside [expression], including one it introduces
+     * itself.
+     *
+     * `findChildrenOfType` returns descendants only, so selecting the `(let [a 1] …)` *itself* left
+     * its own `a` unaccounted for and passed it in as an argument to itself.
+     */
+    private fun boundWithin(expression: PhelForm): Set<String> {
+        val bound = HashSet<String>()
+        val lists = listOfNotNull(expression as? PhelList) +
+                PsiTreeUtil.findChildrenOfType(expression, PhelList::class.java)
+
+        for (list in lists) {
+            val head = PhelPsiUtils.asSymbol(PhelPsiUtils.activeForms(list).firstOrNull())?.text ?: continue
+            if (head !in PhelSpecialForms.LET_LIKE && head !in PhelSpecialForms.FUNCTION_DEFINING) continue
+
+            val vector = PhelPsiUtils.activeForms(list).filterIsInstance<PhelVec>().firstOrNull() ?: continue
+            bound += namesIn(vector, isBindingVector = head in PhelSpecialForms.LET_LIKE)
+        }
+
+        return bound
+    }
+
+    /**
+     * A `let` vector binds every *even* element; a parameter vector binds all of them.
+     *
+     * Taking every symbol in a `let` vector would treat its initialisers as bindings too, so
+     * `(let [a (f b)] …)` would wrongly report `b` as bound rather than free.
+     */
+    private fun namesIn(vector: PhelVec, isBindingVector: Boolean): List<String> {
+        val forms = PhelPsiUtils.activeForms(vector)
+        val binding = if (isBindingVector) forms.filterIndexed { index, _ -> index % 2 == 0 } else forms
+
+        return binding.mapNotNull { PhelPsiUtils.asSymbol(it)?.text }
+    }
+
+    /**
+     * True when [symbol] is being introduced here rather than read.
+     *
+     * The symbol has to be a *direct* element of the vector, at an even index when the vector binds
+     * pairs. Treating every symbol inside one as bound made `n` in `(let [a (* n 2)] …)` a binding
+     * rather than the free variable it is, so the extracted function took `a` and not `n`.
+     */
+    private fun isBindingSite(symbol: PhelSymbol): Boolean {
+        val vector = PsiTreeUtil.getParentOfType(symbol, PhelVec::class.java) ?: return false
+        val owner = PsiTreeUtil.getParentOfType(vector, PhelList::class.java) ?: return false
+        val head = PhelPsiUtils.asSymbol(PhelPsiUtils.activeForms(owner).firstOrNull())?.text ?: return false
+
+        val binds = head in PhelSpecialForms.LET_LIKE || head in PhelSpecialForms.FUNCTION_DEFINING
+        if (!binds) return false
+
+        val index = PhelPsiUtils.activeForms(vector).indexOfFirst { PhelPsiUtils.asSymbol(it) === symbol }
+        if (index < 0) return false
+
+        return head !in PhelSpecialForms.LET_LIKE || index % 2 == 0
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -234,6 +234,13 @@
 
         <!-- The group hides itself outside Phel files; see PhelPareditActionGroup. Without the
              add-to-group these actions had no menu at all and were reachable only by chord. -->
+        <action id="Phel.ExtractFunction"
+                class="org.phellang.refactoring.PhelExtractFunctionAction"
+                text="Extract Ph_el Function..."
+                description="Lift the selected expression into a new top-level defn">
+            <add-to-group group-id="RefactoringMenu" anchor="last"/>
+        </action>
+
         <group id="Phel.Paredit" text="Phel Paredit" popup="true"
                class="org.phellang.editor.paredit.PhelPareditActionGroup">
             <add-to-group group-id="EditorPopupMenu" anchor="last"/>

--- a/src/test/kotlin/org/phellang/integration/refactoring/PhelExtractFunctionTest.kt
+++ b/src/test/kotlin/org/phellang/integration/refactoring/PhelExtractFunctionTest.kt
@@ -1,0 +1,127 @@
+package org.phellang.integration.refactoring
+
+import com.intellij.refactoring.util.CommonRefactoringUtil
+import org.phellang.integration.PhelIntegrationTestCase
+import org.phellang.refactoring.extract.PhelExtractFunctionHandler
+
+/**
+ * Extract Function.
+ *
+ * The interesting part is the **parameter list**, which is derived rather than asked for: the locals
+ * the expression uses but does not bind become its parameters, and everything else it references —
+ * globals, stdlib, required names — resolves the same from the new function's position.
+ */
+class PhelExtractFunctionTest : PhelIntegrationTestCase() {
+
+    private val handler = PhelExtractFunctionHandler()
+    private var fileIndex = 0
+
+    private fun extracted(source: String): String {
+        myFixture.configureByText("ef${fileIndex++}.phel", source)
+        handler.invoke(project, myFixture.editor, myFixture.file, null)
+
+        return myFixture.editor.document.text
+    }
+
+    // ---- the parameter list ----
+
+    /** Nothing local is used, so the function takes nothing. */
+    fun testTakesNoParametersWhenTheExpressionIsSelfContained() {
+        val extracted = extracted("(ns app\\m)\n(defn f [] <selection>(* 2 3)</selection>)\n")
+
+        assertEquals("(ns app\\m)\n(defn extracted []\n  (* 2 3))\n\n(defn f [] (extracted))\n", extracted)
+    }
+
+    /** A parameter of the enclosing function is a local the expression does not bind. */
+    fun testTakesAnEnclosingParameterAsAParameter() {
+        val extracted = extracted("(ns app\\m)\n(defn f [n] <selection>(* n 2)</selection>)\n")
+
+        assertEquals("(ns app\\m)\n(defn extracted [n]\n  (* n 2))\n\n(defn f [n] (extracted n))\n", extracted)
+    }
+
+    fun testTakesALetBindingFromOutsideTheSelection() {
+        val extracted = extracted("(ns app\\m)\n(defn f [] (let [a 1] <selection>(+ a 2)</selection>))\n")
+
+        assertEquals("(ns app\\m)\n(defn extracted [a]\n  (+ a 2))\n\n(defn f [] (let [a 1] (extracted a)))\n", extracted)
+    }
+
+    /** In first-appearance order, so the signature reads like the expression does. */
+    fun testTakesSeveralLocalsInTheOrderTheyAppear() {
+        val extracted = extracted("(ns app\\m)\n(defn f [a b] <selection>(+ b a)</selection>)\n")
+
+        assertEquals("(ns app\\m)\n(defn extracted [b a]\n  (+ b a))\n\n(defn f [a b] (extracted b a))\n", extracted)
+    }
+
+    /** A name bound *inside* the selection travels with it and is not passed in. */
+    fun testDoesNotTakeALetBoundInsideTheSelection() {
+        val extracted = extracted("(ns app\\m)\n(defn f [] <selection>(let [a 1] (+ a 2))</selection>)\n")
+
+        assertEquals(
+            "(ns app\\m)\n(defn extracted []\n  (let [a 1] (+ a 2)))\n\n(defn f [] (extracted))\n",
+            extracted,
+        )
+    }
+
+    /** But a free name used in that inner `let`'s initialiser still is: it comes from outside. */
+    fun testStillTakesALocalUsedInsideAnInnerLetInitialiser() {
+        val extracted = extracted("(ns app\\m)\n(defn f [n] <selection>(let [a (* n 2)] a)</selection>)\n")
+
+        assertEquals(
+            "(ns app\\m)\n(defn extracted [n]\n  (let [a (* n 2)] a))\n\n(defn f [n] (extracted n))\n",
+            extracted,
+        )
+    }
+
+    /** A stdlib call resolves from anywhere; passing it in would be nonsense. */
+    fun testDoesNotTakeStdlibNamesAsParameters() {
+        val extracted = extracted("(ns app\\m)\n(defn f [xs] <selection>(map inc xs)</selection>)\n")
+
+        assertEquals("(ns app\\m)\n(defn extracted [xs]\n  (map inc xs))\n\n(defn f [xs] (extracted xs))\n", extracted)
+    }
+
+    /** So does another top-level definition in the same file. */
+    fun testDoesNotTakeATopLevelDefinitionAsAParameter() {
+        val extracted = extracted("(ns app\\m)\n(defn helper [] 1)\n(defn f [] <selection>(+ (helper) 2)</selection>)\n")
+
+        assertTrue("helper must not become a parameter: $extracted", extracted.contains("(defn extracted []"))
+    }
+
+    // ---- placement ----
+
+    /** Immediately above the form it came from, which is where a reader looks for it. */
+    fun testPlacesTheNewFunctionAboveItsOrigin() {
+        val extracted = extracted("(ns app\\m)\n(defn first-fn [] 1)\n(defn f [n] <selection>(* n 2)</selection>)\n")
+
+        val definitionAt = extracted.indexOf("(defn extracted")
+        val originAt = extracted.indexOf("(defn f [n]")
+        assertTrue("expected the new defn above f: $extracted", definitionAt in 1..<originAt)
+        assertTrue("and below first-fn: $extracted", extracted.indexOf("(defn first-fn") < definitionAt)
+    }
+
+    fun testAvoidsANameTheFileAlreadyUses() {
+        val extracted = extracted("(ns app\\m)\n(defn extracted [] 0)\n(defn f [n] <selection>(* n 2)</selection>)\n")
+
+        assertTrue("expected a fresh name: $extracted", extracted.contains("(defn extracted2 [n]"))
+    }
+
+    // ---- declining ----
+
+    fun testDeclinesABareSymbol() {
+        try {
+            extracted("(ns app\\m)\n(defn f [n] (+ n <selection>n</selection>))\n")
+            fail("expected the refactoring to decline a bare symbol")
+        } catch (expected: CommonRefactoringUtil.RefactoringErrorHintException) {
+            assertEquals("Select an expression to extract into a function.", expected.message)
+        }
+    }
+
+    /** A whole top-level form is already a function; there is nothing to lift it out of. */
+    fun testDeclinesAWholeTopLevelForm() {
+        try {
+            extracted("(ns app\\m)\n<selection>(defn f [] 1)</selection>\n")
+            fail("expected the refactoring to decline a top-level form")
+        } catch (expected: CommonRefactoringUtil.RefactoringErrorHintException) {
+            assertEquals("This expression is already a top-level form.", expected.message)
+        }
+    }
+}


### PR DESCRIPTION
Last of the three in #300, and the one the issue called out as needing real design.

Lifts the selected expression into a new top-level `defn` and calls it.

## The parameter list is derived, not asked for

That is the whole refactoring. `PhelFreeVariables` works out which locals the expression *uses but does not bind*, and those become the parameters, in first-appearance order so the signature reads like the expression does.

```phel
(defn f [n] (let [a 1] (+ a n)))
;; extracting (+ a n)  ->  (defn extracted [a n] (+ a n))
```

Everything else it references — globals, stdlib, `(:require)`d names — resolves the same from the new function's position, so it needs no help. The first half of that judgement is `PhelLocalBindingScope`, which already decides that a shadowing local is a different function from the stdlib name it shadows.

## Its own action

The platform has no language-agnostic extract-method extension point. `RefactoringSupportProvider` offers `getIntroduceVariableHandler`, `...ConstantHandler`, `...FieldHandler`, `...ParameterHandler` — and the Extract Method action is Java's. I checked the EP declarations in the SDK rather than assume.

So this registers a `PhelExtractFunctionAction` into `RefactoringMenu`, giving Phel the same menu position without pretending to be that action. It hides itself outside Phel files.

## Two analysis bugs the tests caught

Both were wrong assumptions, and both would have shipped silently:

- **`findChildrenOfType` returns descendants only.** Selecting a `(let [a 1] …)` *itself* left its own `a` unaccounted for, so the extracted function took `a` as a parameter and was then passed it as an argument to itself.
- **Not every symbol in a binding vector is bound.** `n` in `(let [a (* n 2)] …)` sits inside the vector but is an *initialiser operand*, not a binding. Treating position as membership made the extracted function take `a` and not `n` — precisely backwards.

Binding-site detection is now direct membership, at an even index for pair-binding vectors.

## Test plan

`./gradlew test` green.

`PhelExtractFunctionTest` (new), 12 cases weighted to the parameter analysis:

| Guard | Case |
|---|---|
| self-contained expression takes nothing | `testTakesNoParametersWhenTheExpressionIsSelfContained` |
| an enclosing parameter, a `let` binding | `testTakesAnEnclosingParameterAsAParameter`, `...ALetBindingFromOutsideTheSelection` |
| first-appearance order | `testTakesSeveralLocalsInTheOrderTheyAppear` |
| a `let` bound *inside* travels with it | `testDoesNotTakeALetBoundInsideTheSelection` |
| but a free name in its initialiser does not | `testStillTakesALocalUsedInsideAnInnerLetInitialiser` |
| stdlib and sibling definitions are not parameters | `testDoesNotTakeStdlibNamesAsParameters`, `...ATopLevelDefinitionAsAParameter` |
| placed directly above its origin | `testPlacesTheNewFunctionAboveItsOrigin` |
| name collision avoided | `testAvoidsANameTheFileAlreadyUses` |
| declines a bare symbol and a whole top-level form, saying why | two cases |

Manual (`./gradlew runIde`): select an expression using a parameter and a `let` binding, run Refactor > Extract Phel Function, and check the signature.

Closes #300
