### PR TITLE
chore: add a manual-test project for the sandbox

### DIFF
--- a/manual-test/README.md
+++ b/manual-test/README.md
@@ -1,0 +1,36 @@
+# Manual test project
+
+A small Phel project to open in the plugin sandbox, so the features that are awkward to assert
+headlessly can be exercised by hand.
+
+```bash
+./gradlew runIde --args="$PWD/manual-test"
+```
+
+The `--args` passes the project path straight through to the IDE, so the sandbox opens here rather
+than on the welcome screen.
+
+## What it covers
+
+`src/refactoring.phel` is annotated per form with what to select and what to expect. It is arranged
+so each refactoring has both an interesting case and a case that must be *declined*:
+
+| Feature | Interesting case | Must decline / must not |
+|---|---|---|
+| Extract Variable | appends to an existing `let` rather than nesting one | wraps the body when there is no `let` |
+| Extract Function | derives the parameter list from free variables | `str` is stdlib, must not become a parameter |
+| Safe Delete | removes the whole form, not just the name | refuses while a usage remains; a recursive call is not a usage |
+| Parameter info | `Ctrl+P` inside a call | — |
+| Smart enter | Complete Current Statement closes open brackets | — |
+| Optimize Imports | drops the unused `json` require | keeps the used `str` one |
+| TODO indexing | the `TODO` comment reaches the TODO tool window | — |
+
+## Why it exists
+
+`./gradlew runIde` is the documented manual-test path, but there was nothing to open in it — so
+every manual check started by hand-writing a file first. The transformations themselves are covered
+by the integration suite; this is for the parts that need eyes on the IDE: menu placement, popup
+rendering, gutter icons and the file-type icon.
+
+It is not built, tested or shipped. `phel-config.php` is here only so the layout looks like a real
+Phel project to the plugin.

--- a/manual-test/phel-config.php
+++ b/manual-test/phel-config.php
@@ -1,0 +1,2 @@
+<?php
+return (new \Phel\Config\PhelConfig())->setSrcDirs(['src'])->setTestDirs(['tests']);

--- a/manual-test/src/refactoring.phel
+++ b/manual-test/src/refactoring.phel
@@ -1,0 +1,55 @@
+(ns manual-test\refactoring
+  (:require phel\str :as str)
+  (:require phel\json :as json))
+
+; --- Extract Variable: wraps the body, because there is no enclosing let ---
+; Select (* width height) and press the Extract Variable shortcut.
+; Expect: (defn area [width height] (let [x (* width height)] x))
+(defn area [width height]
+  (* width height))
+
+; --- Extract Variable: appends to the existing let, rather than nesting a second one ---
+; Select (* width height).
+; Expect: (let [label "box" x (* width height)] ...)
+;
+; --- Extract Function: the payoff is the derived signature ---
+; Select (str label ": " (* width height)) and run Refactor > Extract Phel Function.
+; Expect: [label width height]. `str` is stdlib and must NOT become a parameter.
+(defn describe [width height]
+  (let [label "box"]
+    (str label ": " (* width height))))
+
+; --- Extract Function: a let bound INSIDE the selection travels with it ---
+; Select the whole (let [scale 2] ...) form.
+; Expect: [n] only. `scale` is bound inside, `n` comes from outside.
+(defn scaled [n]
+  (let [scale 2]
+    (* n scale)))
+
+; --- Safe Delete: nothing references this, so the whole form goes ---
+; Put the caret on the name and press Safe Delete.
+(defn unused-helper [x]
+  (+ x 1))
+
+; --- Safe Delete: refuses, because `used-helper` is called below ---
+; Expect a usage report rather than a deletion.
+(defn used-helper [x]
+  (+ x 1))
+
+(defn calls-the-helper [n]
+  (used-helper n))
+
+; --- Safe Delete: a recursive function must not block on its own call ---
+(defn countdown [n]
+  (if (= n 0) 0 (countdown (- n 1))))
+
+; --- Parameter info: press Ctrl+P inside the call ---
+; --- Smart enter: delete a closing paren, then Complete Current Statement ---
+(defn totals [xs]
+  (map inc xs))
+
+; --- Optimize Imports: json is required above but never used ---
+; Expect the json require to go and the str one to stay.
+
+; --- TODO indexing: this should appear in the TODO tool window ---
+; TODO check this file still covers every refactoring


### PR DESCRIPTION
A small Phel project to open in the plugin sandbox.

`./gradlew runIde` is the documented manual-test path in `CLAUDE.md`, but there was nothing to open in it — so every manual check started by hand-writing a file first. This is that file, kept.

```bash
./gradlew runIde --args="$PWD/manual-test"
```

`--args` passes the project path straight to the IDE, so the sandbox opens on the project rather than the welcome screen.

## What is in it

`src/refactoring.phel` is annotated per form with what to select and what to expect. It is arranged so each refactoring has both an interesting case **and** a case it must *decline* — the declines are the ones worth eyeballing, since they are where a refactoring quietly does the wrong thing:

- **Extract Variable** — appends to an existing `let` rather than nesting a second one; wraps the body when there is no `let`.
- **Extract Function** — derives the parameter list from free variables. `str` is stdlib and must not become a parameter; a `let` bound *inside* the selection travels with it.
- **Safe Delete** — removes the whole form; refuses while a usage remains; does not block on a recursive call.
- Plus parameter info, smart enter, Optimize Imports (unused `json` require goes, used `str` one stays), and a `TODO` for the TODO tool window.

## Scope

Not built, tested or shipped: it sits outside `src/main` and `src/test`, so no source set picks it up. Verified `./gradlew test` is unaffected. `phel-config.php` is there only so the layout reads as a real Phel project to the plugin.

This exists for the parts the integration suite cannot cover — menu placement, popup rendering, gutter icons, the file-type icon. The transformations themselves are already covered headlessly.

Related to #300