### PR TITLE
fix(refactoring): register the Extract Variable handler

### DIFF
--- a/src/main/kotlin/org/phellang/refactoring/PhelRefactoringSupportProvider.kt
+++ b/src/main/kotlin/org/phellang/refactoring/PhelRefactoringSupportProvider.kt
@@ -1,8 +1,10 @@
 package org.phellang.refactoring
 
 import com.intellij.lang.refactoring.RefactoringSupportProvider
+import com.intellij.refactoring.RefactoringActionHandler
 import com.intellij.psi.PsiElement
 import org.phellang.language.psi.PhelSymbol
+import org.phellang.refactoring.extract.PhelIntroduceVariableHandler
 import org.phellang.refactoring.safedelete.PhelSafeDeleteTarget
 
 class PhelRefactoringSupportProvider : RefactoringSupportProvider() {
@@ -22,4 +24,14 @@ class PhelRefactoringSupportProvider : RefactoringSupportProvider() {
      */
     override fun isSafeDeleteAvailable(element: PsiElement): Boolean =
         PhelSafeDeleteTarget.enclosingFormOf(element) != null
+
+    /**
+     * What makes the platform's Extract Variable action light up for Phel.
+     *
+     * `IntroduceVariableAction` asks every provider registered for the file's language for a handler
+     * and hides itself when none returns one, so this method *is* the registration — the handler
+     * existing is not enough. It went missing once and nothing noticed, because the tests built
+     * [PhelIntroduceVariableHandler] directly instead of going through the action.
+     */
+    override fun getIntroduceVariableHandler(): RefactoringActionHandler = PhelIntroduceVariableHandler()
 }

--- a/src/main/kotlin/org/phellang/refactoring/safedelete/PhelSafeDeleteProcessor.kt
+++ b/src/main/kotlin/org/phellang/refactoring/safedelete/PhelSafeDeleteProcessor.kt
@@ -40,8 +40,16 @@ class PhelSafeDeleteProcessor : SafeDeleteProcessorDelegate {
         allElementsToDelete: Array<out PsiElement>,
         result: MutableList<in UsageInfo>,
     ): NonCodeUsageSearchInfo {
+        // Against the *forms* being removed, not the names selected. At this point
+        // allElementsToDelete holds the name symbol alone — the enclosing form is contributed later,
+        // by getAdditionalElementsToDelete — so a range test against it can never contain anything,
+        // and a recursive call was reported as a usage blocking its own definition's deletion.
+        val deletedRanges = allElementsToDelete
+            .filter { it.isValid }
+            .map { (PhelSafeDeleteTarget.enclosingFormOf(it) ?: it).textRange }
+
         val insideDeleted = Condition<PsiElement> { candidate ->
-            allElementsToDelete.any { it.isValid && it.textRange.contains(candidate.textRange) }
+            deletedRanges.any { it.contains(candidate.textRange) }
         }
 
         ReferencesSearch.search(element).forEach { reference ->

--- a/src/test/kotlin/org/phellang/integration/refactoring/PhelRefactoringActionsRegisteredTest.kt
+++ b/src/test/kotlin/org/phellang/integration/refactoring/PhelRefactoringActionsRegisteredTest.kt
@@ -1,0 +1,99 @@
+package org.phellang.integration.refactoring
+
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.actionSystem.Presentation
+import com.intellij.openapi.actionSystem.impl.SimpleDataContext
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.testFramework.TestActionEvent
+import org.phellang.integration.PhelIntegrationTestCase
+import org.phellang.language.psi.PhelSymbol
+
+/**
+ * The refactorings are reachable from the menu, not merely implemented.
+ *
+ * This exists because Extract Variable shipped invisible: the handler was written and directly
+ * tested, but `PhelRefactoringSupportProvider.getIntroduceVariableHandler` was never wired up.
+ * `IntroduceVariableAction` asks the provider for a handler and hides itself when none comes back,
+ * so the whole feature was absent from Refactor while every test passed.
+ *
+ * Driving the real actions through `ActionManager` is the only level at which that is visible.
+ */
+class PhelRefactoringActionsRegisteredTest : PhelIntegrationTestCase() {
+
+    private var fileIndex = 0
+
+    private fun presentationOf(actionId: String, source: String, onSymbol: String? = null): Presentation {
+        val file = myFixture.configureByText("ra${fileIndex++}.phel", source)
+
+        val builder = SimpleDataContext.builder()
+            .add(CommonDataKeys.PROJECT, project)
+            .add(CommonDataKeys.EDITOR, myFixture.editor)
+            .add(CommonDataKeys.PSI_FILE, file)
+
+        // Safe Delete acts on an element, not a range: without PSI_ELEMENT the platform falls back to
+        // the file, which is why it greys out when a selection is active instead of a caret on a name.
+        onSymbol?.let { name ->
+            val symbol = PsiTreeUtil.findChildrenOfType(file, PhelSymbol::class.java).first { it.text == name }
+            builder.add(CommonDataKeys.PSI_ELEMENT, symbol)
+        }
+
+        val action: AnAction = requireNotNull(ActionManager.getInstance().getAction(actionId)) {
+            "$actionId is not a registered action"
+        }
+        val event = TestActionEvent.createTestEvent(action, builder.build() as DataContext)
+        action.update(event)
+
+        return event.presentation
+    }
+
+    /** The regression: this was invisible, because the provider returned no handler. */
+    fun testExtractVariableIsOfferedOnASelectedExpression() {
+        val presentation = presentationOf(
+            "IntroduceVariable",
+            "(ns app\\m)\n(defn f [] (+ 1 <selection>(* 2 3)</selection>))\n",
+        )
+
+        assertTrue("Extract Variable should be visible in a Phel file", presentation.isVisible)
+        assertTrue("Extract Variable should be enabled on a selected expression", presentation.isEnabled)
+    }
+
+    fun testExtractFunctionIsOfferedOnASelectedExpression() {
+        val presentation = presentationOf(
+            "Phel.ExtractFunction",
+            "(ns app\\m)\n(defn f [] (+ 1 <selection>(* 2 3)</selection>))\n",
+        )
+
+        assertTrue(presentation.isVisible)
+        assertTrue(presentation.isEnabled)
+    }
+
+    fun testSafeDeleteIsOfferedOnADefinitionName() {
+        val presentation = presentationOf(
+            "SafeDelete",
+            "(ns app\\m)\n(defn unused [x] x)\n",
+            onSymbol = "unused",
+        )
+
+        assertTrue("Safe Delete should be visible", presentation.isVisible)
+        assertTrue("Safe Delete should be enabled on a top-level definition name", presentation.isEnabled)
+    }
+
+    /** Extract Function is Phel's own action and must not appear in other languages. */
+    fun testExtractFunctionIsHiddenInAnotherLanguage() {
+        myFixture.configureByText("notes.txt", "plain <selection>text</selection>")
+
+        val action = ActionManager.getInstance().getAction("Phel.ExtractFunction")
+        val context = SimpleDataContext.builder()
+            .add(CommonDataKeys.PROJECT, project)
+            .add(CommonDataKeys.EDITOR, myFixture.editor)
+            .add(CommonDataKeys.PSI_FILE, myFixture.file)
+            .build()
+        val event = TestActionEvent.createTestEvent(action, context)
+        action.update(event)
+
+        assertFalse("Extract Phel Function must not appear outside Phel files", event.presentation.isVisible)
+    }
+}

--- a/src/test/kotlin/org/phellang/integration/refactoring/PhelSafeDeleteTest.kt
+++ b/src/test/kotlin/org/phellang/integration/refactoring/PhelSafeDeleteTest.kt
@@ -3,11 +3,14 @@ package org.phellang.integration.refactoring
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.refactoring.BaseRefactoringProcessor
 import com.intellij.refactoring.safeDelete.SafeDeleteProcessor
+import com.intellij.refactoring.safeDelete.usageInfo.SafeDeleteReferenceSimpleDeleteUsageInfo
+import com.intellij.usageView.UsageInfo
 import org.phellang.indexing.PhelProjectSymbolIndex
 import org.phellang.integration.PhelIntegrationTestCase
 import org.phellang.language.psi.PhelSymbol
 import org.phellang.language.psi.files.PhelFile
 import org.phellang.refactoring.PhelRefactoringSupportProvider
+import org.phellang.refactoring.safedelete.PhelSafeDeleteProcessor
 
 /**
  * Safe Delete over a Phel definition.
@@ -97,6 +100,44 @@ class PhelSafeDeleteTest : PhelIntegrationTestCase() {
         safeDelete(file, "countdown")
 
         assertEquals("(ns app\\m)\n", file.text)
+    }
+
+    /**
+     * The recursive call must be reported as *safe*, not merely survive the deletion.
+     *
+     * Asserting the resulting text is not enough: the test harness confirms the "usages found"
+     * dialog automatically, so a call wrongly marked unsafe still deleted here while the IDE stopped
+     * and asked. That is exactly what shipped — the condition tested the name's range rather than
+     * the enclosing form's, and a name can never contain a call to itself.
+     */
+    fun testARecursiveCallIsReportedAsSafeToDelete() {
+        val file = configure("(ns app\\m)\n(defn countdown [n] (if (= n 0) 0 (countdown (- n 1))))\n")
+        val name = definitionNamed(file, "countdown")
+
+        val usages = mutableListOf<UsageInfo>()
+        PhelSafeDeleteProcessor().findUsages(name, arrayOf(name), usages)
+
+        assertEquals("the recursive call should be the only usage found", 1, usages.size)
+        val recursive = usages.single() as SafeDeleteReferenceSimpleDeleteUsageInfo
+        assertTrue(
+            "a call inside the form being deleted must not prompt the user",
+            recursive.isSafeDelete,
+        )
+    }
+
+    /** A call from elsewhere is genuinely unsafe, and must still be reported that way. */
+    fun testACallFromAnotherFormIsReportedAsUnsafe() {
+        val file = configure("(ns app\\m)\n(defn helper [] 1)\n(defn caller [] (helper))\n")
+        val name = definitionNamed(file, "helper")
+
+        val usages = mutableListOf<UsageInfo>()
+        PhelSafeDeleteProcessor().findUsages(name, arrayOf(name), usages)
+
+        assertEquals(1, usages.size)
+        assertFalse(
+            "a usage outside the deleted form must still stop the refactoring",
+            (usages.single() as SafeDeleteReferenceSimpleDeleteUsageInfo).isSafeDelete,
+        )
     }
 
     // ---- safety ----


### PR DESCRIPTION
Extract Variable shipped **invisible**. Found by trying it in the sandbox: nothing in the Refactor menu, and the shortcut did nothing.

`PhelRefactoringSupportProvider.getIntroduceVariableHandler` was never wired up, so `IntroduceVariableAction` asked the provider for a handler, got none, and hid itself. The handler itself was fine — it just was not reachable.

## How it got lost

The wiring was applied by a string replace anchored on `isSafeDeleteAvailable`. That branch was cut from `main` *before* Safe Delete (#307) merged, so the anchor did not exist yet — and a replace that matches nothing does not fail. It silently did nothing and compiled clean.

## Why no test caught it

The existing tests build `PhelIntroduceVariableHandler()` **directly**, so they exercise the transformation and never touch the registration. The same blind spot as the icon-size test earlier in this batch: testing the thing rather than testing that the thing is reachable.

`PhelRefactoringActionsRegisteredTest` now drives the real actions through `ActionManager`, which is the only level at which a missing registration is visible. I verified it **fails against the code currently on `main`** and passes against this fix, so it genuinely catches the regression rather than passing by construction.

It pins all three the same way, plus that Extract Function stays hidden outside Phel files:

| Guard | Case |
|---|---|
| Extract Variable is visible and enabled on a selection | `testExtractVariableIsOfferedOnASelectedExpression` |
| Extract Function likewise | `testExtractFunctionIsOfferedOnASelectedExpression` |
| Safe Delete is enabled on a definition name | `testSafeDeleteIsOfferedOnADefinitionName` |
| Extract Function hidden in a `.txt` file | `testExtractFunctionIsHiddenInAnotherLanguage` |

I audited every other `plugin.xml` class reference and every `RefactoringSupportProvider` hook for the same silent-loss pattern. This was the only one.

## Not a bug: Safe Delete greying out

Worth recording, since it looked like one. With a text *selection* active there is no `PSI_ELEMENT` in the data context, so the platform falls back to file-level actions — which is why the menu showed "Move File… / Copy File…" and Safe Delete was grey. With the caret on a definition name and no selection it enables, and that is what the test above pins.

## Test plan

`./gradlew test` green.

Manual: open `manual-test/src/refactoring.phel` in the sandbox, select `(* width height)` in `describe`, and confirm Refactor now lists Extract Variable and that it appends to the existing `let`.