### PR TITLE
fix(editor): correct the Phel samples shown in Settings

### DIFF
--- a/src/main/kotlin/org/phellang/editor/format/PhelLanguageCodeStyleSettingsProvider.kt
+++ b/src/main/kotlin/org/phellang/editor/format/PhelLanguageCodeStyleSettingsProvider.kt
@@ -52,13 +52,13 @@ class PhelLanguageCodeStyleSettingsProvider : LanguageCodeStyleSettingsProvider(
         const val DEFAULT_KEEP_BLANK_LINES = 2
 
         val CODE_SAMPLE = """
-            (ns app\example
-              (:require phel\str :as str))
+            (ns app.example
+              (:require phel.string))
 
             (defn greet
               "Returns a greeting for the given name."
               [name]
-              (let [trimmed (str/trim name)]
+              (let [trimmed (string/trim name)]
                 (when (pos? (php/strlen trimmed))
                   (str "Hello, " trimmed))))
         """.trimIndent()

--- a/src/main/resources/inspectionDescriptions/PhelUnusedImport.html
+++ b/src/main/resources/inspectionDescriptions/PhelUnusedImport.html
@@ -4,13 +4,13 @@
 
 <p>An import is flagged when no namespace-qualified symbol outside the <code>(ns ...)</code>
     declaration uses its qualifier. Under <code>:as</code> the alias is the qualifier that counts, so
-    <code>(:require phel\str :as s)</code> is used by <code>(s/join ...)</code> and not by
-    <code>(str/join ...)</code>.</p>
+    <code>(:require phel.string :as s)</code> is used by <code>(s/join ...)</code> and not by
+    <code>(string/join ...)</code>.</p>
 
 <h3>Example:</h3>
 <pre><code>
-(ns app\core
-  (:require phel\str))   ;; reported: Unused import
+(ns app.example
+  (:require phel.string))   ;; reported: Unused import
 
 (println "hi")
 </code></pre>

--- a/src/test/kotlin/org/phellang/unit/samples/PhelShippedSamplesTest.kt
+++ b/src/test/kotlin/org/phellang/unit/samples/PhelShippedSamplesTest.kt
@@ -1,0 +1,87 @@
+package org.phellang.unit.samples
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.phellang.editor.colorsettings.PhelDemoTextProvider
+import java.io.File
+
+/**
+ * The Phel snippets this plugin shows to users must be valid, current Phel.
+ *
+ * They are plain string constants and HTML files, so nothing compiles or parses them — which is how
+ * the Code Style preview came to use `(ns app\example …)` with `(:require phel\str :as str)`: a
+ * separator deprecated since Phel 0.35, a namespace that does not exist, and a `str/trim` call that
+ * therefore resolved to nothing. The plugin ships an inspection reporting exactly that separator, so
+ * its own preview would have been flagged by its own inspection.
+ */
+class PhelShippedSamplesTest {
+
+    /**
+     * `(ns a\b)` and `(:require x\y)`, which are the deprecated spellings.
+     *
+     * `:use` is deliberately not matched: PHP class names in `(:use \DateTime)` really are
+     * backslash-separated, and flagging those would be wrong.
+     */
+    private val deprecatedSeparator =
+        Regex("""\(ns\s+[A-Za-z][\w-]*\\|:require\s+[A-Za-z][\w-]*\\""")
+
+    private fun assertNoBackslashNamespace(label: String, sample: String) {
+        val offenders = deprecatedSeparator.findAll(sample).map { it.value }.toList()
+
+        assertTrue(
+            offenders.isEmpty(),
+        ) { "$label uses the backslash namespace separator, deprecated since Phel 0.35: $offenders" }
+    }
+
+    @Test
+    fun `the code style preview uses current Phel`() {
+        val sample = codeStyleSample()
+
+        assertNoBackslashNamespace("The Code Style preview", sample)
+        assertTrue(sample.contains("(:require phel.string)")) { "should require phel.string, got:\n$sample" }
+        assertTrue(sample.contains("string/trim")) { "should call string/trim, got:\n$sample" }
+    }
+
+    /** `str` is core's string-building function; `str/…` is not a namespace the registry knows. */
+    @Test
+    fun `the code style preview does not use the non-existent str namespace`() {
+        assertFalse(codeStyleSample().contains("str/")) {
+            "`str/` is not a Phel namespace — the registry declares `string`"
+        }
+    }
+
+    @Test
+    fun `the colour scheme demo text uses current Phel`() {
+        assertNoBackslashNamespace("The Color Scheme demo text", PhelDemoTextProvider().getDemoText())
+    }
+
+    /**
+     * Every inspection description except the one whose whole subject is the deprecated form —
+     * `PhelBackslashNamespace.html` shows `(ns my-app\core …)` on purpose, as the "before" example.
+     */
+    @Test
+    fun `inspection descriptions use current Phel`() {
+        val descriptions = File("src/main/resources/inspectionDescriptions")
+            .listFiles { file -> file.extension == "html" && file.nameWithoutExtension != "PhelBackslashNamespace" }
+            .orEmpty()
+
+        assertTrue(descriptions.isNotEmpty()) { "expected the inspection descriptions to be found" }
+
+        descriptions.forEach { assertNoBackslashNamespace(it.name, it.readText()) }
+    }
+
+    /** The one file that is meant to contain it, so the exclusion above cannot quietly stop mattering. */
+    @Test
+    fun `the backslash inspection still documents the deprecated form it reports`() {
+        val description = File("src/main/resources/inspectionDescriptions/PhelBackslashNamespace.html").readText()
+
+        assertTrue(deprecatedSeparator.containsMatchIn(description)) {
+            "this description must keep showing the deprecated spelling as its example"
+        }
+    }
+
+    private fun codeStyleSample(): String =
+        org.phellang.editor.format.PhelLanguageCodeStyleSettingsProvider()
+            .getCodeSample(com.intellij.psi.codeStyle.LanguageCodeStyleSettingsProvider.SettingsType.BLANK_LINES_SETTINGS)
+}


### PR DESCRIPTION
The Code Style preview showed code that this plugin's own inspection would flag, and that does not run.

```phel
(ns app\example
  (:require phel\str :as str))
...
  (let [trimmed (str/trim name)]
```

Three problems in four lines:

- **Deprecated separator.** `\` has been deprecated since Phel 0.35 — `PhelBackslashNamespaceInspection` exists to report exactly this, so the preview would have been flagged by the plugin itself.
- **`str` is not a namespace.** The registry declares `string`: `registerStringFunctions.kt` has `namespace = "string"` with entries `string/trim`, `string/blank?`, `string/capitalize`. Searching `name = "str/` across `registry/data/` returns nothing — so `(str/trim name)` resolved to nothing.
- **The alias made it worse.** `:as str` reads as core's `str`, a *different* function the sample uses two lines later in `(str "Hello, " trimmed)`.

## The fix

```phel
(ns app.example
  (:require phel.string))

(defn greet
  "Returns a greeting for the given name."
  [name]
  (let [trimmed (string/trim name)]
    (when (pos? (php/strlen trimmed))
      (str "Hello, " trimmed))))
```

No `:as`. The namespace's last segment is already the qualifier, so requiring `phel.string` gives `string/trim` directly — which is precisely how the registry names those entries. `string/trim` and `str` are now visibly different things.

`inspectionDescriptions/PhelUnusedImport.html` carried the same two mistakes in text users read in Settings, and is corrected the same way.

## Why nothing caught it

These are plain string constants and HTML files. Nothing compiles or parses them, so they drifted silently while `PhelDemoTextProvider` — the Color Scheme preview one settings page over — already used `(ns src.demo` and `phel.string` correctly. The two Settings pages contradicted each other.

`PhelShippedSamplesTest` now pins every user-visible sample. **Verified to fail against the code on `main`** (3 of its 5 tests), so it catches the regression rather than passing by construction.

Two exclusions, both deliberate and both asserted rather than assumed:

- `PhelBackslashNamespace.html` is excluded, because showing the deprecated form *is* its subject — and a separate test asserts it still contains it, so the exclusion cannot quietly stop mattering.
- `:use \DateTime` is not matched by the pattern at all. PHP class names genuinely are backslash-separated, as `PhelBackslashNamespaceInspection:24` documents.

## Test plan

`./gradlew test` green.

Manual: `Settings ▸ Editor ▸ Code Style ▸ Phel` — the preview should now show dot-separated namespaces and no warning squiggles, and read consistently with `Settings ▸ Editor ▸ Color Scheme ▸ Phel`.

Closes #312
