### PR TITLE
feat: support Phel v0.50.0 — bench namespace, regenerated registry, syntax changes

### DIFF
--- a/.agnostic-ai/rules/phel-language.md
+++ b/.agnostic-ai/rules/phel-language.md
@@ -10,24 +10,45 @@ Lisp transpiling to PHP; Clojure/Janet dialect. Source of truth: https://phel-la
 **Comments**: `;` line. `#_` comments next form (stackable `#_#_` = two).
 `[#_:one :two :three]` → `[:two :three]`.
 
-**Deprecated — never emit, never lex** (Phel still accepts these with an `E_USER_DEPRECATED`;
-the plugin lexer deliberately does not support any of them, so don't "fix" that as a gap):
-bare `#` line comments (use `;`) · `#| ... |#` nesting block comments (use `;` or `#_`) ·
-`|()` short fn (use `#()`) · `,` / `,@` unquote+splice (use `~` / `~@`; the plugin lexes `,`
-as whitespace).
+**Removed in v0.50.0 — never emit, never lex.** These are gone from the language, not merely
+deprecated: a file using one fails to lex or reports an unresolvable symbol. The plugin lexer
+deliberately does not support any of them, so don't "fix" that as a gap.
+
+| Removed              | Replacement                                       |
+|----------------------|---------------------------------------------------|
+| `#` line comment     | `;`                                               |
+| `#\| ... \|#` block comment | `;` or `#_`                                |
+| `\|(...)` short fn, `$`/`$1` params | `#(...)`, `%`/`%1` params          |
+| `,` / `,@` unquote+splice | `~` / `~@` (the plugin lexes `,` as whitespace) |
+| `foo$` auto-gensym   | `foo#`                                            |
+
+Only the auto-gensym meaning of a trailing `$` is gone: bare `$` is still the return value inside
+an `fn` `:post` condition, and `$` remains an ordinary character in a name.
 
 **Keywords**: `:kw` · `:ns/kw` · `::foo` (current-ns) · `::alias/foo`.
 
-**PHP interop**: static `(php/:: Class method)` · instance `(php/-> obj method)` · ops `php/+ - && || !== @ ^ ~`.
-Bring classes in via `(:use \DateTime \Exception)` in `ns`. Shorthands:
+**PHP interop**: the Clojure-style shorthand is **the** spelling. `php/new`, `php/->`, `php/::`
+and `set-var` are deprecated as source since v0.50.0 (they remain as the expansion target, and
+`PhelSupersededFormInspection` flags them). A root class needs no leading `\`; namespaced classes
+take the dotted form (`Symfony.Component.Console.Command.Command/SUCCESS`). A class is recognised
+lexically by an upper-case first segment — import a lower-case-initial vendor namespace via
+`(:use ...)` first.
 
-| Shorthand               | Expands to                       |
-|-------------------------|----------------------------------|
-| `(Class. args)` / `(new Class args)` | `(php/new Class args)`  |
-| `(.method obj args)`    | `(php/-> obj (method args))`     |
-| `(.-field obj)`         | `(php/-> obj field)`             |
-| `(Class/method args)`   | `(php/:: Class (method args))`   |
-| `Class/MEMBER`          | `(php/:: Class MEMBER)`          |
+| Written                 | Expands to                         | Position |
+|-------------------------|------------------------------------|----------|
+| `(.m obj args)`         | `(php/-> obj (m args))`            | call     |
+| `(.-field obj)`         | `(php/-> obj field)`               | call     |
+| `(C/m args)`            | `(php/:: C (m args))`              | call     |
+| `(C. args)` / `(new C args)` | `(php/new C args)`            | call     |
+| `C/CONST`               | `(php/:: C CONST)`                 | value    |
+| `C/$prop`               | `(php/:: C $prop)`                 | value    |
+| `C/m`                   | `(php/callable C m)`               | value    |
+| `C/.m`                  | `(fn [o & args] ...)`              | value    |
+
+`(set! C/slot v)` assigns a static property; reading it back needs the sigil (`C/$prop`), since a
+bare name in read position is the constant. The rest of the `php/` family stays current:
+`php/aget` `php/aset` `php/apush` `php/aunset` `php/oset` `php/ref` `php/callable`, plus the
+operators `php/+ - && || !== @ ^ ~`.
 
 **File**: starts `(ns namespace\name)`. Top-level: `def`/`defn`/`defmacro`/comments. Bare literals not idiomatic.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,33 @@ refreshed, since completion, hover and arity checking are all driven by it.
 
 ## [Unreleased]
 
+### Added
+
+- The `bench` namespace (`defbench`, `run-benchmarks`) now completes and hovers. It shipped in Phel 0.50.0 but was
+  missing from the registry's namespace config, so the generator skipped it with a warning on every run (#321).
+- PHP superglobals (`php/$_SERVER`, `php/$_GET`, …) now appear in completion and hover, matching what Phel's own LSP
+  and REPL gained in 0.50.0. They are variables rather than functions, so no generator can derive them from the PHP
+  docs and the list is maintained by hand (#321).
+- A **Superseded interop or var form** inspection flags the source spellings Phel 0.50.0 deprecated: `php/new`,
+  `php/->`, `php/::` and `set-var`, each reported with the Clojure-style spelling to write instead. The rest of the
+  `php/` family is untouched, since each of those reaches a PHP capability Phel has no other word for (#321).
+
+### Changed
+
+- Registry refreshed to **Phel 0.50.0**. Documentation links now point at the 0.50.0 sources and multi-arity
+  signatures are shown one arity per line instead of collapsed into an `& [...]` tail (#321).
+- Phel 0.50.0 removed every deprecated function from the language, so no stdlib symbol is reported as deprecated any
+  more. The deprecated-function inspection, annotator and quick fix are unchanged and will light up again the next
+  time Phel deprecates something (#321).
+
+### Fixed
+
+- Arity checking is no longer suppressed for calls containing a bare `|`. That accommodated the `|(...)` short fn,
+  which Phel 0.50.0 removed; `(some |(> % 10) coll)` is now correctly reported as a wrong-arity call rather than
+  silently skipped (#321).
+- `$`-prefixed names are checked by the unresolved-symbol inspection again. Only bare `$` is still meaningful, as the
+  return value inside an `fn` `:post` condition; `$1` was a `|(...)` parameter and is now an ordinary symbol (#321).
+
 ## [1.1.0] - 2026-07-25
 
 ### Fixed

--- a/src/main/kotlin/org/phellang/inspection/PhelArityCallSite.kt
+++ b/src/main/kotlin/org/phellang/inspection/PhelArityCallSite.kt
@@ -28,18 +28,9 @@ internal object PhelArityCallSite {
         if (isInQuoteContext(list)) return true
         if (isThreadedArgList(list)) return true
         if (PhelLocalBindingScope.resolvesToLocalBinding(head, name)) return true
-        if (containsShortFnMarker(forms)) return true
 
         return false
     }
-
-    /**
-     * True when any argument is a bare `|` symbol — the marker for Phel's deprecated `|(...)`
-     * short-fn syntax. The lexer treats `|` as a plain symbol, so `|(> $ 10)` parses as two forms
-     * (a `|` symbol and a list), inflating the textual argument count. Skip rather than misreport.
-     */
-    private fun containsShortFnMarker(forms: List<PhelForm>): Boolean =
-        forms.drop(1).any { PhelPsiUtils.asSymbol(it)?.text == "|" }
 
     /**
      * True when [list] is a data form — inside `quote`, `var`, or a `'` / `` ` `` reader macro — and

--- a/src/main/kotlin/org/phellang/inspection/analysis/PhelUnresolvedSymbolFinder.kt
+++ b/src/main/kotlin/org/phellang/inspection/analysis/PhelUnresolvedSymbolFinder.kt
@@ -61,8 +61,11 @@ internal object PhelUnresolvedSymbolFinder {
      */
     private fun isReferencePosition(symbol: PhelSymbol, text: String): Boolean {
         if (text in ALWAYS_IGNORED) return false
-        // `%`, `%1`, `%2` are the short-fn anaphors; `$` is accepted defensively.
-        if (text.startsWith("%") || text.startsWith("$")) return false
+        // `%`, `%1`, `%2` are the short-fn anaphors. Bare `$` is the return value inside an `fn`
+        // `:post` condition — the one meaning of `$` Phel v0.50.0 kept when it removed the `|(...)`
+        // short fn, whose parameters were `$` and `$1`. A `$`-prefixed *name* is now an ordinary
+        // symbol and is checked like any other.
+        if (text.startsWith("%") || text == "$") return false
         if (text.contains("/") || text.contains("\\")) return false
         if (text.startsWith(".") || PhelInteropShorthands.isInteropClassName(text)) return false
 

--- a/src/main/kotlin/org/phellang/inspection/deprecated/PhelSupersededFormInspection.kt
+++ b/src/main/kotlin/org/phellang/inspection/deprecated/PhelSupersededFormInspection.kt
@@ -1,0 +1,61 @@
+package org.phellang.inspection.deprecated
+
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElementVisitor
+import org.phellang.language.psi.PhelSymbol
+import org.phellang.language.psi.PhelVisitor
+import org.phellang.language.psi.analysis.PhelSymbolAnalyzer
+
+/**
+ * Flags the source forms Phel v0.50.0 superseded, mirroring the compiler's own
+ * `--warn-deprecations` output in the IDE.
+ *
+ * One rule drives the interop entries: `php/` means host access, and is never a second spelling
+ * for something Phel already says the Clojure way. The three interop forms below each have a
+ * Clojure-style spelling that is now *the* spelling; they remain as the compilation target the
+ * shorthand expands to, which is why they still appear in the registry and in completion.
+ *
+ * The rest of the `php/` family is deliberately absent: `php/aget`, `php/aset`, `php/apush`,
+ * `php/aunset`, `php/oset`, `php/ref` and `php/callable` each reach a PHP capability Phel has no
+ * other word for, so they are current, not superseded.
+ *
+ * No quick fix. Every replacement here reorders or re-nests the call's arguments —
+ * `(php/-> obj (m a))` becomes `(.m obj a)` — so there is no text substitution that is correct in
+ * general, and a fix that mangles a working call is worse than none. The message names the
+ * replacement instead.
+ *
+ * Sources: the language-surface spec's "Deprecated inside 1.x" table, and phel-lang #2877 / #2888.
+ */
+class PhelSupersededFormInspection : LocalInspectionTool() {
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        return object : PhelVisitor() {
+            override fun visitSymbol(symbol: PhelSymbol) {
+                val text = symbol.text ?: return
+                val superseded = SUPERSEDED[text] ?: return
+
+                // A local binding or a definition that happens to share the name is not the form.
+                if (PhelSymbolAnalyzer.isLocalBindingOrReference(symbol)) return
+                if (PhelSymbolAnalyzer.isDefinition(symbol)) return
+
+                holder.registerProblem(
+                    symbol,
+                    "'$text' is deprecated since Phel 0.50; write $superseded instead",
+                    ProblemHighlightType.LIKE_DEPRECATED,
+                )
+            }
+        }
+    }
+
+    private companion object {
+        /** Superseded form -> the spelling to write instead, as it appears in the warning. */
+        val SUPERSEDED = mapOf(
+            "php/new" to "(Foo. arg) or (new Foo arg)",
+            "php/->" to "(.method obj arg) or (.-field obj)",
+            "php/::" to "(Foo/method arg) or Foo/CONST",
+            "set-var" to "(alter-var-root #'v f), or (set! v x) for the current binding frame",
+        )
+    }
+}

--- a/src/main/kotlin/org/phellang/language/psi/PhelProjectNamespaceFinder.kt
+++ b/src/main/kotlin/org/phellang/language/psi/PhelProjectNamespaceFinder.kt
@@ -21,6 +21,7 @@ object PhelProjectNamespaceFinder {
         "ai" to "phel.ai",
         "async" to "phel.async",
         "base64" to "phel.base64",
+        "bench" to "phel.bench",
         "cli" to "phel.cli",
         "core" to "phel.core",
         "debug" to "phel.debug",

--- a/src/main/kotlin/org/phellang/registry/Namespace.kt
+++ b/src/main/kotlin/org/phellang/registry/Namespace.kt
@@ -5,6 +5,7 @@ enum class Namespace {
     AI,
     ASYNC,
     BASE64,
+    BENCH,
     CLI,
     CORE,
     EDN,

--- a/src/main/kotlin/org/phellang/registry/PhelFunctionRegistry.kt
+++ b/src/main/kotlin/org/phellang/registry/PhelFunctionRegistry.kt
@@ -38,6 +38,9 @@ import org.phellang.registry.data.test.registerTestSelectorFunctions
 import org.phellang.registry.data.test.registerTestShrinkFunctions
 // endregion GENERATED IMPORTS — updatePhelRegistry
 
+// Outside the GENERATED region on purpose: updatePhelRegistry rewrites only what is inside it.
+import org.jetbrains.annotations.TestOnly
+
 /**
  * Based on official Phel API documentation: https://phel-lang.org/documentation/api/
  */
@@ -139,16 +142,49 @@ object PhelFunctionRegistry {
     }
 
     fun getFunction(name: String): PhelFunction? {
-        return functionsByName[name]
+        return testFunctionsByName[name] ?: functionsByName[name]
     }
 
     fun isDeprecated(functionName: String): Boolean {
-        if (functionName in deprecatedFunctionNames) {
+        if (functionName in testDeprecatedNames || functionName in deprecatedFunctionNames) {
             return true
         }
 
         // A namespace-prefixed input (e.g. "core/put") may only be stored under its short name.
         val shortName = functionName.substringAfter("/")
-        return shortName in deprecatedFunctionNames
+        return shortName in testDeprecatedNames || shortName in deprecatedFunctionNames
     }
+
+    // region Test overlay
+    //
+    // Phel v0.50.0 deleted every deprecated function from the language, so api.json — and with it
+    // the generated registry — now carries no deprecation data at all. The deprecation feature
+    // (inspection, annotator rule, completion priority) is still shipped and still correct, but
+    // its tests had nothing left to exercise. They install synthetic functions here instead of
+    // pinning to whichever stdlib names happen to be deprecated this release.
+    //
+    // Deliberately narrow: the overlay backs [getFunction] and [isDeprecated] only. It is not part
+    // of `flattenedFunctions`, so it cannot leak into completion, `getFunctions`, or the
+    // priority caches. In production both fields stay empty and each read costs one miss on an
+    // empty map.
+
+    private var testFunctionsByName: Map<String, PhelFunction> = emptyMap()
+    private var testDeprecatedNames: Set<String> = emptySet()
+
+    /** Overlays [overlay] onto name and deprecation lookups. Always pair with [clearTestFunctions]. */
+    @TestOnly
+    fun installTestFunctions(overlay: List<PhelFunction>) {
+        // Indexed exactly like the production `functionsByName`, so a fixture is reachable under
+        // the same name shape the generated data would have used.
+        testFunctionsByName = overlay.associateBy { it.name }
+        testDeprecatedNames = overlay.filter { it.isDeprecated }
+            .flatMapTo(HashSet()) { setOf(it.name, it.name.substringAfter("/")) }
+    }
+
+    @TestOnly
+    fun clearTestFunctions() {
+        testFunctionsByName = emptyMap()
+        testDeprecatedNames = emptySet()
+    }
+    // endregion Test overlay
 }

--- a/src/main/kotlin/org/phellang/registry/PhelFunctionRegistry.kt
+++ b/src/main/kotlin/org/phellang/registry/PhelFunctionRegistry.kt
@@ -108,9 +108,11 @@ object PhelFunctionRegistry {
         functions[Namespace.WATCH] = registerWatchFunctions()
         // endregion GENERATED INIT — updatePhelRegistry
 
-        // Hand-wired native PHP functions (see PhpNativeFunctions.kt, same package so no import).
+        // Hand-wired native PHP functions (see PhpNativeFunctions.kt, same package so no import),
+        // plus the superglobals, which are variables and so appear in no function synopsis for
+        // updatePhpRegistry to find (see PhpSuperglobals.kt).
         // Kept out of the GENERATED region so updatePhelRegistry does not overwrite it.
-        functions[Namespace.PHP_NATIVE] = phpNativeFunctions()
+        functions[Namespace.PHP_NATIVE] = phpNativeFunctions() + phpSuperglobals()
     }
 
     fun getFunctions(namespace: Namespace): List<PhelFunction> {

--- a/src/main/kotlin/org/phellang/registry/PhelFunctionRegistry.kt
+++ b/src/main/kotlin/org/phellang/registry/PhelFunctionRegistry.kt
@@ -4,6 +4,7 @@ package org.phellang.registry
 import org.phellang.registry.data.registerAiFunctions
 import org.phellang.registry.data.registerAsyncFunctions
 import org.phellang.registry.data.registerBase64Functions
+import org.phellang.registry.data.registerBenchFunctions
 import org.phellang.registry.data.registerCliFunctions
 import org.phellang.registry.data.registerCoreFunctions
 import org.phellang.registry.data.registerEdnFunctions
@@ -72,6 +73,7 @@ object PhelFunctionRegistry {
         functions[Namespace.AI] = registerAiFunctions()
         functions[Namespace.ASYNC] = registerAsyncFunctions()
         functions[Namespace.BASE64] = registerBase64Functions()
+        functions[Namespace.BENCH] = registerBenchFunctions()
         functions[Namespace.CLI] = registerCliFunctions()
         functions[Namespace.CORE] = registerCoreFunctions()
         functions[Namespace.EDN] = registerEdnFunctions()

--- a/src/main/kotlin/org/phellang/registry/PhpSuperglobals.kt
+++ b/src/main/kotlin/org/phellang/registry/PhpSuperglobals.kt
@@ -1,0 +1,36 @@
+package org.phellang.registry
+
+/**
+ * PHP's superglobals, reachable from Phel as `php/$_SERVER` and friends.
+ *
+ * Hand-curated rather than generated: `updatePhpRegistry` derives [PhpNativeFunctions] from
+ * php/doc-en's `<methodsynopsis>` entries, and a superglobal is a *variable*, so it appears in no
+ * function synopsis and no generator can find it. The set is fixed by the PHP language itself and
+ * has not changed in years, so a static list carries no drift risk.
+ *
+ * Phel v0.50.0 added completion and hover for these to its own LSP and REPL (#3037); this is the
+ * IntelliJ side of the same surface. They are values, not calls, so each carries an empty
+ * signature — the same shape the generator emits for any non-callable entry.
+ */
+internal fun phpSuperglobals(): List<PhelFunction> = listOf(
+    superglobal("\$GLOBALS", "References all variables available in global scope"),
+    superglobal("\$_SERVER", "Server and execution environment information"),
+    superglobal("\$_GET", "HTTP GET variables"),
+    superglobal("\$_POST", "HTTP POST variables"),
+    superglobal("\$_FILES", "HTTP file upload variables"),
+    superglobal("\$_COOKIE", "HTTP cookies"),
+    superglobal("\$_SESSION", "Session variables"),
+    superglobal("\$_REQUEST", "HTTP request variables"),
+    superglobal("\$_ENV", "Environment variables"),
+)
+
+private fun superglobal(name: String, summary: String): PhelFunction = PhelFunction(
+    namespace = "php",
+    name = "php/$name",
+    signature = "",
+    completion = CompletionInfo(tailText = summary, priority = PhelCompletionPriority.PHP_INTEROP),
+    documentation = DocumentationInfo(
+        summary = summary,
+        links = DocumentationLinks(docs = "https://www.php.net/manual/en/reserved.variables.php"),
+    ),
+)

--- a/src/main/kotlin/org/phellang/registry/data/core/registerCoreArraysFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/core/registerCoreArraysFunctions.kt
@@ -19,11 +19,11 @@ internal fun registerCoreArraysFunctions(): List<PhelFunction> = listOf(
         ),
         documentation = DocumentationInfo(
             summary = """
-Returns a shallow copy of a PHP array. The returned array is a distinct value â€” mutating the copy via <code>php/aset</code> does not affect the original, and vice versa. Matches Clojure's <code>aclone</code> for <code>.cljc</code> interop; raises <code>InvalidArgumentException</code> on non-array inputs since Phel's persistent collections are already immutable and don't need cloning.
+Returns a shallow copy of a PHP array. The returned array is a distinct value â€” mutating the copy via <code>aset</code> does not affect the original, and vice versa. Matches Clojure's <code>aclone</code> for <code>.cljc</code> interop; raises <code>InvalidArgumentException</code> on non-array inputs since Phel's persistent collections are already immutable and don't need cloning.
 """,
             example = "(aclone (object-array 3)) ; =&gt; &lt;PHP-Array [nil, nil, nil]&gt;",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/arrays.phel#L89",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/arrays.phel#L106",
                 docs = "",
             ),
         ),
@@ -31,7 +31,7 @@ Returns a shallow copy of a PHP array. The returned array is a distinct value â€
     PhelFunction(
         namespace = "core",
         name = "aget",
-        signature = "(aget arr & indices)",
+        signature = "(aget arr index)\n(aget arr index & indices)",
         completion = CompletionInfo(
             tailText = "Returns the value at index in a PHP array",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -40,9 +40,9 @@ Returns a shallow copy of a PHP array. The returned array is a distinct value â€
             summary = """
 Returns the value at <code>index</code> in a PHP array. With multiple indices, accesses nested arrays: <code>(aget arr i j)</code> is <code>(aget (aget arr i) j)</code>. Matches Clojure's <code>aget</code> for <code>.cljc</code> interop.
 """,
-            example = "(aget (php/array 10 20 30) 1) ; =&gt; 20",
+            example = "(aget (php-indexed-array 10 20 30) 1) ; =&gt; 20",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/arrays.phel#L189",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/arrays.phel#L206",
                 docs = "",
             ),
         ),
@@ -63,7 +63,7 @@ Returns the number of elements in a PHP array. Matches Clojure's<br />
 """,
             example = "(alength (int-array 3)) ; =&gt; 3",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/arrays.phel#L96",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/arrays.phel#L113",
                 docs = "",
             ),
         ),
@@ -85,9 +85,9 @@ Sets the value at <code>index</code> in a PHP array to <code>val</code>. Returns
    This is a macro because PHP arrays are value types; a function<br />
    wrapper would mutate a copy rather than the original.
 """,
-            example = "(let [a (php/array 1 2 3)] (aset a 0 42) (aget a 0)) ; =&gt; 42",
+            example = "(let [a (php-indexed-array 1 2 3)] (aset a 0 42) (aget a 0)) ; =&gt; 42",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/arrays.phel#L200",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/arrays.phel#L220",
                 docs = "",
             ),
         ),
@@ -104,9 +104,9 @@ Sets the value at <code>index</code> in a PHP array to <code>val</code>. Returns
             summary = """
 Creates a PHP array of doubles (same as float-array in PHP). Accepts the same arities and semantics as <code>float-array</code>.
 """,
-            example = "(double-array 3) ; =&gt; &lt;PHP-Array [0, 0, 0]&gt;\n(double-array 4 1.5) ; =&gt; &lt;PHP-Array [1.5, 1.5, 1.5, 1.5]&gt;",
+            example = "(double-array 3) ; =&gt; &lt;PHP-Array [0.0, 0.0, 0.0]&gt;\n(double-array 4 1.5) ; =&gt; &lt;PHP-Array [1.5, 1.5, 1.5, 1.5]&gt;",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/arrays.phel#L175",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/arrays.phel#L192",
                 docs = "",
             ),
         ),
@@ -123,9 +123,9 @@ Creates a PHP array of doubles (same as float-array in PHP). Accepts the same ar
             summary = """
 Creates a PHP array of floats. Accepts the same arities as <code>int-array</code>; coerces elements to float via <code>floatval</code> and zero-pads with <code>0.0</code>.
 """,
-            example = "(float-array 3) ; =&gt; &lt;PHP-Array [0, 0, 0]&gt;\n(float-array 4 1.5) ; =&gt; &lt;PHP-Array [1.5, 1.5, 1.5, 1.5]&gt;",
+            example = "(float-array 3) ; =&gt; &lt;PHP-Array [0.0, 0.0, 0.0]&gt;\n(float-array 4 1.5) ; =&gt; &lt;PHP-Array [1.5, 1.5, 1.5, 1.5]&gt;",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/arrays.phel#L168",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/arrays.phel#L185",
                 docs = "",
             ),
         ),
@@ -151,7 +151,7 @@ PHP has no typed arrays, so the result is a plain PHP array.
 """,
             example = "(int-array 3) ; =&gt; &lt;PHP-Array [0, 0, 0]&gt;\n(int-array [1.5 2.7]) ; =&gt; &lt;PHP-Array [1, 2]&gt;\n(int-array 4 7) ; =&gt; &lt;PHP-Array [7, 7, 7, 7]&gt;\n(int-array 5 [10 20]) ; =&gt; &lt;PHP-Array [10, 20, 0, 0, 0]&gt;",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/arrays.phel#L145",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/arrays.phel#L162",
                 docs = "",
             ),
         ),
@@ -176,7 +176,7 @@ Returns a PHP array containing the elements of <code>aseq</code>. Accepts any<br
 """,
             example = "(into-array [1 2 3]) ; =&gt; &lt;PHP-Array [1, 2, 3]&gt;\n(into-array :Object [:a :b]) ; =&gt; &lt;PHP-Array [:a, :b]&gt;",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/arrays.phel#L68",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/arrays.phel#L85",
                 docs = "",
             ),
         ),
@@ -195,7 +195,7 @@ Creates a PHP array of longs (same as int-array in PHP). Accepts the same aritie
 """,
             example = "(long-array 3) ; =&gt; &lt;PHP-Array [0, 0, 0]&gt;\n(long-array 4 7) ; =&gt; &lt;PHP-Array [7, 7, 7, 7]&gt;",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/arrays.phel#L161",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/arrays.phel#L178",
                 docs = "",
             ),
         ),
@@ -213,12 +213,12 @@ Creates a PHP array of longs (same as int-array in PHP). Accepts the same aritie
 Creates a PHP array of the given size initialized to <code>nil</code>, or a PHP<br />
   array containing the elements of the given sequence. Matches Clojure's<br />
   <code>object-array</code> for <code>.cljc</code> interop â€” in Phel the result is a plain PHP<br />
-  array (accessible via <code>php/aget</code>/<code>php/aset</code>) since PHP has no typed<br />
+  array (accessible via <code>aget</code>/<code>aset</code>) since PHP has no typed<br />
   array distinction.
 """,
             example = "(object-array 3) ; =&gt; &lt;PHP-Array [nil, nil, nil]&gt;\n(object-array [1 2 3]) ; =&gt; &lt;PHP-Array [1, 2, 3]&gt;",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/arrays.phel#L42",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/arrays.phel#L59",
                 docs = "",
             ),
         ),
@@ -239,7 +239,7 @@ Arguments:<br />
 """,
             example = "(php-associative-array \"name\" \"Alice\" \"age\" 30) ; =&gt; &lt;PHP-Array [\"name\":\"Alice\", \"age\":30]&gt;",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/arrays.phel#L24",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/arrays.phel#L26",
                 docs = "",
             ),
         ),
@@ -256,7 +256,7 @@ Arguments:<br />
             summary = "Creates a PHP indexed array from the given values.",
             example = "(php-indexed-array 1 2 3) ; =&gt; &lt;PHP-Array [1, 2, 3]&gt;",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/arrays.phel#L18",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/arrays.phel#L19",
                 docs = "",
             ),
         ),
@@ -275,7 +275,7 @@ Creates a PHP array of shorts (16-bit integers). Accepts the same arities and se
 """,
             example = "(short-array 3) ; =&gt; &lt;PHP-Array [0, 0, 0]&gt;\n(short-array 4 7) ; =&gt; &lt;PHP-Array [7, 7, 7, 7]&gt;",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/arrays.phel#L182",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/arrays.phel#L199",
                 docs = "",
             ),
         ),
@@ -294,7 +294,7 @@ Returns a PHP array containing the elements of <code>coll</code>. Accepts any co
 """,
             example = "(to-array [1 2 3]) ; =&gt; &lt;PHP-Array [1, 2, 3]&gt;\n(to-array nil) ; =&gt; &lt;PHP-Array []&gt;",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/arrays.phel#L59",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/arrays.phel#L76",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/core/registerCoreAsyncFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/core/registerCoreAsyncFunctions.kt
@@ -23,7 +23,7 @@ Converts a Phel function to a PHP Closure. Many PHP libraries (AMPHP, ReactPHP) 
 """,
             example = "(-&gt;closure (fn [x] (* x 2)))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/async.phel#L19",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/async.phel#L19",
                 docs = "",
             ),
         ),
@@ -45,7 +45,7 @@ Captures the caller's dynamic bindings and reinstalls them inside<br />
 """,
             example = "(async (do-something))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/async.phel#L25",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/async.phel#L25",
                 docs = "",
             ),
         ),
@@ -64,7 +64,7 @@ Blocks the current fiber until the Future resolves and returns its value. Accept
 """,
             example = "(await (async (+ 1 2)))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/async.phel#L46",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/async.phel#L46",
                 docs = "",
             ),
         ),
@@ -83,7 +83,7 @@ Awaits all Futures in the given collection. Returns a vector of results in the s
 """,
             example = "(await-all [(async 1) (async 2)])",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/async.phel#L53",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/async.phel#L53",
                 docs = "",
             ),
         ),
@@ -102,7 +102,7 @@ Awaits the first Future to resolve. Returns its value. Accepts a mix of raw <cod
 """,
             example = "(await-any [(async 1) (async 2)])",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/async.phel#L67",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/async.phel#L67",
                 docs = "",
             ),
         ),
@@ -121,7 +121,7 @@ Delivers <code>value</code> to <code>p</code> if it is still unrealized. Returns
 """,
             example = "(deliver (promise) 7)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/async.phel#L131",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/async.phel#L131",
                 docs = "",
             ),
         ),
@@ -145,7 +145,7 @@ Captures the caller's dynamic bindings and reinstalls them inside<br />
 """,
             example = "(future-call (fn [] 42))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/async.phel#L138",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/async.phel#L138",
                 docs = "",
             ),
         ),
@@ -164,7 +164,7 @@ Signals the future's internal cancellation token, causing any pending or subsequ
 """,
             example = "(future-cancel (future (expensive-call)))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/async.phel#L89",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/async.phel#L89",
                 docs = "",
             ),
         ),
@@ -183,7 +183,7 @@ Returns <code>true</code> if <code>future-cancel</code> was called on <code>f</c
 """,
             example = "(future-cancelled? f)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/async.phel#L96",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/async.phel#L96",
                 docs = "",
             ),
         ),
@@ -199,11 +199,11 @@ Returns <code>true</code> if <code>future-cancel</code> was called on <code>f</c
         documentation = DocumentationInfo(
             summary = """
 Returns <code>true</code> if the future is in a final state (completed, failed, or cancelled).<br /><br />
-Dispatches on type: for a <code>\Phel\Fiber\Domain\Future</code> (fiber-backed) it calls <code>isDone</code>; for any other value it falls back to <code>realized?</code>. This lets the same predicate serve both the AMPHP <code>Future</code> wrapper and the cooperative fiber future.
+Dispatches on type: for a <code>Phel.Fiber.Domain.Future</code> (fiber-backed) it calls <code>isDone</code>; for any other value it falls back to <code>realized?</code>. This lets the same predicate serve both the AMPHP <code>Future</code> wrapper and the cooperative fiber future.
 """,
             example = "(future-done? f)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/async.phel#L103",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/async.phel#L103",
                 docs = "",
             ),
         ),
@@ -226,7 +226,7 @@ Runs <code>body</code> in a new fiber via the cooperative scheduler. Returns a<b
 """,
             example = "@(future-fiber (+ 1 2))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/async.phel#L154",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/async.phel#L154",
                 docs = "",
             ),
         ),
@@ -245,7 +245,7 @@ Returns true if <code>x</code> is a fiber-future (from <code>future-call</code>/
 """,
             example = "(future? (future-call (fn [] 1))) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/async.phel#L165",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/async.phel#L165",
                 docs = "",
             ),
         ),
@@ -266,7 +266,7 @@ PHP fibers are cooperative on a single thread, so <code>pmap</code> overlaps IO-
 """,
             example = "(pmap inc [1 2 3]) ; =&gt; [2 3 4]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/async.phel#L75",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/async.phel#L75",
                 docs = "",
             ),
         ),
@@ -286,7 +286,7 @@ Once delivered the value is frozen; subsequent <code>deliver</code> calls are no
 """,
             example = "(let [p (promise)] (deliver p 42) @p) ; =&gt; 42",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/async.phel#L122",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/async.phel#L122",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/core/registerCoreAtomsFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/core/registerCoreAtomsFunctions.kt
@@ -23,7 +23,7 @@ Adds a watch function to a variable. The watch fn is called when the variable ch
 """,
             example = "(add-watch my-var :logger (fn [key ref old new] (println old \"-&gt;\" new)))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/atoms.phel#L133",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/atoms.phel#L147",
                 docs = "",
             ),
         ),
@@ -45,7 +45,7 @@ Replaces the metadata on <code>r</code> with <code>(apply f current-meta args)</
 """,
             example = "(alter-meta! #'my-var assoc :tag :int)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/atoms.phel#L180",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/atoms.phel#L194",
                 docs = "",
             ),
         ),
@@ -64,7 +64,7 @@ Replaces the root binding of <code>v</code> with <code>(apply f current-root arg
 """,
             example = "(def counter 0)\n(alter-var-root #'counter inc) ; =&gt; 1",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/atoms.phel#L141",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/atoms.phel#L155",
                 docs = "",
             ),
         ),
@@ -85,7 +85,7 @@ Optional <code>:meta</code> and <code>:validator</code> keyword arguments may fo
 """,
             example = "(def counter (atom 0))\n(atom 0 :meta {:tag :counter} :validator number?)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/atoms.phel#L22",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/atoms.phel#L22",
                 docs = "",
             ),
         ),
@@ -100,9 +100,9 @@ Optional <code>:meta</code> and <code>:validator</code> keyword arguments may fo
         ),
         documentation = DocumentationInfo(
             summary = "Returns true if the given value is an atom.",
-            example = null,
+            example = "(atom? (atom 1)) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/atoms.phel#L38",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/atoms.phel#L38",
                 docs = "",
             ),
         ),
@@ -121,7 +121,7 @@ Returns true when <code>v</code> has a current root binding in the namespace reg
 """,
             example = "(bound? #'phel.core/map) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/atoms.phel#L149",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/atoms.phel#L163",
                 docs = "",
             ),
         ),
@@ -140,7 +140,7 @@ Atomically sets the value of the atom <code>variable</code> to <code>new-value</
 """,
             example = "(def a (atom 1))\n(compare-and-set! a 1 2) ; =&gt; true\n(compare-and-set! a 1 3) ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/atoms.phel#L101",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/atoms.phel#L103",
                 docs = "",
             ),
         ),
@@ -161,7 +161,7 @@ With three arguments, and when <code>variable</code> is a future or promise, blo
 """,
             example = "(deref (atom 42)) ; =&gt; 42\n(deref #'phel.core/map) ; =&gt; &lt;function:map&gt;",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/atoms.phel#L62",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/atoms.phel#L65",
                 docs = "",
             ),
         ),
@@ -180,7 +180,7 @@ Repeatedly executes body for side effects with bindings and modifiers as provide
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/atoms.phel#L341",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/atoms.phel#L376",
                 docs = "",
             ),
         ),
@@ -203,7 +203,7 @@ Repeatedly executes body for side effects with Clojure-style bindings.<br />
 """,
             example = "(doseq [x [1 2 3]] (println x))\n(doseq [[k v] {:a 1 :b 2}] (println k v))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/atoms.phel#L390",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/atoms.phel#L425",
                 docs = "",
             ),
         ),
@@ -225,7 +225,7 @@ Internal helper used by the <code>doseq</code> macro expansion. Returns a value<
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/atoms.phel#L353",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/atoms.phel#L388",
                 docs = "",
             ),
         ),
@@ -260,7 +260,7 @@ Finally, additional options can be set:<br /><br />
 """,
             example = "(for [x :in [1 2 3]] (* x 2)) ; =&gt; [2 4 6]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/atoms.phel#L301",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/atoms.phel#L321",
                 docs = "",
             ),
         ),
@@ -275,9 +275,9 @@ Finally, additional options can be set:<br /><br />
         ),
         documentation = DocumentationInfo(
             summary = "Returns the validator function of a variable, or nil.",
-            example = null,
+            example = "(get-validator (atom 1)) ; =&gt; nil",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/atoms.phel#L222",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/atoms.phel#L236",
                 docs = "",
             ),
         ),
@@ -292,9 +292,9 @@ Finally, additional options can be set:<br /><br />
         ),
         documentation = DocumentationInfo(
             summary = "Returns its argument.",
-            example = null,
+            example = "(identity 42) ; =&gt; 42",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/atoms.phel#L401",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/atoms.phel#L436",
                 docs = "",
             ),
         ),
@@ -302,7 +302,7 @@ Finally, additional options can be set:<br /><br />
     PhelFunction(
         namespace = "core",
         name = "range",
-        signature = "(range & args)",
+        signature = "(range)\n(range end)\n(range start end)\n(range start end step)",
         completion = CompletionInfo(
             tailText = "Creates a lazy sequence of numbers",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,
@@ -311,9 +311,9 @@ Finally, additional options can be set:<br /><br />
             summary = """
 Creates a lazy sequence of numbers. With no arguments returns an infinite sequence starting at 0. With one argument returns (0..n). With two (start..end). With three (start..end step). Note: the infinite sequence is bounded by PHP_INT_MAX.
 """,
-            example = "(range 5) ; =&gt; @[0 1 2 3 4]",
+            example = "(range 5) ; =&gt; (0 1 2 3 4)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/atoms.phel#L240",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/atoms.phel#L255",
                 docs = "",
             ),
         ),
@@ -330,7 +330,7 @@ Creates a lazy sequence of numbers. With no arguments returns an infinite sequen
             summary = "Removes a watch function from a variable by key.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/atoms.phel#L207",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/atoms.phel#L221",
                 docs = "",
             ),
         ),
@@ -347,7 +347,7 @@ Creates a lazy sequence of numbers. With no arguments returns an infinite sequen
             summary = "Sets a new value on the given atom. Returns the new value.",
             example = "(def x (atom 10))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/atoms.phel#L55",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/atoms.phel#L58",
                 docs = "",
             ),
         ),
@@ -366,7 +366,7 @@ Installs <code>meta-map</code> as the metadata on <code>r</code>, replacing any 
 """,
             example = "(reset-meta! #'my-var {:tag :int})",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/atoms.phel#L196",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/atoms.phel#L210",
                 docs = "",
             ),
         ),
@@ -385,7 +385,7 @@ Sets the value of the atom <code>variable</code> to <code>new-value</code>. Retu
 """,
             example = "(def a (atom 1))\n(reset-vals! a 2) ; =&gt; [1 2]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/atoms.phel#L110",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/atoms.phel#L112",
                 docs = "",
             ),
         ),
@@ -404,7 +404,7 @@ Sets a validator function on a variable. The validator is called before any stat
 """,
             example = "(set-validator! my-var pos?)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/atoms.phel#L214",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/atoms.phel#L228",
                 docs = "",
             ),
         ),
@@ -412,7 +412,7 @@ Sets a validator function on a variable. The validator is called before any stat
     PhelFunction(
         namespace = "core",
         name = "swap!",
-        signature = "(swap! variable f & args)",
+        signature = "(swap! variable f)\n(swap! variable f a)\n(swap! variable f a b)\n(swap! variable f a b & args)",
         completion = CompletionInfo(
             tailText = "Atomically swaps the value of the atom to (apply f current-value args)",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -424,7 +424,7 @@ Returns the new value after the swap.
 """,
             example = "(def counter (atom 0))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/atoms.phel#L86",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/atoms.phel#L89",
                 docs = "",
             ),
         ),
@@ -432,7 +432,7 @@ Returns the new value after the swap.
     PhelFunction(
         namespace = "core",
         name = "swap-vals!",
-        signature = "(swap-vals! variable f & args)",
+        signature = "(swap-vals! variable f)\n(swap-vals! variable f a)\n(swap-vals! variable f a b)\n(swap-vals! variable f a b & args)",
         completion = CompletionInfo(
             tailText = "Atomically swaps the value of the atom variable to (apply f current-value args)",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -443,7 +443,7 @@ Atomically swaps the value of the atom <code>variable</code> to <code>(apply f c
 """,
             example = "(def a (atom 1))\n(swap-vals! a inc) ; =&gt; [1 2]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/atoms.phel#L119",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/atoms.phel#L121",
                 docs = "",
             ),
         ),
@@ -462,7 +462,7 @@ Returns true when a fiber-local <code>binding</code> (or <code>with-bindings</co
 """,
             example = "(binding [*foo* 1] (thread-bound? #'*foo*)) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/atoms.phel#L158",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/atoms.phel#L172",
                 docs = "",
             ),
         ),
@@ -483,7 +483,7 @@ Sets the value of the topmost active fiber-local binding frame for<br />
 """,
             example = "(def ^:dynamic *x* 0)\n(binding [*x* 1] (var-set #'*x* 2) *x*) ; =&gt; 2",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/atoms.phel#L168",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/atoms.phel#L182",
                 docs = "",
             ),
         ),
@@ -500,9 +500,9 @@ Sets the value of the topmost active fiber-local binding frame for<br />
             summary = """
 Returns true if the given value is a <code>Var</code>, the first-class handle to a global definition produced by <code>(var sym)</code> and <code>#'sym</code>.
 """,
-            example = null,
+            example = "(var? #'map) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/atoms.phel#L43",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/atoms.phel#L45",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/core/registerCoreBooleansFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/core/registerCoreBooleansFunctions.kt
@@ -12,7 +12,7 @@ internal fun registerCoreBooleansFunctions(): List<PhelFunction> = listOf(
     PhelFunction(
         namespace = "core",
         name = "<",
-        signature = "(< a & more)",
+        signature = "(< a)\n(< a b)\n(< a b & more)",
         completion = CompletionInfo(
             tailText = "Checks if each argument is strictly less than the following argument",
             priority = PhelCompletionPriority.ARITHMETIC_FUNCTIONS,
@@ -21,7 +21,7 @@ internal fun registerCoreBooleansFunctions(): List<PhelFunction> = listOf(
             summary = "Checks if each argument is strictly less than the following argument.",
             example = "(&lt; 1 2 3 4) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/booleans.phel#L197",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/booleans.phel#L263",
                 docs = "",
             ),
         ),
@@ -29,7 +29,7 @@ internal fun registerCoreBooleansFunctions(): List<PhelFunction> = listOf(
     PhelFunction(
         namespace = "core",
         name = "<=",
-        signature = "(<= a & more)",
+        signature = "(<= a)\n(<= a b)\n(<= a b & more)",
         completion = CompletionInfo(
             tailText = "Checks if each argument is less than or equal to the following argument",
             priority = PhelCompletionPriority.ARITHMETIC_FUNCTIONS,
@@ -38,9 +38,9 @@ internal fun registerCoreBooleansFunctions(): List<PhelFunction> = listOf(
             summary = """
 Checks if each argument is less than or equal to the following argument. Returns a boolean.
 """,
-            example = null,
+            example = "(&lt;= 1 1 2) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/booleans.phel#L208",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/booleans.phel#L285",
                 docs = "",
             ),
         ),
@@ -57,9 +57,9 @@ Checks if each argument is less than or equal to the following argument. Returns
             summary = """
 Alias for the spaceship PHP operator in ascending order. Returns an int. Dispatches on <code>Ratio</code> and <code>BigInt</code> so numeric ordering stays correct for those types.
 """,
-            example = null,
+            example = "(&lt;=&gt; 1 2) ; =&gt; -1\n(&lt;=&gt; 2 2) ; =&gt; 0",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/booleans.phel#L239",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/booleans.phel#L353",
                 docs = "",
             ),
         ),
@@ -67,7 +67,7 @@ Alias for the spaceship PHP operator in ascending order. Returns an int. Dispatc
     PhelFunction(
         namespace = "core",
         name = "=",
-        signature = "(= a & more)",
+        signature = "(= a)\n(= a b)\n(= a b & more)",
         completion = CompletionInfo(
             tailText = "Checks if all values are equal (value equality, not identity)",
             priority = PhelCompletionPriority.ARITHMETIC_FUNCTIONS,
@@ -76,7 +76,7 @@ Alias for the spaceship PHP operator in ascending order. Returns an int. Dispatc
             summary = "Checks if all values are equal (value equality, not identity).",
             example = "(= [1 2 3] [1 2 3]) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/booleans.phel#L105",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/booleans.phel#L117",
                 docs = "",
             ),
         ),
@@ -84,7 +84,7 @@ Alias for the spaceship PHP operator in ascending order. Returns an int. Dispatc
     PhelFunction(
         namespace = "core",
         name = "==",
-        signature = "(== a & more)",
+        signature = "(== a)\n(== a b)\n(== a b & more)",
         completion = CompletionInfo(
             tailText = "Numeric equality comparison",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -98,7 +98,7 @@ Numeric equality comparison. Returns true if all arguments have the same<br />
 """,
             example = "(== 1 1.0) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/booleans.phel#L132",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/booleans.phel#L155",
                 docs = "",
             ),
         ),
@@ -106,7 +106,7 @@ Numeric equality comparison. Returns true if all arguments have the same<br />
     PhelFunction(
         namespace = "core",
         name = ">",
-        signature = "(> a & more)",
+        signature = "(> a)\n(> a b)\n(> a b & more)",
         completion = CompletionInfo(
             tailText = "Checks if each argument is strictly greater than the following argument",
             priority = PhelCompletionPriority.ARITHMETIC_FUNCTIONS,
@@ -115,7 +115,7 @@ Numeric equality comparison. Returns true if all arguments have the same<br />
             summary = "Checks if each argument is strictly greater than the following argument.",
             example = "(&gt; 4 3 2 1) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/booleans.phel#L218",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/booleans.phel#L308",
                 docs = "",
             ),
         ),
@@ -123,7 +123,7 @@ Numeric equality comparison. Returns true if all arguments have the same<br />
     PhelFunction(
         namespace = "core",
         name = ">=",
-        signature = "(>= a & more)",
+        signature = "(>= a)\n(>= a b)\n(>= a b & more)",
         completion = CompletionInfo(
             tailText = "Checks if each argument is greater than or equal to the following argument",
             priority = PhelCompletionPriority.ARITHMETIC_FUNCTIONS,
@@ -132,9 +132,9 @@ Numeric equality comparison. Returns true if all arguments have the same<br />
             summary = """
 Checks if each argument is greater than or equal to the following argument. Returns a boolean.
 """,
-            example = null,
+            example = "(&gt;= 3 3 2) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/booleans.phel#L229",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/booleans.phel#L330",
                 docs = "",
             ),
         ),
@@ -149,9 +149,9 @@ Checks if each argument is greater than or equal to the following argument. Retu
         ),
         documentation = DocumentationInfo(
             summary = "Alias for the spaceship PHP operator in descending order. Returns an int.",
-            example = null,
+            example = "(&gt;=&lt; 1 2) ; =&gt; 1",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/booleans.phel#L246",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/booleans.phel#L362",
                 docs = "",
             ),
         ),
@@ -170,7 +170,7 @@ Returns true if predicate is true for every element in collection, false otherwi
 """,
             example = "(all? even? [2 4 6 8]) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/booleans.phel#L255",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/booleans.phel#L373",
                 docs = "",
             ),
         ),
@@ -189,7 +189,7 @@ Evaluates expressions left to right, returning the first falsy value or the last
 """,
             example = "(and true 1 \"hello\") ; =&gt; \"hello\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/booleans.phel#L49",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/booleans.phel#L49",
                 docs = "",
             ),
         ),
@@ -212,9 +212,9 @@ Compares <code>x</code> and <code>y</code>, returning a negative<br />
   <code>BigDecimal</code>). Throws <code>InvalidArgumentException</code> when <code>x</code> and <code>y</code> come from<br />
   mutually incomparable categories (e.g. <code>(compare 1 [])</code>).
 """,
-            example = null,
+            example = "(compare 1 2) ; =&gt; -1\n(compare :a :a) ; =&gt; 0",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/booleans.phel#L426",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/booleans.phel#L577",
                 docs = "",
             ),
         ),
@@ -231,7 +231,7 @@ Compares <code>x</code> and <code>y</code>, returning a negative<br />
             summary = "Returns true if key is present in collection (checks keys/indices, not values).",
             example = "(contains? [10 20 30] 1) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/booleans.phel#L338",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/booleans.phel#L489",
                 docs = "",
             ),
         ),
@@ -250,7 +250,7 @@ Returns true if predicate is true for every element in collection, false otherwi
 """,
             example = "(every? even? [2 4 6 8]) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/booleans.phel#L264",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/booleans.phel#L397",
                 docs = "",
             ),
         ),
@@ -267,27 +267,7 @@ Returns true if predicate is true for every element in collection, false otherwi
             summary = "Checks if value is exactly false (not just falsy).",
             example = "(false? nil) ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/booleans.phel#L320",
-                docs = "",
-            ),
-        ),
-    ),
-    PhelFunction(
-        namespace = "core",
-        name = "id",
-        signature = "(id a & more)",
-        completion = CompletionInfo(
-            tailText = "Checks if all values are identical",
-            priority = PhelCompletionPriority.DEPRECATED_FUNCTIONS,
-        ),
-        documentation = DocumentationInfo(
-            summary = """
-Checks if all values are identical. Same as <code>a === b</code> in PHP.
-""",
-            example = null,
-            deprecation = DeprecationInfo(version = "0.32.0", replacement = "identical?"),
-            links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/booleans.phel#L98",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/booleans.phel#L477",
                 docs = "",
             ),
         ),
@@ -295,7 +275,7 @@ Checks if all values are identical. Same as <code>a === b</code> in PHP.
     PhelFunction(
         namespace = "core",
         name = "identical?",
-        signature = "(identical? a & more)",
+        signature = "(identical? a)\n(identical? a b)\n(identical? a b & more)",
         completion = CompletionInfo(
             tailText = "Checks if all values are identical",
             priority = PhelCompletionPriority.PREDICATE_FUNCTIONS,
@@ -304,9 +284,9 @@ Checks if all values are identical. Same as <code>a === b</code> in PHP.
             summary = """
 Checks if all values are identical. Same as <code>a === b</code> in PHP.
 """,
-            example = null,
+            example = "(identical? :a :a) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/booleans.phel#L88",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/booleans.phel#L94",
                 docs = "",
             ),
         ),
@@ -326,11 +306,13 @@ Arity-1 accepts a string, keyword, or symbol. Returns <code>nil</code> when <cod
   If <code>x</code> is already a keyword, it is returned unchanged. A string is split on<br />
   the first <code>/</code> into namespace and name parts, like <code>symbol</code>.<br /><br />
 Arity-2 builds a namespaced keyword from the namespace and name parts (taken<br />
-  verbatim, without splitting); returns <code>nil</code> when <code>name</code> is <code>nil</code>.
+  verbatim, without splitting); returns <code>nil</code> when <code>name</code> is <code>nil</code>. Non-string<br />
+  parts are converted with PHP's <code>strval</code> rather than <code>str</code>, which is both<br />
+  faster on this hot path and renders <code>true</code> as <code>"1"</code> and <code>false</code> as <code>""</code>.
 """,
             example = "(keyword \"name\") ; =&gt; :name\n(keyword :abc) ; =&gt; :abc\n(keyword \"ns/name\") ; =&gt; :ns/name\n(keyword \"ns\" \"name\") ; =&gt; :ns/name",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/booleans.phel#L60",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/booleans.phel#L60",
                 docs = "",
             ),
         ),
@@ -347,7 +329,7 @@ Arity-2 builds a namespaced keyword from the namespace and name parts (taken<br 
             summary = "Returns true if value is nil, false otherwise.",
             example = "(nil? (get {:a 1} :b)) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/booleans.phel#L326",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/booleans.phel#L483",
                 docs = "",
             ),
         ),
@@ -364,7 +346,7 @@ Arity-2 builds a namespaced keyword from the namespace and name parts (taken<br 
             summary = "Returns true if value is falsy (nil or false), false otherwise.",
             example = "(not nil) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/booleans.phel#L147",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/booleans.phel#L180",
                 docs = "",
             ),
         ),
@@ -383,7 +365,7 @@ Returns true if <code>(pred x)</code> is logical false for every <code>x</code> 
 """,
             example = "(not-any? even? [1 3 5]) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/booleans.phel#L291",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/booleans.phel#L433",
                 docs = "",
             ),
         ),
@@ -402,7 +384,7 @@ Returns false if <code>(pred x)</code> is logical true for every <code>x</code> 
 """,
             example = "(not-every? even? [2 3 4]) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/booleans.phel#L271",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/booleans.phel#L404",
                 docs = "",
             ),
         ),
@@ -410,7 +392,7 @@ Returns false if <code>(pred x)</code> is logical true for every <code>x</code> 
     PhelFunction(
         namespace = "core",
         name = "not=",
-        signature = "(not= a & more)",
+        signature = "(not= a)\n(not= a b)\n(not= a b & more)",
         completion = CompletionInfo(
             tailText = "Checks if all values are unequal",
             priority = PhelCompletionPriority.ARITHMETIC_FUNCTIONS,
@@ -419,9 +401,9 @@ Returns false if <code>(pred x)</code> is logical true for every <code>x</code> 
             summary = """
 Checks if all values are unequal. Same as <code>a != b</code> in PHP.
 """,
-            example = null,
+            example = "(not= 1 2) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/booleans.phel#L153",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/booleans.phel#L186",
                 docs = "",
             ),
         ),
@@ -440,7 +422,7 @@ Evaluates expressions left to right, returning the first truthy value or the las
 """,
             example = "(or false nil 42 100) ; =&gt; 42",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/booleans.phel#L38",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/booleans.phel#L38",
                 docs = "",
             ),
         ),
@@ -459,7 +441,7 @@ Returns the first truthy value of applying predicate to elements, or nil if none
 """,
             example = "(some #(when (&gt; % 10) %) [5 15 8]) ; =&gt; 15",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/booleans.phel#L298",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/booleans.phel#L440",
                 docs = "",
             ),
         ),
@@ -478,25 +460,7 @@ With 1 arg, returns true if <code>x</code> is not nil (Clojure semantics). With 
 """,
             example = "(some? 1) ; =&gt; true\n(some? even? [1 3 5 6 7]) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/booleans.phel#L281",
-                docs = "",
-            ),
-        ),
-    ),
-    PhelFunction(
-        namespace = "core",
-        name = "str-contains?",
-        signature = "(str-contains? str s)",
-        completion = CompletionInfo(
-            tailText = "Returns true if str contains s",
-            priority = PhelCompletionPriority.DEPRECATED_FUNCTIONS,
-        ),
-        documentation = DocumentationInfo(
-            summary = "Returns true if str contains s.",
-            example = null,
-            deprecation = DeprecationInfo(version = "Use phel\\string\\contains?"),
-            links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/booleans.phel#L332",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/booleans.phel#L414",
                 docs = "",
             ),
         ),
@@ -513,7 +477,7 @@ With 1 arg, returns true if <code>x</code> is not nil (Clojure semantics). With 
             summary = "Checks if value is exactly true (not just truthy).",
             example = "(true? 1) ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/booleans.phel#L309",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/booleans.phel#L464",
                 docs = "",
             ),
         ),
@@ -530,9 +494,9 @@ With 1 arg, returns true if <code>x</code> is not nil (Clojure semantics). With 
             summary = """
 Checks if <code>x</code> is truthy. Same as <code>x == true</code> in PHP.
 """,
-            example = null,
+            example = "(truthy? 0) ; =&gt; true\n(truthy? nil) ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/booleans.phel#L315",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/booleans.phel#L470",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/core/registerCoreCollectionsFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/core/registerCoreCollectionsFunctions.kt
@@ -12,7 +12,7 @@ internal fun registerCoreCollectionsFunctions(): List<PhelFunction> = listOf(
     PhelFunction(
         namespace = "core",
         name = "hash-set",
-        signature = "(hash-set & xs)",
+        signature = "(hash-set)\n(hash-set a)\n(hash-set a b)\n(hash-set a b c)\n(hash-set a b c & more)",
         completion = CompletionInfo(
             tailText = "Creates a new Set from the given arguments",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -21,7 +21,7 @@ internal fun registerCoreCollectionsFunctions(): List<PhelFunction> = listOf(
             summary = "Creates a new Set from the given arguments. Shortcut: #{}",
             example = "(hash-set 1 2 3) ; =&gt; #{1 2 3}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/collections.phel#L15",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/collections.phel#L15",
                 docs = "",
             ),
         ),
@@ -40,7 +40,7 @@ Creates a new sorted map. Keys are in natural sorted order. The number of parame
 """,
             example = "(sorted-map :c 3 :a 1 :b 2) ; keys iterate as :a :b :c",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/collections.phel#L21",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/collections.phel#L28",
                 docs = "",
             ),
         ),
@@ -59,7 +59,7 @@ Creates a new sorted map using the given comparator for key ordering. The compar
 """,
             example = "(sorted-map-by (fn [a b] (compare b a)) :a 1 :b 2) ; keys iterate as :b :a",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/collections.phel#L28",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/collections.phel#L35",
                 docs = "",
             ),
         ),
@@ -76,7 +76,7 @@ Creates a new sorted map using the given comparator for key ordering. The compar
             summary = "Creates a new sorted set. Elements are in natural sorted order.",
             example = "(sorted-set 3 1 2) ; iterates as 1 2 3",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/collections.phel#L35",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/collections.phel#L42",
                 docs = "",
             ),
         ),
@@ -93,7 +93,7 @@ Creates a new sorted map using the given comparator for key ordering. The compar
             summary = "Creates a new sorted set using the given comparator for element ordering.",
             example = "(sorted-set-by (fn [a b] (compare b a)) 3 1 2) ; iterates as 3 2 1",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/collections.phel#L42",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/collections.phel#L49",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/core/registerCoreControlFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/core/registerCoreControlFunctions.kt
@@ -23,7 +23,7 @@ Evaluates expression and matches it against constant test values, returning the 
 """,
             example = "(case x 1 \"one\" 2 \"two\" \"other\") ; =&gt; \"one\" (when x is 1)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/control.phel#L57",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/control.phel#L57",
                 docs = "",
             ),
         ),
@@ -40,7 +40,7 @@ Evaluates expression and matches it against constant test values, returning the 
             summary = "Evaluates test/expression pairs, returning the first matching expression.",
             example = "(cond (&lt; x 0) \"negative\" (&gt; x 0) \"positive\" \"zero\") ; =&gt; \"negative\", \"positive\", or \"zero\" depending on x",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/control.phel#L32",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/control.phel#L32",
                 docs = "",
             ),
         ),
@@ -68,7 +68,7 @@ Takes a binary predicate, an expression, and a set of clauses.<br />
 """,
             example = "(condp = 1 1 \"one\" 2 \"two\" \"other\") ; =&gt; \"one\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/control.phel#L88",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/control.phel#L88",
                 docs = "",
             ),
         ),
@@ -85,7 +85,7 @@ Takes a binary predicate, an expression, and a set of clauses.<br />
             summary = "Evaluates then if test is false, else otherwise.",
             example = "(if-not (&lt; 5 3) \"not less\" \"less\") ; =&gt; \"not less\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/control.phel#L14",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/control.phel#L14",
                 docs = "",
             ),
         ),
@@ -102,7 +102,7 @@ Takes a binary predicate, an expression, and a set of clauses.<br />
             summary = "Evaluates body if test is true, otherwise returns nil.",
             example = "(when (&gt; 10 5) \"greater\") ; =&gt; \"greater\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/control.phel#L20",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/control.phel#L20",
                 docs = "",
             ),
         ),
@@ -119,7 +119,7 @@ Takes a binary predicate, an expression, and a set of clauses.<br />
             summary = "Evaluates body if test is false, otherwise returns nil.",
             example = "(when-not (empty? [1 2 3]) \"has items\") ; =&gt; \"has items\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/control.phel#L26",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/control.phel#L26",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/core/registerCoreDefsFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/core/registerCoreDefsFunctions.kt
@@ -21,7 +21,7 @@ internal fun registerCoreDefsFunctions(): List<PhelFunction> = listOf(
             summary = "Ignores the body of the comment.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/defs.phel#L179",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/defs.phel#L190",
                 docs = "",
             ),
         ),
@@ -29,7 +29,7 @@ internal fun registerCoreDefsFunctions(): List<PhelFunction> = listOf(
     PhelFunction(
         namespace = "core",
         name = "def-",
-        signature = "",
+        signature = "(def- name value)",
         completion = CompletionInfo(
             tailText = "Define a private value that will not be exported",
             priority = PhelCompletionPriority.MACROS,
@@ -38,7 +38,7 @@ internal fun registerCoreDefsFunctions(): List<PhelFunction> = listOf(
             summary = "Define a private value that will not be exported.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/defs.phel#L104",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/defs.phel#L115",
                 docs = "",
             ),
         ),
@@ -64,13 +64,13 @@ Defines a native PHP enum. Each case is named by a keyword followed by an<br />
 (defenum Suit<br />
         :hearts :spades :clubs :diamonds<br />
         Describable<br />
-        (describe [this] (php/-> this name))<br />
+        (describe [this] (.-name this))<br />
         :php<br />
-        (label [this] (php/-> this name)))
+        (label [this] (.-name this)))
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/defs.phel#L153",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/defs.phel#L164",
                 docs = "",
             ),
         ),
@@ -86,12 +86,13 @@ Defines a native PHP enum. Each case is named by a keyword followed by an<br />
         documentation = DocumentationInfo(
             summary = """
 Define a new exception. Optionally pass a parent class to extend (defaults to<br />
-  <code>\Exception</code>), so frameworks can catch it by type, e.g.<br />
-  <code>(defexception ProductNotFound \RuntimeException)</code>.
+  <code>Exception</code>), so frameworks can catch it by type, e.g.<br />
+  <code>(defexception ProductNotFound RuntimeException)</code>. The parent takes any class<br />
+  spelling: bare, dotted (<code>My.Ns.Error</code>), or an alias brought in with <code>:use</code>.
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/defs.phel#L137",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/defs.phel#L148",
                 docs = "",
             ),
         ),
@@ -99,7 +100,7 @@ Define a new exception. Optionally pass a parent class to extend (defaults to<br
     PhelFunction(
         namespace = "core",
         name = "defmacro",
-        signature = "",
+        signature = "(defmacro name & fdecl)",
         completion = CompletionInfo(
             tailText = "Define a macro",
             priority = PhelCompletionPriority.MACROS,
@@ -108,7 +109,7 @@ Define a new exception. Optionally pass a parent class to extend (defaults to<br
             summary = "Define a macro.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/defs.phel#L109",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/defs.phel#L120",
                 docs = "",
             ),
         ),
@@ -125,7 +126,7 @@ Define a new exception. Optionally pass a parent class to extend (defaults to<br
             summary = "Define a private macro that will not be exported.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/defs.phel#L119",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/defs.phel#L130",
                 docs = "",
             ),
         ),
@@ -133,7 +134,7 @@ Define a new exception. Optionally pass a parent class to extend (defaults to<br
     PhelFunction(
         namespace = "core",
         name = "defn",
-        signature = "",
+        signature = "(defn name & fdecl)",
         completion = CompletionInfo(
             tailText = "Define a new global function",
             priority = PhelCompletionPriority.MACROS,
@@ -142,7 +143,7 @@ Define a new exception. Optionally pass a parent class to extend (defaults to<br
             summary = "Define a new global function.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/defs.phel#L99",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/defs.phel#L110",
                 docs = "",
             ),
         ),
@@ -159,7 +160,7 @@ Define a new exception. Optionally pass a parent class to extend (defaults to<br
             summary = "Define a private function that will not be exported.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/defs.phel#L114",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/defs.phel#L125",
                 docs = "",
             ),
         ),
@@ -178,7 +179,7 @@ A Struct is a special kind of Map. It only supports a predefined number of keys 
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/defs.phel#L124",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/defs.phel#L135",
                 docs = "",
             ),
         ),
@@ -186,7 +187,7 @@ A Struct is a special kind of Map. It only supports a predefined number of keys 
     PhelFunction(
         namespace = "core",
         name = "to-php-array",
-        signature = "",
+        signature = "(to-php-array coll)",
         completion = CompletionInfo(
             tailText = "Creates a PHP Array from a sequential data structure",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -195,7 +196,7 @@ A Struct is a special kind of Map. It only supports a predefined number of keys 
             summary = "Creates a PHP Array from a sequential data structure.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/defs.phel#L22",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/defs.phel#L23",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/core/registerCoreExceptionsFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/core/registerCoreExceptionsFunctions.kt
@@ -19,9 +19,9 @@ internal fun registerCoreExceptionsFunctions(): List<PhelFunction> = listOf(
         ),
         documentation = DocumentationInfo(
             summary = "Returns the cause of an exception, or nil.",
-            example = null,
+            example = "(ex-cause (ex-info \"boom\" {})) ; =&gt; nil",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/exceptions.phel#L33",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/exceptions.phel#L35",
                 docs = "",
             ),
         ),
@@ -36,9 +36,9 @@ internal fun registerCoreExceptionsFunctions(): List<PhelFunction> = listOf(
         ),
         documentation = DocumentationInfo(
             summary = "Returns the data map from an ex-info exception, or nil if not an ExceptionInfo.",
-            example = null,
+            example = "(ex-data (ex-info \"boom\" {:a 1})) ; =&gt; {:a 1}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/exceptions.phel#L20",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/exceptions.phel#L20",
                 docs = "",
             ),
         ),
@@ -55,7 +55,7 @@ internal fun registerCoreExceptionsFunctions(): List<PhelFunction> = listOf(
             summary = "Creates an exception with a message and a data map. Optionally takes a cause.",
             example = "(throw (ex-info \"Invalid input\" {:field :email}))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/exceptions.phel#L11",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/exceptions.phel#L11",
                 docs = "",
             ),
         ),
@@ -70,9 +70,9 @@ internal fun registerCoreExceptionsFunctions(): List<PhelFunction> = listOf(
         ),
         documentation = DocumentationInfo(
             summary = "Returns the message of an exception.",
-            example = null,
+            example = "(ex-message (ex-info \"boom\" {})) ; =&gt; \"boom\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/exceptions.phel#L27",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/exceptions.phel#L28",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/core/registerCoreFnsSetsFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/core/registerCoreFnsSetsFunctions.kt
@@ -21,9 +21,9 @@ internal fun registerCoreFnsSetsFunctions(): List<PhelFunction> = listOf(
             summary = """
 Returns the number of required parameters of the function <code>f</code>. For a variadic function this is the number of parameters before <code>&</code>. A multi-arity function compiles to a single variadic dispatch, so it reports <code>0</code>.
 """,
-            example = "(arity inc) ; =&gt; 1\n(arity assoc) ; =&gt; 3",
+            example = "(arity inc) ; =&gt; 1\n(arity swap!) ; =&gt; 2",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/fns-sets.phel#L142",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/fns-sets.phel#L197",
                 docs = "",
             ),
         ),
@@ -40,9 +40,9 @@ Returns the number of required parameters of the function <code>f</code>. For a 
             summary = """
 Returns a function that takes the same arguments as <code>f</code> and returns the opposite truth value.
 """,
-            example = null,
+            example = "((complement even?) 3) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/fns-sets.phel#L131",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/fns-sets.phel#L176",
                 docs = "",
             ),
         ),
@@ -59,9 +59,9 @@ Returns a function that takes the same arguments as <code>f</code> and returns t
             summary = """
 Returns a function that always returns <code>x</code> and ignores any passed arguments.
 """,
-            example = null,
+            example = "((constantly 42) 1 2 3) ; =&gt; 42",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/fns-sets.phel#L126",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/fns-sets.phel#L164",
                 docs = "",
             ),
         ),
@@ -69,16 +69,16 @@ Returns a function that always returns <code>x</code> and ignores any passed arg
     PhelFunction(
         namespace = "core",
         name = "deep-merge",
-        signature = "(deep-merge & args)",
+        signature = "(deep-merge)\n(deep-merge m)\n(deep-merge m1 m2)\n(deep-merge m1 m2 & args)",
         completion = CompletionInfo(
             tailText = "Recursively merges data structures",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,
         ),
         documentation = DocumentationInfo(
             summary = "Recursively merges data structures.",
-            example = null,
+            example = "(deep-merge {:a {:x 1}} {:a {:y 2}}) ; =&gt; {:a {:x 1, :y 2}}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/fns-sets.phel#L343",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/fns-sets.phel#L534",
                 docs = "",
             ),
         ),
@@ -93,9 +93,9 @@ Returns a function that always returns <code>x</code> and ignores any passed arg
         ),
         documentation = DocumentationInfo(
             summary = "Difference between multiple sets into a new one.",
-            example = null,
+            example = "(difference (hash-set 1 2 3) (hash-set 2)) ; =&gt; #{1 3}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/fns-sets.phel#L55",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/fns-sets.phel#L89",
                 docs = "",
             ),
         ),
@@ -114,7 +114,7 @@ Takes a variadic set of predicates and returns a function <code>f</code> that, w
 """,
             example = "((every-pred even? pos?) 2 4 6) ; =&gt; true\n((every-pred even? pos?) 2 -4) ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/fns-sets.phel#L167",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/fns-sets.phel#L229",
                 docs = "",
             ),
         ),
@@ -129,9 +129,9 @@ Takes a variadic set of predicates and returns a function <code>f</code> that, w
         ),
         documentation = DocumentationInfo(
             summary = "Flattens nested sequential structure into a lazy sequence of all leaf values.",
-            example = "(flatten [[1 2] [3 [4 5]] 6]) ; =&gt; @[1 2 3 4 5 6]",
+            example = "(flatten [[1 2] [3 [4 5]] 6]) ; =&gt; (1 2 3 4 5 6)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/fns-sets.phel#L307",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/fns-sets.phel#L477",
                 docs = "",
             ),
         ),
@@ -150,7 +150,7 @@ Returns a function that replaces nil arguments with the provided defaults before
 """,
             example = "(let [safe-inc (fnil inc 0)] (safe-inc nil)) ; =&gt; 1",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/fns-sets.phel#L195",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/fns-sets.phel#L321",
                 docs = "",
             ),
         ),
@@ -167,9 +167,9 @@ Returns a function that replaces nil arguments with the provided defaults before
             summary = """
 Returns a map that groups the maps in the relation <code>xrel</code> by their values for the keys in <code>ks</code>. Each key is <code>(select-keys map ks)</code> and each value is the set of maps sharing those key-values.
 """,
-            example = "(index (hash-set {:name \"a\" :dept 1} {:name \"b\" :dept 1}) [:dept]) ; =&gt; {{:dept 1} (hash-set {:name \"a\" :dept 1} {:name \"b\" :dept 1})}",
+            example = "(index (hash-set {:name \"a\" :dept 1} {:name \"b\" :dept 1}) [:dept]) ; =&gt; {{:dept 1} #{{:name \"a\", :dept 1} {:name \"b\", :dept 1}}}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/fns-sets.phel#L100",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/fns-sets.phel#L138",
                 docs = "",
             ),
         ),
@@ -184,9 +184,9 @@ Returns a map that groups the maps in the relation <code>xrel</code> by their va
         ),
         documentation = DocumentationInfo(
             summary = "Intersect multiple sets into a new one.",
-            example = null,
+            example = "(intersection (hash-set 1 2 3) (hash-set 2 3 4)) ; =&gt; #{2 3}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/fns-sets.phel#L36",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/fns-sets.phel#L68",
                 docs = "",
             ),
         ),
@@ -194,7 +194,7 @@ Returns a map that groups the maps in the relation <code>xrel</code> by their va
     PhelFunction(
         namespace = "core",
         name = "juxt",
-        signature = "(juxt & fs)",
+        signature = "(juxt f)\n(juxt f g)\n(juxt f g h)\n(juxt f g h & fs)",
         completion = CompletionInfo(
             tailText = "Takes a list of functions and returns a new function that is the juxtaposition of those functions",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -203,9 +203,9 @@ Returns a map that groups the maps in the relation <code>xrel</code> by their va
             summary = """
 Takes a list of functions and returns a new function that is the juxtaposition of those functions.
 """,
-            example = "((juxt inc dec #(* % 2)) 10) =&gt; [11 9 20]",
+            example = "((juxt inc dec #(* % 2)) 10) ; =&gt; [11 9 20]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/fns-sets.phel#L178",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/fns-sets.phel#L247",
                 docs = "",
             ),
         ),
@@ -224,7 +224,7 @@ Returns a map with the keys and values of <code>m</code> swapped. When several k
 """,
             example = "(map-invert {:a 1 :b 2}) ; =&gt; {1 :a, 2 :b}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/fns-sets.phel#L374",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/fns-sets.phel#L577",
                 docs = "",
             ),
         ),
@@ -243,7 +243,7 @@ Returns a memoized version of the function <code>f</code>. The memoized function
 """,
             example = "(defn fact [n]\n  (if (zero? n)\n    1\n    (* n (fact (dec n)))))\n(def fact-memo (memoize fact))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/fns-sets.phel#L225",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/fns-sets.phel#L381",
                 docs = "",
             ),
         ),
@@ -263,7 +263,7 @@ Without arguments, uses a default cache size of 128 entries.
 """,
             example = "(defn fact [n]\n  (if (zero? n)\n    1\n    (* n (fact (dec n)))))\n(def fact-memo (memoize-lru fact 100))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/fns-sets.phel#L247",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/fns-sets.phel#L403",
                 docs = "",
             ),
         ),
@@ -271,7 +271,7 @@ Without arguments, uses a default cache size of 128 entries.
     PhelFunction(
         namespace = "core",
         name = "merge-with",
-        signature = "(merge-with f & hash-maps)",
+        signature = "(merge-with f)\n(merge-with f m)\n(merge-with f m1 m2)\n(merge-with f m1 m2 & hash-maps)",
         completion = CompletionInfo(
             tailText = "Merges multiple maps into one new map",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,
@@ -280,9 +280,9 @@ Without arguments, uses a default cache size of 128 entries.
             summary = """
 Merges multiple maps into one new map. If a key appears in more than one collection, the result of <code>(f current-val next-val)</code> is used.
 """,
-            example = null,
+            example = "(merge-with + {:a 1 :b 2} {:a 10}) ; =&gt; {:a 11, :b 2}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/fns-sets.phel#L323",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/fns-sets.phel#L509",
                 docs = "",
             ),
         ),
@@ -301,7 +301,7 @@ Takes a function <code>f</code> and fewer than the normal number of arguments to
 """,
             example = "((partial + 10) 1 2) ; =&gt; 13",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/fns-sets.phel#L188",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/fns-sets.phel#L286",
                 docs = "",
             ),
         ),
@@ -318,9 +318,9 @@ Takes a function <code>f</code> and fewer than the normal number of arguments to
             summary = """
 Returns a set of maps, keeping only the keys in <code>ks</code> from each map in the relation <code>xrel</code>.
 """,
-            example = "(project (hash-set {:a 1 :b 2}) [:a]) ; =&gt; (hash-set {:a 1})",
+            example = "(project (hash-set {:a 1 :b 2}) [:a]) ; =&gt; #{{:a 1}}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/fns-sets.phel#L86",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/fns-sets.phel#L124",
                 docs = "",
             ),
         ),
@@ -337,9 +337,9 @@ Returns a set of maps, keeping only the keys in <code>ks</code> from each map in
             summary = """
 Returns a set of maps like the relation <code>xrel</code>, with the keys of each map renamed according to <code>kmap</code> (a map of old-key to new-key).
 """,
-            example = "(rename (hash-set {:a 1 :b 2}) {:a :x}) ; =&gt; (hash-set {:x 1 :b 2})",
+            example = "(rename (hash-set {:a 1 :b 2}) {:a :x}) ; =&gt; #{{:x 1, :b 2}}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/fns-sets.phel#L93",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/fns-sets.phel#L131",
                 docs = "",
             ),
         ),
@@ -356,9 +356,9 @@ Returns a set of maps like the relation <code>xrel</code>, with the keys of each
             summary = """
 Returns a set of the elements of <code>xset</code> for which <code>(pred element)</code> is logical true.
 """,
-            example = "(select even? (hash-set 1 2 3 4)) ; =&gt; (hash-set 2 4)",
+            example = "(select even? (hash-set 1 2 3 4)) ; =&gt; #{2 4}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/fns-sets.phel#L79",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/fns-sets.phel#L117",
                 docs = "",
             ),
         ),
@@ -377,7 +377,7 @@ Takes a variadic set of predicates and returns a function <code>f</code> that, w
 """,
             example = "((some-fn even? nil?) 1 2) ; =&gt; true\n((some-fn pos? even?) -3 -1) ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/fns-sets.phel#L156",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/fns-sets.phel#L211",
                 docs = "",
             ),
         ),
@@ -396,7 +396,7 @@ Returns true if <code>s1</code> is a subset of <code>s2</code>, i.e. every eleme
 """,
             example = "(subset? (hash-set 1 2) (hash-set 1 2 3)) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/fns-sets.phel#L65",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/fns-sets.phel#L103",
                 docs = "",
             ),
         ),
@@ -415,7 +415,7 @@ Returns true if <code>s1</code> is a superset of <code>s2</code>, i.e. every ele
 """,
             example = "(superset? (hash-set 1 2 3) (hash-set 1 2)) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/fns-sets.phel#L73",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/fns-sets.phel#L111",
                 docs = "",
             ),
         ),
@@ -430,9 +430,9 @@ Returns true if <code>s1</code> is a superset of <code>s2</code>, i.e. every ele
         ),
         documentation = DocumentationInfo(
             summary = "Symmetric difference between multiple sets into a new one.",
-            example = null,
+            example = "(symmetric-difference (hash-set 1 2) (hash-set 2 3)) ; =&gt; #{1 3}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/fns-sets.phel#L60",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/fns-sets.phel#L96",
                 docs = "",
             ),
         ),
@@ -451,7 +451,7 @@ Calls <code>f</code> with any supplied <code>args</code>. While the return value
 """,
             example = "(defn my-even? [n] (if (zero? n) true (fn [] (my-odd? (dec n)))))\n(defn my-odd? [n] (if (zero? n) false (fn [] (my-even? (dec n)))))\n(trampoline my-even? 10000) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/fns-sets.phel#L212",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/fns-sets.phel#L368",
                 docs = "",
             ),
         ),
@@ -468,9 +468,9 @@ Calls <code>f</code> with any supplied <code>args</code>. While the return value
             summary = """
 Returns a vector of the nodes in the tree, via a depth-first walk. branch? is a function with one argument that returns true if the given node has children. children must be a function with one argument that returns the children of the node. root the root node of the tree.
 """,
-            example = null,
+            example = "(tree-seq indexed? identity [1 [2 3]]) ; =&gt; [[1 [2 3]] 1 [2 3] 2 3]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/fns-sets.phel#L293",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/fns-sets.phel#L449",
                 docs = "",
             ),
         ),
@@ -478,16 +478,16 @@ Returns a vector of the nodes in the tree, via a depth-first walk. branch? is a 
     PhelFunction(
         namespace = "core",
         name = "union",
-        signature = "(union & sets)",
+        signature = "(union)\n(union s)\n(union s1 s2)\n(union s1 s2 & sets)",
         completion = CompletionInfo(
             tailText = "Union multiple sets into a new one",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,
         ),
         documentation = DocumentationInfo(
             summary = "Union multiple sets into a new one.",
-            example = null,
+            example = "(union (hash-set 1 2) (hash-set 2 3)) ; =&gt; #{1 2 3}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/fns-sets.phel#L17",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/fns-sets.phel#L37",
                 docs = "",
             ),
         ),
@@ -506,7 +506,7 @@ Returns a map with <code>f</code> applied to each key.
 """,
             example = "(update-keys {:a 1 :b 2} name) ; =&gt; {\"a\" 1, \"b\" 2}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/fns-sets.phel#L354",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/fns-sets.phel#L547",
                 docs = "",
             ),
         ),
@@ -525,7 +525,7 @@ Returns a map with <code>f</code> applied to each value.
 """,
             example = "(update-vals {:a 1 :b 2} inc) ; =&gt; {:a 2, :b 3}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/fns-sets.phel#L364",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/fns-sets.phel#L559",
                 docs = "",
             ),
         ),
@@ -544,7 +544,7 @@ Returns true if the function <code>f</code> accepts a variable number of argumen
 """,
             example = "(variadic? +) ; =&gt; true\n(variadic? inc) ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/fns-sets.phel#L149",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/fns-sets.phel#L204",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/core/registerCoreFuturesFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/core/registerCoreFuturesFunctions.kt
@@ -25,7 +25,7 @@ Must be called from inside a fiber context (e.g. the AMPHP event loop or an encl
 """,
             example = "(let [f (future (expensive-computation))] @f)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/futures.phel#L9",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/futures.phel#L9",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/core/registerCoreInteropFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/core/registerCoreInteropFunctions.kt
@@ -1,0 +1,61 @@
+package org.phellang.registry.data.core
+
+import org.phellang.registry.CompletionInfo
+import org.phellang.registry.DocumentationInfo
+import org.phellang.registry.DocumentationLinks
+import org.phellang.registry.DeprecationInfo
+import org.phellang.registry.PhelFunction
+
+import org.phellang.registry.PhelCompletionPriority
+
+internal fun registerCoreInteropFunctions(): List<PhelFunction> = listOf(
+    PhelFunction(
+        namespace = "core",
+        name = "php-invoke",
+        signature = "(php-invoke target method & args)",
+        completion = CompletionInfo(
+            tailText = "Calls the method method on target, where the method name is a value rather than a literal",
+            priority = PhelCompletionPriority.CORE_FUNCTIONS,
+        ),
+        documentation = DocumentationInfo(
+            summary = """
+Calls the method <code>method</code> on <code>target</code>, where the method name is a value<br />
+  rather than a literal. <code>target</code> is either an object or a class-name string<br />
+  for a static method. Matches ClojureScript's <code>js-invoke</code>; use the dot<br />
+  syntax (<code>(.format d "Y")</code>) whenever the name is known at compile time.
+""",
+            example = "(php-invoke (new DateTimeImmutable \"2024-03-10\") \"format\" \"Y\") ; =&gt; \"2024\"\n(let [m \"format\"] (php-invoke (new DateTimeImmutable \"2024-03-10\") m \"Y\")) ; =&gt; \"2024\"",
+            links = DocumentationLinks(
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/interop.phel#L60",
+                docs = "",
+            ),
+        ),
+    ),
+    PhelFunction(
+        namespace = "core",
+        name = "set!",
+        signature = "(set! place value)",
+        completion = CompletionInfo(
+            tailText = "Sets place to value and returns value, covering all three shapes Clojure's set",
+            priority = PhelCompletionPriority.MACROS,
+        ),
+        documentation = DocumentationInfo(
+            summary = """
+Sets <code>place</code> to <code>value</code> and returns <code>value</code>, covering all three shapes<br />
+  Clojure's <code>set!</code> covers.<br /><br />
+A property access (<code>(.-prop obj)</code>) assigns the property, as does any other<br />
+  place <code>php/oset</code> accepts. A <strong>qualified symbol naming a member of a PHP<br />
+  class</strong> (<code>Foo/slot</code>) assigns that static property. Any other <strong>symbol</strong><br />
+  names a dynamic var and assigns its current thread-local binding, throwing<br />
+  when no <code>binding</code> frame is active, so it never writes the root by accident;<br />
+  <code>alter-var-root</code> is the way to change a root.<br /><br />
+A macro rather than a function because the place is a location, not a value.
+""",
+            example = "(let [o (new ArrayObject)] (set! (.-y o) 2024)) ; =&gt; 2024\n(def ^:dynamic *x* 0)\n(binding [*x* 1] (set! *x* 2) *x*) ; =&gt; 2",
+            links = DocumentationLinks(
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/interop.phel#L21",
+                docs = "",
+            ),
+        ),
+    )
+)

--- a/src/main/kotlin/org/phellang/registry/data/core/registerCoreIoFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/core/registerCoreIoFunctions.kt
@@ -23,7 +23,7 @@ Threads the expr through the forms. Inserts <code>x</code> as the second item in
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/io.phel#L293",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/io.phel#L377",
                 docs = "",
             ),
         ),
@@ -42,7 +42,7 @@ Threads the expr through the forms. Inserts <code>x</code> as the last item in t
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/io.phel#L306",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/io.phel#L390",
                 docs = "",
             ),
         ),
@@ -59,9 +59,9 @@ Threads the expr through the forms. Inserts <code>x</code> as the last item in t
             summary = """
 Binds <code>name</code> to <code>expr</code>, evaluates the first form in the lexical context of that binding, then binds name to that result, repeating for each successive form, returning the result of the last form.
 """,
-            example = null,
+            example = "(as-&gt; 1 x (+ x 2) (* x 3)) ; =&gt; 9",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/io.phel#L367",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/io.phel#L455",
                 docs = "",
             ),
         ),
@@ -87,7 +87,7 @@ Throws at runtime if any var in the bindings vector is not<br />
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/io.phel#L493",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/io.phel#L533",
                 docs = "",
             ),
         ),
@@ -106,7 +106,7 @@ Takes an expression and a set of test/form pairs. Threads <code>expr</code> (via
 """,
             example = "(cond-&gt; 1 true inc false (* 42) true (* 3)) ; =&gt; 6",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/io.phel#L386",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/io.phel#L478",
                 docs = "",
             ),
         ),
@@ -123,9 +123,9 @@ Takes an expression and a set of test/form pairs. Threads <code>expr</code> (via
             summary = """
 Takes an expression and a set of test/form pairs. Threads <code>expr</code> (via <code>->></code>) through each form for which the corresponding test expression is true. Note that, unlike <code>cond</code> branching, <code>cond->></code> threading does not short-circuit after the first true test expression.
 """,
-            example = "(cond-&gt;&gt; [1 2 3] true (map inc) false (filter odd?)) ; =&gt; @[2 3 4]",
+            example = "(cond-&gt;&gt; [1 2 3] true (map inc) false (filter odd?)) ; =&gt; (2 3 4)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/io.phel#L400",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/io.phel#L492",
                 docs = "",
             ),
         ),
@@ -142,7 +142,7 @@ Takes an expression and a set of test/form pairs. Threads <code>expr</code> (via
             summary = "Returns a lazy sequence of rows from a CSV file.",
             example = "(take 10 (csv-seq \"data.csv\")) ; =&gt; [[\"col1\" \"col2\"] [\"val1\" \"val2\"] ...]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/io.phel#L236",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/io.phel#L320",
                 docs = "",
             ),
         ),
@@ -161,7 +161,7 @@ Prints <code>[file:line] form => value</code> to the standard error stream and r
 """,
             example = "(defn area [w h] (* (dbg w) h))\n(area 3 4) ; stderr: [src/main.phel:12] w =&gt; 3",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/io.phel#L131",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/io.phel#L191",
                 docs = "",
             ),
         ),
@@ -180,7 +180,7 @@ Writes <code>message</code> to the standard error stream. Output primitive behin
 """,
             example = "(dbg-write \"debug line\\n\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/io.phel#L112",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/io.phel#L172",
                 docs = "",
             ),
         ),
@@ -197,9 +197,9 @@ Writes <code>message</code> to the standard error stream. Output primitive behin
             summary = """
 Evaluates x then calls all of the methods and functions with the value of x supplied at the front of the given arguments. The forms are evaluated in order. Returns x.
 """,
-            example = null,
+            example = "(deref (doto (atom 0) (reset! 5))) ; =&gt; 5",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/io.phel#L374",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/io.phel#L464",
                 docs = "",
             ),
         ),
@@ -216,7 +216,7 @@ Evaluates x then calls all of the methods and functions with the value of x supp
             summary = "Returns a lazy sequence of all files and directories in a directory tree.",
             example = "(filter #(php/str_ends_with % \".phel\") (file-seq \"src/\")) ; =&gt; [\"src/file1.phel\" \"src/file2.phel\" ...]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/io.phel#L210",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/io.phel#L294",
                 docs = "",
             ),
         ),
@@ -233,9 +233,9 @@ Evaluates x then calls all of the methods and functions with the value of x supp
             summary = """
 Returns a formatted string. See PHP's <a href="https://www.php.net/manual/en/function.sprintf.php">sprintf</a> for more information.
 """,
-            example = null,
+            example = "(format \"%d-%s\" 1 \"a\") ; =&gt; \"1-a\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/io.phel#L101",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/io.phel#L159",
                 docs = "",
             ),
         ),
@@ -252,7 +252,7 @@ Returns a formatted string. See PHP's <a href="https://www.php.net/manual/en/fun
             summary = "Returns a lazy sequence of lines from a file.",
             example = "(take 10 (line-seq \"large-file.txt\")) ; =&gt; [\"line1\" \"line2\" ...]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/io.phel#L198",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/io.phel#L282",
                 docs = "",
             ),
         ),
@@ -271,7 +271,7 @@ Same as <code>print</code>, but prints each value readably (strings quoted). Ret
 """,
             example = "(pr \"a\" 1) ; prints \"a\" 1",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/io.phel#L77",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/io.phel#L135",
                 docs = "",
             ),
         ),
@@ -290,7 +290,7 @@ Same as <code>print-str</code>, but prints each value readably: strings are quot
 """,
             example = "(pr-str \"a\" 1) ; =&gt; \"\\\"a\\\" 1\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/io.phel#L50",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/io.phel#L108",
                 docs = "",
             ),
         ),
@@ -307,7 +307,7 @@ Same as <code>print-str</code>, but prints each value readably: strings are quot
             summary = "Prints the given values to the default output stream. Returns nil.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/io.phel#L57",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/io.phel#L115",
                 docs = "",
             ),
         ),
@@ -324,9 +324,9 @@ Same as <code>print-str</code>, but prints each value readably: strings are quot
             summary = """
 Same as print. But instead of writing it to an output stream, the resulting string is returned.
 """,
-            example = null,
+            example = "(print-str \"a\" 1) ; =&gt; \"a 1\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/io.phel#L45",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/io.phel#L101",
                 docs = "",
             ),
         ),
@@ -345,7 +345,7 @@ Output a formatted string. See PHP's <a href="https://www.php.net/manual/en/func
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/io.phel#L106",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/io.phel#L166",
                 docs = "",
             ),
         ),
@@ -362,7 +362,7 @@ Output a formatted string. See PHP's <a href="https://www.php.net/manual/en/func
             summary = "Same as print followed by a newline.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/io.phel#L63",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/io.phel#L121",
                 docs = "",
             ),
         ),
@@ -381,7 +381,7 @@ Same as <code>println</code>, but instead of writing to an output stream the res
 """,
             example = "(println-str \"a\" \"b\") ; =&gt; \"a b\\n\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/io.phel#L70",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/io.phel#L128",
                 docs = "",
             ),
         ),
@@ -400,7 +400,7 @@ Same as <code>pr</code> followed by a newline. Returns nil.
 """,
             example = "(prn \"a\" 1) ; prints \"a\" 1 and a newline",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/io.phel#L85",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/io.phel#L143",
                 docs = "",
             ),
         ),
@@ -419,7 +419,7 @@ Same as <code>prn</code>, but instead of writing to an output stream the resulti
 """,
             example = "(prn-str \"a\" 1) ; =&gt; \"\\\"a\\\" 1\\n\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/io.phel#L94",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/io.phel#L152",
                 docs = "",
             ),
         ),
@@ -438,7 +438,7 @@ Returns the first match of pattern in string, or nil if no match. If the pattern
 """,
             example = "(re-find #\"\\d+\" \"abc123def\") ; =&gt; \"123\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/io.phel#L442",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/io.phel#L49",
                 docs = "",
             ),
         ),
@@ -457,7 +457,7 @@ Returns the match, if any, of string to pattern. If the pattern has groups, retu
 """,
             example = "(re-matches #\"(\\d+)-(\\d+)\" \"12-34\") ; =&gt; [\"12-34\" \"12\" \"34\"]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/io.phel#L455",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/io.phel#L62",
                 docs = "",
             ),
         ),
@@ -476,7 +476,7 @@ Returns a PCRE pattern string from <code>s</code>. If <code>s</code> is already 
 """,
             example = "(re-pattern \"\\\\d+\") ; =&gt; \"/\\\\d+/\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/io.phel#L418",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/io.phel#L24",
                 docs = "",
             ),
         ),
@@ -493,7 +493,7 @@ Returns a PCRE pattern string from <code>s</code>. If <code>s</code> is already 
             summary = "Returns a sequence of successive matches of pattern in string.",
             example = "(re-seq #\"\\d+\" \"a1b2c3\") ; =&gt; [\"1\" \"2\" \"3\"]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/io.phel#L430",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/io.phel#L37",
                 docs = "",
             ),
         ),
@@ -510,7 +510,7 @@ Returns a PCRE pattern string from <code>s</code>. If <code>s</code> is already 
             summary = "Returns a lazy sequence of byte chunks from a file.",
             example = "(take 5 (read-file-lazy \"large-file.bin\" 1024)) ; =&gt; [\"chunk1\" \"chunk2\" ...]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/io.phel#L222",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/io.phel#L306",
                 docs = "",
             ),
         ),
@@ -520,14 +520,14 @@ Returns a PCRE pattern string from <code>s</code>. If <code>s</code> is already 
         name = "slurp",
         signature = "(slurp path & [opts])",
         completion = CompletionInfo(
-            tailText = "Reads entire file or URL into a string",
+            tailText = "Reads an entire file, URL or stream into a string",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
         ),
         documentation = DocumentationInfo(
-            summary = "Reads entire file or URL into a string.",
+            summary = "Reads an entire file, URL or stream into a string.",
             example = "(slurp \"file.txt\") ; =&gt; \"file contents\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/io.phel#L156",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/io.phel#L242",
                 docs = "",
             ),
         ),
@@ -544,9 +544,9 @@ Returns a PCRE pattern string from <code>s</code>. If <code>s</code> is already 
             summary = """
 Threads <code>x</code> through the forms like <code>-></code> but stops when a form returns <code>nil</code>.
 """,
-            example = null,
+            example = "(some-&gt; {:a 1} :a inc) ; =&gt; 2",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/io.phel#L319",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/io.phel#L403",
                 docs = "",
             ),
         ),
@@ -563,9 +563,9 @@ Threads <code>x</code> through the forms like <code>-></code> but stops when a f
             summary = """
 Threads <code>x</code> through the forms like <code>->></code> but stops when a form returns <code>nil</code>.
 """,
-            example = null,
+            example = "(some-&gt;&gt; 5 (+ 3) (* 2)) ; =&gt; 16",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/io.phel#L343",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/io.phel#L429",
                 docs = "",
             ),
         ),
@@ -585,7 +585,7 @@ See PHP's <a href="https://www.php.net/manual/en/function.file-put-contents.php"
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/io.phel#L184",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/io.phel#L268",
                 docs = "",
             ),
         ),
@@ -604,7 +604,7 @@ Like <code>binding</code> but takes a map of <code>Var -> value</code> instead o
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/io.phel#L520",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/io.phel#L560",
                 docs = "",
             ),
         ),
@@ -626,7 +626,7 @@ Evaluates body with the names bound as in <code>let</code>, then closes every bo
 """,
             example = "(with-open [f (php/fopen \"data.txt\" \"r\")] (php/fgets f))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/io.phel#L266",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/io.phel#L350",
                 docs = "",
             ),
         ),
@@ -645,7 +645,7 @@ Everything that is printed inside the body will be stored in a buffer. The resul
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/io.phel#L21",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/io.phel#L77",
                 docs = "",
             ),
         ),
@@ -671,7 +671,7 @@ Accepts any var, dynamic or not. The previous root values are<br />
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/io.phel#L507",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/io.phel#L547",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/core/registerCoreLazyFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/core/registerCoreLazyFunctions.kt
@@ -23,7 +23,7 @@ Takes a body of expressions and yields a Delay object that will invoke the body 
 """,
             example = "(def d (delay (println \"computing\") 42))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/lazy.phel#L12",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/lazy.phel#L12",
                 docs = "",
             ),
         ),
@@ -38,9 +38,9 @@ Takes a body of expressions and yields a Delay object that will invoke the body 
         ),
         documentation = DocumentationInfo(
             summary = "Returns true if x is a Delay.",
-            example = null,
+            example = "(delay? (delay 1)) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/lazy.phel#L28",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/lazy.phel#L28",
                 docs = "",
             ),
         ),
@@ -57,7 +57,7 @@ Takes a body of expressions and yields a Delay object that will invoke the body 
             summary = "If x is a Delay, forces it and returns its cached value. Otherwise returns x.",
             example = "(force (delay 42)) ; =&gt; 42",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/lazy.phel#L19",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/lazy.phel#L19",
                 docs = "",
             ),
         ),
@@ -83,7 +83,7 @@ Options map keys:<br />
 """,
             example = "(iteration fetch-page {:kf :next-token :vf :items :initk nil})",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/lazy.phel#L36",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/lazy.phel#L37",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/core/registerCoreLoopsFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/core/registerCoreLoopsFunctions.kt
@@ -23,7 +23,7 @@ Evaluates body <code>n</code> times with <code>binding</code> bound to integers 
 """,
             example = "(dotimes [i 5] (println i))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/loops.phel#L16",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/loops.phel#L16",
                 docs = "",
             ),
         ),
@@ -42,7 +42,7 @@ Calls <code>(f x)</code> for each element in <code>coll</code> for side effects.
 """,
             example = "(run! println [1 2 3])",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/loops.phel#L8",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/loops.phel#L8",
                 docs = "",
             ),
         ),
@@ -61,7 +61,7 @@ Repeatedly evaluates <code>body</code> (for side effects) as long as <code>test<
 """,
             example = "(while (pos? @counter) (swap! counter dec))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/loops.phel#L25",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/loops.phel#L25",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/core/registerCoreMacroexpandFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/core/registerCoreMacroexpandFunctions.kt
@@ -21,7 +21,7 @@ internal fun registerCoreMacroexpandFunctions(): List<PhelFunction> = listOf(
             summary = "Recursively expands the given form until it is no longer a macro call.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/macroexpand.phel#L32",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/macroexpand.phel#L34",
                 docs = "",
             ),
         ),
@@ -36,9 +36,9 @@ internal fun registerCoreMacroexpandFunctions(): List<PhelFunction> = listOf(
         ),
         documentation = DocumentationInfo(
             summary = "Expands the given form once if it is a macro call.",
-            example = null,
+            example = "(macroexpand-1 '(when true 1)) ; =&gt; (if true (do 1))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/macroexpand.phel#L12",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/macroexpand.phel#L12",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/core/registerCoreMathFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/core/registerCoreMathFunctions.kt
@@ -24,7 +24,7 @@ Alias for <code>rem</code>. Returns the truncated remainder of <code>dividend</c
 """,
             example = "(% 11 2) ; =&gt; 1",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L227",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L310",
                 docs = "",
             ),
         ),
@@ -32,7 +32,7 @@ Alias for <code>rem</code>. Returns the truncated remainder of <code>dividend</c
     PhelFunction(
         namespace = "core",
         name = "*",
-        signature = "(* & xs)",
+        signature = "(*)\n(* x)\n(* x y)\n(* x y z)\n(* x y z w)\n(* x y z w & more)",
         completion = CompletionInfo(
             tailText = "Returns the product of all elements in xs",
             priority = PhelCompletionPriority.ARITHMETIC_FUNCTIONS,
@@ -43,7 +43,7 @@ Returns the product of all elements in <code>xs</code>. All elements in <code>xs
 """,
             example = "(* 2 3 4) ; =&gt; 24",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L172",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L236",
                 docs = "",
             ),
         ),
@@ -63,7 +63,7 @@ Auto-promoting variant of <code>*</code>. Integer results are returned as<br />
 """,
             example = "(*' 2 3) ; =&gt; 6",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L284",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L371",
                 docs = "",
             ),
         ),
@@ -82,7 +82,7 @@ Return <code>a</code> to the power of <code>x</code>.
 """,
             example = "(** 2 8) ; =&gt; 256",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L235",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L322",
                 docs = "",
             ),
         ),
@@ -90,7 +90,7 @@ Return <code>a</code> to the power of <code>x</code>.
     PhelFunction(
         namespace = "core",
         name = "+",
-        signature = "(+ & xs)",
+        signature = "(+)\n(+ x)\n(+ x y)\n(+ x y z)\n(+ x y z w)\n(+ x y z w & more)",
         completion = CompletionInfo(
             tailText = "Returns the sum of all elements in xs",
             priority = PhelCompletionPriority.ARITHMETIC_FUNCTIONS,
@@ -101,7 +101,7 @@ Returns the sum of all elements in <code>xs</code>. All elements <code>xs</code>
 """,
             example = "(+ 1 2 3) ; =&gt; 6",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L148",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L182",
                 docs = "",
             ),
         ),
@@ -124,7 +124,7 @@ Auto-promoting variant of <code>+</code>. Integer results are returned as<br />
 """,
             example = "(+' 1 2) ; =&gt; 3",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L265",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L352",
                 docs = "",
             ),
         ),
@@ -132,7 +132,7 @@ Auto-promoting variant of <code>+</code>. Integer results are returned as<br />
     PhelFunction(
         namespace = "core",
         name = "-",
-        signature = "(- & xs)",
+        signature = "(-)\n(- x)\n(- x y)\n(- x y z)\n(- x y z w)\n(- x y z w & more)",
         completion = CompletionInfo(
             tailText = "Returns the difference of all elements in xs",
             priority = PhelCompletionPriority.ARITHMETIC_FUNCTIONS,
@@ -143,7 +143,7 @@ Returns the difference of all elements in <code>xs</code>. If <code>xs</code> is
 """,
             example = "(- 10 3 2) ; =&gt; 5\n(- 4) ; =&gt; -4",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L160",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L209",
                 docs = "",
             ),
         ),
@@ -163,7 +163,7 @@ Auto-promoting variant of <code>-</code>. Integer results are returned as<br />
 """,
             example = "(-' 5 2) ; =&gt; 3",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L276",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L363",
                 docs = "",
             ),
         ),
@@ -171,7 +171,7 @@ Auto-promoting variant of <code>-</code>. Integer results are returned as<br />
     PhelFunction(
         namespace = "core",
         name = "/",
-        signature = "(/ & xs)",
+        signature = "(/)\n(/ x)\n(/ x y)\n(/ x y & more)",
         completion = CompletionInfo(
             tailText = "Returns the nominator divided by all the denominators",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -186,7 +186,7 @@ Integer division with a non-zero remainder returns a <code>Ratio</code><br />
 """,
             example = "(/ 1 2) ; =&gt; 1/2\n(/ 10 2) ; =&gt; 5",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L184",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L263",
                 docs = "",
             ),
         ),
@@ -203,7 +203,7 @@ Integer division with a non-zero remainder returns a <code>Ratio</code><br />
             summary = "Constant for Not a Number (NAN) values.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L144",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L178",
                 docs = "",
             ),
         ),
@@ -222,7 +222,7 @@ Checks if <code>x</code> is not a number. Alias for <code>nan?</code>, matching 
 """,
             example = "(NaN? ##NaN) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L359",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L466",
                 docs = "",
             ),
         ),
@@ -243,7 +243,7 @@ Returns the absolute value of <code>x</code>.<br />
 """,
             example = "(abs -5) ; =&gt; 5",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L380",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L487",
                 docs = "",
             ),
         ),
@@ -262,7 +262,7 @@ Coerces <code>x</code> to a <code>Phel\Lang\BigDecimal</code>. Accepts <code>Big
 """,
             example = "(bigdec 1.5) ; =&gt; 1.5M\n(bigdec 1/2) ; =&gt; 0.5M\n(bigdec \"3.14\") ; =&gt; 3.14M",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L676",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L856",
                 docs = "",
             ),
         ),
@@ -281,7 +281,7 @@ Returns true when <code>x</code> is a <code>Phel\Lang\BigDecimal</code> value.
 """,
             example = "(bigdec? 1.5M) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L662",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L842",
                 docs = "",
             ),
         ),
@@ -302,7 +302,7 @@ Coerces <code>x</code> to a <code>Phel\Lang\BigInt</code>. Accepts ints, floats<
 """,
             example = "(bigint 42) ; =&gt; 42\n(bigint 1.9) ; =&gt; 1\n(bigint \"123\") ; =&gt; 123",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L794",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L975",
                 docs = "",
             ),
         ),
@@ -319,9 +319,9 @@ Coerces <code>x</code> to a <code>Phel\Lang\BigInt</code>. Accepts ints, floats<
             summary = """
 Returns true when <code>x</code> is a <code>Phel\Lang\BigInt</code> value.
 """,
-            example = "(bigint? (php/:: \\Phel\\Lang\\BigInt (fromInt 1))) ; =&gt; true",
+            example = "(bigint? (Phel.Lang.BigInt/fromInt 1)) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L655",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L835",
                 docs = "",
             ),
         ),
@@ -340,7 +340,7 @@ Alias for <code>bigint</code>. Coerces <code>x</code> to a <code>Phel\Lang\BigIn
 """,
             example = "(biginteger 42) ; =&gt; 42",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L810",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L991",
                 docs = "",
             ),
         ),
@@ -357,7 +357,7 @@ Alias for <code>bigint</code>. Coerces <code>x</code> to a <code>Phel\Lang\BigIn
             summary = "Bitwise and.",
             example = "(bit-and 12 10) ; =&gt; 8",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L34",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L68",
                 docs = "",
             ),
         ),
@@ -376,7 +376,7 @@ Bitwise <code>and</code> with the complement of each subsequent argument: <code>
 """,
             example = "(bit-and-not 0xFF 0x0F) ; =&gt; 240",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L103",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L137",
                 docs = "",
             ),
         ),
@@ -395,7 +395,7 @@ Returns the integer <code>x</code> with the bit at index <code>n</code> (0-based
 """,
             example = "(bit-clear 7 1) ; =&gt; 5",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L119",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L153",
                 docs = "",
             ),
         ),
@@ -414,7 +414,7 @@ Returns the integer <code>x</code> with the bit at index <code>n</code> (0-based
 """,
             example = "(bit-flip 5 1) ; =&gt; 7",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L126",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L160",
                 docs = "",
             ),
         ),
@@ -431,7 +431,7 @@ Returns the integer <code>x</code> with the bit at index <code>n</code> (0-based
             summary = "Bitwise complement.",
             example = "(bit-not 0) ; =&gt; -1",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L64",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L98",
                 docs = "",
             ),
         ),
@@ -448,7 +448,7 @@ Returns the integer <code>x</code> with the bit at index <code>n</code> (0-based
             summary = "Bitwise or.",
             example = "(bit-or 12 10) ; =&gt; 14",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L44",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L78",
                 docs = "",
             ),
         ),
@@ -467,7 +467,7 @@ Returns the integer <code>x</code> with the bit at index <code>n</code> (0-based
 """,
             example = "(bit-set 0 2) ; =&gt; 4",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L112",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L146",
                 docs = "",
             ),
         ),
@@ -484,7 +484,7 @@ Returns the integer <code>x</code> with the bit at index <code>n</code> (0-based
             summary = "Bitwise shift left.",
             example = "(bit-shift-left 1 4) ; =&gt; 16",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L73",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L107",
                 docs = "",
             ),
         ),
@@ -501,7 +501,7 @@ Returns the integer <code>x</code> with the bit at index <code>n</code> (0-based
             summary = "Bitwise shift right.",
             example = "(bit-shift-right 16 2) ; =&gt; 4",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L82",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L116",
                 docs = "",
             ),
         ),
@@ -520,7 +520,7 @@ Returns <code>true</code> if the bit at index <code>n</code> (0-based, least sig
 """,
             example = "(bit-test 5 0) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L133",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L167",
                 docs = "",
             ),
         ),
@@ -537,7 +537,7 @@ Returns <code>true</code> if the bit at index <code>n</code> (0-based, least sig
             summary = "Bitwise xor.",
             example = "(bit-xor 12 10) ; =&gt; 6",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L54",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L88",
                 docs = "",
             ),
         ),
@@ -556,7 +556,7 @@ Coerces <code>x</code> to a signed 8-bit integer in the range <code>-128..127</c
 """,
             example = "(byte 127) ; =&gt; 127\n(byte 1.9) ; =&gt; 1\n(byte -128) ; =&gt; -128",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L488",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L603",
                 docs = "",
             ),
         ),
@@ -573,9 +573,9 @@ Coerces <code>x</code> to a signed 8-bit integer in the range <code>-128..127</c
             summary = """
 Returns the smallest integer not less than <code>x</code>. Ints and <code>BigInt</code> values are returned unchanged. Ratios collapse via ceiling division. Floats route through PHP's <code>ceil</code>.
 """,
-            example = "(ceil 1.2) ; =&gt; 2\n(ceil -1.7) ; =&gt; -1\n(ceil 7/3) ; =&gt; 3",
+            example = "(ceil 1.2) ; =&gt; 2.0\n(ceil -1.7) ; =&gt; -1.0\n(ceil 7/3) ; =&gt; 3",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L850",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L1031",
                 docs = "",
             ),
         ),
@@ -594,7 +594,7 @@ Coerces <code>x</code> to a single-character string representing the given Unico
 """,
             example = "(char 65) ; =&gt; \"A\"\n(char 32) ; =&gt; \" \"\n(char \\A) ; =&gt; \"A\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L495",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L610",
                 docs = "",
             ),
         ),
@@ -613,7 +613,7 @@ Returns <code>v</code> if it is in the range, or <code>min</code> if <code>v</co
 """,
             example = "(coerce-in 5 0 10) ; =&gt; 5\n(coerce-in 15 0 10) ; =&gt; 10",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L613",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L764",
                 docs = "",
             ),
         ),
@@ -632,7 +632,7 @@ Decrements <code>x</code> by one.
 """,
             example = "(dec 5) ; =&gt; 4",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L251",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L338",
                 docs = "",
             ),
         ),
@@ -652,7 +652,7 @@ Auto-promoting variant of <code>dec</code>. Integer results are returned as<br /
 """,
             example = "(dec' 1) ; =&gt; 0",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L300",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L387",
                 docs = "",
             ),
         ),
@@ -671,7 +671,7 @@ Alias for <code>bigdec?</code>. Returns true when <code>x</code> is a <code>Phel
 """,
             example = "(decimal? 1.5M) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L669",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L849",
                 docs = "",
             ),
         ),
@@ -690,7 +690,7 @@ Returns the denominator of <code>r</code>. For rationals the denominator collaps
 """,
             example = "(denominator 1/2) ; =&gt; 2\n(denominator 5) ; =&gt; 1",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L714",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L893",
                 docs = "",
             ),
         ),
@@ -707,9 +707,9 @@ Returns the denominator of <code>r</code>. For rationals the denominator collaps
             summary = """
 Coerces <code>x</code> to a double. In PHP there is no distinction between float and double; both map to the same native PHP float type. Alias for <code>float</code>.
 """,
-            example = "(double 1) ; =&gt; 1",
+            example = "(double 1) ; =&gt; 1.0",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L454",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L567",
                 docs = "",
             ),
         ),
@@ -728,7 +728,7 @@ Checks if <code>x</code> is even.
 """,
             example = "(even? 4) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L308",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L395",
                 docs = "",
             ),
         ),
@@ -747,7 +747,7 @@ Returns the most extreme value in <code>args</code> based on the binary <code>or
 """,
             example = "(extreme &gt; [1 5 2]) ; =&gt; 5",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L554",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L671",
                 docs = "",
             ),
         ),
@@ -770,9 +770,9 @@ Coerces <code>x</code> to a float. In PHP there is no distinction between float 
    keywords, vectors, or maps raise <code>InvalidArgumentException</code> instead of<br />
    leaking a raw PHP float-coercion warning.
 """,
-            example = "(float 1) ; =&gt; 1\n(float 1/2) ; =&gt; 0.5",
+            example = "(float 1) ; =&gt; 1.0\n(float 1/2) ; =&gt; 0.5",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L435",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L548",
                 docs = "",
             ),
         ),
@@ -789,9 +789,9 @@ Coerces <code>x</code> to a float. In PHP there is no distinction between float 
             summary = """
 Returns the largest integer not greater than <code>x</code>. Ints and <code>BigInt</code> values are returned unchanged. Ratios collapse via floor division. Floats route through PHP's <code>floor</code>.
 """,
-            example = "(floor 1.7) ; =&gt; 1\n(floor -1.2) ; =&gt; -2\n(floor 7/3) ; =&gt; 2",
+            example = "(floor 1.7) ; =&gt; 1.0\n(floor -1.2) ; =&gt; -2.0\n(floor 7/3) ; =&gt; 2",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L835",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L1016",
                 docs = "",
             ),
         ),
@@ -811,7 +811,7 @@ Returns the greatest common divisor of <code>a</code> and <code>b</code>, comput
 """,
             example = "(gcd 12 18) ; =&gt; 6\n(gcd -12 18) ; =&gt; 6",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L391",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L498",
                 docs = "",
             ),
         ),
@@ -830,7 +830,7 @@ Increments <code>x</code> by one.
 """,
             example = "(inc 1) ; =&gt; 2",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L243",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L330",
                 docs = "",
             ),
         ),
@@ -850,7 +850,7 @@ Auto-promoting variant of <code>inc</code>. Integer results are returned as<br /
 """,
             example = "(inc' 1) ; =&gt; 2",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L292",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L379",
                 docs = "",
             ),
         ),
@@ -869,7 +869,7 @@ Checks if <code>x</code> is infinite.
 """,
             example = "(inf? php/INF) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L366",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L473",
                 docs = "",
             ),
         ),
@@ -888,7 +888,7 @@ Checks if <code>x</code> is positive or negative infinity. Alias for <code>inf?<
 """,
             example = "(infinite? php/INF) ; =&gt; true\n(infinite? 1.0) ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L373",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L480",
                 docs = "",
             ),
         ),
@@ -914,7 +914,7 @@ Coerces <code>x</code> to an integer. <code>Ratio</code> and <code>BigDecimal</c
 """,
             example = "(int 1.9) ; =&gt; 1\n(int \"42\") ; =&gt; 42\n(int 1/10) ; =&gt; 0",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L414",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L521",
                 docs = "",
             ),
         ),
@@ -934,7 +934,7 @@ Returns the least common multiple of <code>a</code> and <code>b</code>. The resu
 """,
             example = "(lcm 4 6) ; =&gt; 12\n(lcm -4 6) ; =&gt; 12",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L403",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L510",
                 docs = "",
             ),
         ),
@@ -953,7 +953,7 @@ Coerces <code>x</code> to a long integer. In PHP there is no distinction between
 """,
             example = "(long 1.9) ; =&gt; 1",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L461",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L574",
                 docs = "",
             ),
         ),
@@ -961,7 +961,7 @@ Coerces <code>x</code> to a long integer. In PHP there is no distinction between
     PhelFunction(
         namespace = "core",
         name = "max",
-        signature = "(max & numbers)",
+        signature = "(max x)\n(max x y)\n(max x y z)\n(max x y z w)\n(max x y z w & more)",
         completion = CompletionInfo(
             tailText = "Returns the maximum of all arguments",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -972,7 +972,7 @@ Returns the maximum of all arguments. Returns <code>##NaN</code> whenever any nu
 """,
             example = "(max 3 1 2) ; =&gt; 3",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L575",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L709",
                 docs = "",
             ),
         ),
@@ -991,7 +991,7 @@ Returns the arg for which (k arg) is largest. On ties, returns the latest argume
 """,
             example = "(max-key count \"bb\" \"aaa\" \"b\") ; =&gt; \"aaa\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L599",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L750",
                 docs = "",
             ),
         ),
@@ -1008,9 +1008,9 @@ Returns the arg for which (k arg) is largest. On ties, returns the latest argume
             summary = """
 Returns the mean of <code>xs</code> as a float.
 """,
-            example = "(mean [1 2 3]) ; =&gt; 2",
+            example = "(mean [1 2 3]) ; =&gt; 2.0",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L629",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L809",
                 docs = "",
             ),
         ),
@@ -1029,7 +1029,7 @@ Returns the median of <code>xs</code>. With an even-sized collection the result 
 """,
             example = "(median [3 1 2]) ; =&gt; 2\n(median [1 2 3 4]) ; =&gt; 2.5",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L636",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L816",
                 docs = "",
             ),
         ),
@@ -1037,7 +1037,7 @@ Returns the median of <code>xs</code>. With an even-sized collection the result 
     PhelFunction(
         namespace = "core",
         name = "min",
-        signature = "(min & numbers)",
+        signature = "(min x)\n(min x y)\n(min x y z)\n(min x y z w)\n(min x y z w & more)",
         completion = CompletionInfo(
             tailText = "Returns the minimum of all arguments",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -1048,7 +1048,7 @@ Returns the minimum of all arguments. Returns <code>##NaN</code> whenever any nu
 """,
             example = "(min 3 1 2) ; =&gt; 1",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L565",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L682",
                 docs = "",
             ),
         ),
@@ -1067,7 +1067,7 @@ Returns the arg for which (k arg) is smallest. On ties, returns the latest argum
 """,
             example = "(min-key count \"bb\" \"aaa\" \"b\") ; =&gt; \"b\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L585",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L736",
                 docs = "",
             ),
         ),
@@ -1088,7 +1088,7 @@ Returns the floor remainder of <code>dividend</code> / <code>divisor</code>. The
 """,
             example = "(mod 7 3) ; =&gt; 1\n(mod -7 3) ; =&gt; 2",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L217",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L300",
                 docs = "",
             ),
         ),
@@ -1107,7 +1107,7 @@ Checks if <code>x</code> is not a number.
 """,
             example = "(nan? ##NaN) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L350",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L457",
                 docs = "",
             ),
         ),
@@ -1126,7 +1126,7 @@ Checks if <code>x</code> is smaller than zero.
 """,
             example = "(neg? -2) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L343",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L447",
                 docs = "",
             ),
         ),
@@ -1145,7 +1145,7 @@ Returns the numerator of <code>r</code>. For rationals the numerator collapses t
 """,
             example = "(numerator 1/2) ; =&gt; 1\n(numerator 5) ; =&gt; 5",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L694",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L873",
                 docs = "",
             ),
         ),
@@ -1164,7 +1164,7 @@ Checks if <code>x</code> is odd.
 """,
             example = "(odd? 3) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L315",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L406",
                 docs = "",
             ),
         ),
@@ -1183,7 +1183,7 @@ Checks if <code>x</code> is one.
 """,
             example = "(one? 1) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L329",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L428",
                 docs = "",
             ),
         ),
@@ -1202,7 +1202,7 @@ Checks if <code>x</code> is greater than zero.
 """,
             example = "(pos? 3) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L336",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L435",
                 docs = "",
             ),
         ),
@@ -1217,11 +1217,11 @@ Checks if <code>x</code> is greater than zero.
         ),
         documentation = DocumentationInfo(
             summary = """
-Returns the truncated integer quotient of <code>dividend</code> / <code>divisor</code>. Truncates toward zero. Throws <code>\DivisionByZeroError</code> when <code>divisor</code> is zero.
+Returns the truncated integer quotient of <code>dividend</code> / <code>divisor</code>. Truncates toward zero. Throws <code>DivisionByZeroError</code> when <code>divisor</code> is zero.
 """,
             example = "(quot 7 3) ; =&gt; 2\n(quot -7 3) ; =&gt; -2",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L201",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L284",
                 docs = "",
             ),
         ),
@@ -1240,7 +1240,7 @@ Without arguments, returns a random number in <code>[0, 1)</code>. With one argu
 """,
             example = "(rand) ; =&gt; 0.42\n(rand 100) ; =&gt; 73.2",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L521",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L638",
                 docs = "",
             ),
         ),
@@ -1259,7 +1259,7 @@ Returns a random number between 0 and <code>n</code>.
 """,
             example = "(rand-int 100) ; =&gt; 42",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L530",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L647",
                 docs = "",
             ),
         ),
@@ -1276,7 +1276,7 @@ Returns a random number between 0 and <code>n</code>.
             summary = "Returns a random item from xs.",
             example = "(rand-nth [:a :b :c]) ; =&gt; :b",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L537",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L654",
                 docs = "",
             ),
         ),
@@ -1293,9 +1293,9 @@ Returns a random number between 0 and <code>n</code>.
             summary = """
 Returns the items of <code>coll</code> for which <code>(rand)</code> is less than <code>prob</code>, so each item is kept independently with probability <code>prob</code> (0 keeps nothing, 1 keeps everything). Lazy. Without a collection, returns a transducer.
 """,
-            example = "(random-sample 0.5 (range 10)) ; =&gt; @[1 4 5 9]",
+            example = "(random-sample 0.5 (range 10)) ; =&gt; (1 4 5 9)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L545",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L662",
                 docs = "",
             ),
         ),
@@ -1314,7 +1314,7 @@ Converts <code>x</code> to a <code>Ratio</code>. Floats use the shortest decimal
 """,
             example = "(rationalize 0.5) ; =&gt; 1/2\n(rationalize 3) ; =&gt; 3\n(rationalize 1M) ; =&gt; 1",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L779",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L960",
                 docs = "",
             ),
         ),
@@ -1333,7 +1333,7 @@ Returns the truncated remainder of <code>dividend</code> / <code>divisor</code>.
 """,
             example = "(rem 7 3) ; =&gt; 1\n(rem -7 3) ; =&gt; -1",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L209",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L292",
                 docs = "",
             ),
         ),
@@ -1350,9 +1350,9 @@ Returns the truncated remainder of <code>dividend</code> / <code>divisor</code>.
             summary = """
 Rounds <code>x</code> to the nearest integer using PHP's <code>round</code> (half away from zero). Ints and <code>BigInt</code> values are returned unchanged. Ratios and floats return floats.
 """,
-            example = "(round 1.5) ; =&gt; 2\n(round -1.5) ; =&gt; -2\n(round 5) ; =&gt; 5",
+            example = "(round 1.5) ; =&gt; 2.0\n(round -1.5) ; =&gt; -2.0\n(round 5) ; =&gt; 5",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L865",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L1046",
                 docs = "",
             ),
         ),
@@ -1371,7 +1371,7 @@ Coerces <code>x</code> to a signed 16-bit integer in the range <code>-32768..327
 """,
             example = "(short 32767) ; =&gt; 32767\n(short 1.9) ; =&gt; 1\n(short -32768) ; =&gt; -32768",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L481",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L596",
                 docs = "",
             ),
         ),
@@ -1389,9 +1389,9 @@ Coerces <code>x</code> to a signed 16-bit integer in the range <code>-32768..327
 Returns the square root of <code>x</code> as a float. Negative inputs return<br />
   <code>##NaN</code> (matches PHP's <code>sqrt</code>).
 """,
-            example = "(sqrt 9) ; =&gt; 3\n(sqrt 2) ; =&gt; 1.4142135623731",
+            example = "(sqrt 9) ; =&gt; 3.0\n(sqrt 2) ; =&gt; 1.4142135623731",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L876",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L1057",
                 docs = "",
             ),
         ),
@@ -1410,7 +1410,7 @@ Returns the sum of all elements is <code>xs</code>.
 """,
             example = "(sum [1 2 3]) ; =&gt; 6",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L622",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L785",
                 docs = "",
             ),
         ),
@@ -1429,7 +1429,7 @@ Bitwise shift right without sign extension: the vacated high bits are filled wit
 """,
             example = "(unsigned-bit-shift-right -1 10) ; =&gt; 18014398509481983",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L91",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L125",
                 docs = "",
             ),
         ),
@@ -1448,7 +1448,7 @@ Checks if <code>x</code> is zero.
 """,
             example = "(zero? 0) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/math.phel#L322",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/math.phel#L417",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/core/registerCoreMetaFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/core/registerCoreMetaFunctions.kt
@@ -12,7 +12,7 @@ internal fun registerCoreMetaFunctions(): List<PhelFunction> = listOf(
     PhelFunction(
         namespace = "core",
         name = "meta",
-        signature = "",
+        signature = "(meta obj)",
         completion = CompletionInfo(
             tailText = "Gets the metadata attached to a value",
             priority = PhelCompletionPriority.MACROS,
@@ -23,25 +23,7 @@ Gets the metadata attached to a value. For a quoted symbol (<code>(meta 'foo)</c
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/meta.phel#L23",
-                docs = "",
-            ),
-        ),
-    ),
-    PhelFunction(
-        namespace = "core",
-        name = "set-meta!",
-        signature = "",
-        completion = CompletionInfo(
-            tailText = "Sets the metadata to a given object",
-            priority = PhelCompletionPriority.DEPRECATED_FUNCTIONS,
-        ),
-        documentation = DocumentationInfo(
-            summary = "Sets the metadata to a given object.",
-            example = null,
-            deprecation = DeprecationInfo(version = "0.32.0", replacement = "with-meta"),
-            links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/meta.phel#L68",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/meta.phel#L23",
                 docs = "",
             ),
         ),
@@ -49,7 +31,7 @@ Gets the metadata attached to a value. For a quoted symbol (<code>(meta 'foo)</c
     PhelFunction(
         namespace = "core",
         name = "vary-meta",
-        signature = "",
+        signature = "(vary-meta obj f & args)",
         completion = CompletionInfo(
             tailText = "Returns an object with (apply f (meta obj) args) as its new metadata",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -58,7 +40,7 @@ Gets the metadata attached to a value. For a quoted symbol (<code>(meta 'foo)</c
             summary = "Returns an object with (apply f (meta obj) args) as its new metadata.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/meta.phel#L75",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/meta.phel#L70",
                 docs = "",
             ),
         ),
@@ -66,7 +48,7 @@ Gets the metadata attached to a value. For a quoted symbol (<code>(meta 'foo)</c
     PhelFunction(
         namespace = "core",
         name = "with-meta",
-        signature = "",
+        signature = "(with-meta obj meta)",
         completion = CompletionInfo(
             tailText = "Returns obj with the given metadata meta attached",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -77,7 +59,7 @@ Returns <code>obj</code> with the given metadata <code>meta</code> attached.
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/meta.phel#L62",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/meta.phel#L64",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/core/registerCoreNsFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/core/registerCoreNsFunctions.kt
@@ -23,7 +23,7 @@ Returns the canonical (dot-separated) form of a namespace string. Pass user-supp
 """,
             example = "(canonical-ns \"phel\\core\") ; =&gt; \"phel.core\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/ns.phel#L17",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/ns.phel#L17",
                 docs = "",
             ),
         ),
@@ -42,7 +42,7 @@ Creates the given namespace if it does not already exist. Returns the namespace 
 """,
             example = "(create-ns \"my-app.tmp\") ; =&gt; \"my-app.tmp\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/ns.phel#L60",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/ns.phel#L60",
                 docs = "",
             ),
         ),
@@ -61,7 +61,7 @@ Returns the display (dot-separated) form of a namespace string. Equivalent to <c
 """,
             example = "(display-ns \"phel\\core\") ; =&gt; \"phel.core\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/ns.phel#L24",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/ns.phel#L24",
                 docs = "",
             ),
         ),
@@ -80,7 +80,7 @@ Returns the namespace name in display form if it is loaded, or nil if no namespa
 """,
             example = "(find-ns \"phel.core\") ; =&gt; \"phel.core\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/ns.phel#L51",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/ns.phel#L51",
                 docs = "",
             ),
         ),
@@ -99,7 +99,7 @@ Returns the <code>Var</code> named by the fully-qualified symbol, or nil if no m
 """,
             example = "(find-var 'phel.core/map) ; =&gt; #'phel.core/map",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/ns.phel#L147",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/ns.phel#L147",
                 docs = "",
             ),
         ),
@@ -118,7 +118,7 @@ Finds or creates a definition named by name-str in namespace ns-str. When a valu
 """,
             example = "(intern \"user\" \"x\" 42) ; =&gt; user/x",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/ns.phel#L97",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/ns.phel#L97",
                 docs = "",
             ),
         ),
@@ -137,7 +137,7 @@ Loads and evaluates a Phel source file. Reads the file content and evaluates it 
 """,
             example = "(load-file \"src/my-module.phel\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/ns.phel#L201",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/ns.phel#L201",
                 docs = "",
             ),
         ),
@@ -154,7 +154,7 @@ Loads and evaluates a Phel source file. Reads the file content and evaluates it 
             summary = "Returns all namespaces currently loaded, in dot-separated display form.",
             example = "(loaded-namespaces) ; =&gt; [\"phel.core\" \"phel.repl\"]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/ns.phel#L31",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/ns.phel#L31",
                 docs = "",
             ),
         ),
@@ -174,7 +174,7 @@ Returns a hash-map of {alias => namespace} for all require aliases in the<br />
 """,
             example = "(ns-aliases *ns*) ; =&gt; {\"repl\" \"phel.repl\" ...}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/ns.phel#L175",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/ns.phel#L175",
                 docs = "",
             ),
         ),
@@ -195,7 +195,7 @@ Returns a hash-map of {name => value} for every definition in the<br />
 """,
             example = "(ns-interns \"phel\\core\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/ns.phel#L88",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/ns.phel#L88",
                 docs = "",
             ),
         ),
@@ -215,7 +215,7 @@ Returns a hash-map of {name => value} for all public definitions in the<br />
 """,
             example = "(ns-publics \"phel\\core\") ; =&gt; {\"map\" &lt;fn&gt; \"filter\" &lt;fn&gt; ...}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/ns.phel#L164",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/ns.phel#L164",
                 docs = "",
             ),
         ),
@@ -235,7 +235,7 @@ Returns a hash-map of {name => source-namespace} for all referred symbols<br />
 """,
             example = "(ns-refers *ns*) ; =&gt; {\"doc\" \"phel.repl\" ...}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/ns.phel#L188",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/ns.phel#L188",
                 docs = "",
             ),
         ),
@@ -254,7 +254,7 @@ Removes the namespace and all of its definitions from the registry. Use with cau
 """,
             example = "(remove-ns \"my-app\\tmp\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/ns.phel#L69",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/ns.phel#L69",
                 docs = "",
             ),
         ),
@@ -282,7 +282,7 @@ With one argument, returns nil when the symbol is not defined. With two<br />
 """,
             example = "(var-get #'phel.core/map) ; =&gt; &lt;function:map&gt;\n(var-get (intern \"user\" \"x\" 42)) ; =&gt; 42\n(var-get 'user/missing ::none) ; =&gt; :user/none",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/ns.phel#L112",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/ns.phel#L112",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/core/registerCoreParsingFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/core/registerCoreParsingFunctions.kt
@@ -26,7 +26,7 @@ Parses a string as a boolean. Returns <code>true</code> for the exact string<br 
 """,
             example = "(parse-boolean \"true\") ; =&gt; true\n(parse-boolean \"True\") ; =&gt; nil",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/parsing.phel#L34",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/parsing.phel#L34",
                 docs = "",
             ),
         ),
@@ -43,9 +43,9 @@ Parses a string as a boolean. Returns <code>true</code> for the exact string<br 
             summary = """
 Parses a string as a float. Returns <code>nil</code> for non-numeric input or for inputs that are not strings. Accepts <code>Infinity</code>, <code>-Infinity</code>, and <code>NaN</code> alongside regular decimal and scientific notation.
 """,
-            example = "(parse-double \"3.14\") ; =&gt; 3.14\n(parse-double \"Infinity\") ; =&gt; INF",
+            example = "(parse-double \"3.14\") ; =&gt; 3.14\n(parse-double \"Infinity\") ; =&gt; Infinity",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/parsing.phel#L20",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/parsing.phel#L20",
                 docs = "",
             ),
         ),
@@ -62,7 +62,7 @@ Parses a string as a float. Returns <code>nil</code> for non-numeric input or fo
             summary = "Parses a string as an integer. Returns nil if parsing fails.",
             example = "(parse-long \"123\") ; =&gt; 123",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/parsing.phel#L10",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/parsing.phel#L10",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/core/registerCorePredicatesFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/core/registerCorePredicatesFunctions.kt
@@ -23,7 +23,7 @@ Returns true given any argument, including <code>nil</code> and <code>false</cod
 """,
             example = "(any? nil) ; =&gt; true\n(any? 0) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L384",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L374",
                 docs = "",
             ),
         ),
@@ -44,7 +44,7 @@ Associative data structures include vectors, hash maps, structs, and PHP arrays<
 """,
             example = "(associative? [1 2 3]) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L530",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L556",
                 docs = "",
             ),
         ),
@@ -64,7 +64,7 @@ Coerces <code>x</code> to a boolean. Returns <code>false</code> if <code>x</code
 """,
             example = "(boolean nil) ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L377",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L367",
                 docs = "",
             ),
         ),
@@ -83,7 +83,7 @@ Returns true if <code>x</code> is a boolean, false otherwise.
 """,
             example = "(boolean? true) ; =&gt; true\n(boolean? nil) ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L370",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L360",
                 docs = "",
             ),
         ),
@@ -107,7 +107,7 @@ Returns true if <code>x</code> is a single-character string, false otherwise.<br
 """,
             example = "(char? \\A) ; =&gt; true\n(char? \"a\") ; =&gt; true\n(char? \"ab\") ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L221",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L223",
                 docs = "",
             ),
         ),
@@ -124,9 +124,9 @@ Returns true if <code>x</code> is a single-character string, false otherwise.<br
             summary = """
 Returns a <code>Phel\Lang\PhpClass</code> for <code>x</code>. With an object argument returns the class of the object. With a string argument resolves the named class or interface FQN. Throws <code>InvalidArgumentException</code> for any other input.
 """,
-            example = "(class (php/new \\stdClass)) ; =&gt; stdClass",
+            example = "(class (new stdClass)) ; =&gt; stdClass",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L111",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L113",
                 docs = "",
             ),
         ),
@@ -145,7 +145,7 @@ Returns the FQN string of <code>c</code> (a <code>Phel\Lang\PhpClass</code>). Le
 """,
             example = "(class-name (class \"stdClass\")) ; =&gt; \"stdClass\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L122",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L124",
                 docs = "",
             ),
         ),
@@ -162,9 +162,9 @@ Returns the FQN string of <code>c</code> (a <code>Phel\Lang\PhpClass</code>). Le
             summary = """
 Returns true if <code>x</code> is a <code>Phel\Lang\PhpClass</code> value.
 """,
-            example = "(class? (class (php/new \\stdClass))) ; =&gt; true",
+            example = "(class? (class (new stdClass))) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L104",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L106",
                 docs = "",
             ),
         ),
@@ -187,7 +187,7 @@ Returns true if <code>x</code> is a persistent collection — vector, list, hash
 """,
             example = "(coll? [1 2 3]) ; =&gt; true\n(coll? \"abc\") ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L551",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L577",
                 docs = "",
             ),
         ),
@@ -211,7 +211,7 @@ Returns true if <code>coll</code> can report its length in constant time — per
 """,
             example = "(counted? [1 2 3]) ; =&gt; true\n(counted? (range)) ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L576",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L602",
                 docs = "",
             ),
         ),
@@ -230,7 +230,7 @@ Returns true if <code>x</code> is a floating-point number, false otherwise. Alia
 """,
             example = "(double? 1.0) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L200",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L202",
                 docs = "",
             ),
         ),
@@ -249,7 +249,7 @@ Returns an empty collection of the same category as <code>coll</code>, preservin
 """,
             example = "(empty [1 2 3]) ; =&gt; []\n(empty {:a 1}) ; =&gt; {}\n(empty (range 10)) ; =&gt; ()",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L461",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L477",
                 docs = "",
             ),
         ),
@@ -264,11 +264,12 @@ Returns an empty collection of the same category as <code>coll</code>, preservin
         ),
         documentation = DocumentationInfo(
             summary = """
-Returns true if x would be 0, "" or empty collection, false otherwise. Safe on infinite/lazy sequences: checks the first element instead of counting.
+Returns true if x would be 0, "" or empty collection, false otherwise. Safe on infinite/lazy sequences: checks the first element instead of counting.<br /><br />
+A non-countable iterable (an <code>eduction</code> pipeline, a PHP generator) is answered by pulling a single element, never by counting it.
 """,
             example = "(empty? []) ; =&gt; true\n(empty? [1]) ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L440",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L430",
                 docs = "",
             ),
         ),
@@ -287,7 +288,7 @@ Returns true if <code>x</code> is float point number, false otherwise.
 """,
             example = "(float? 1.0) ; =&gt; true\n(float? 1) ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L131",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L133",
                 docs = "",
             ),
         ),
@@ -306,47 +307,7 @@ Returns true if <code>x</code> is a function, false otherwise.
 """,
             example = "(fn? inc) ; =&gt; true\n(fn? 42) ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L295",
-                docs = "",
-            ),
-        ),
-    ),
-    PhelFunction(
-        namespace = "core",
-        name = "function?",
-        signature = "(function? x)",
-        completion = CompletionInfo(
-            tailText = "Returns true if x is a function, false otherwise",
-            priority = PhelCompletionPriority.DEPRECATED_FUNCTIONS,
-        ),
-        documentation = DocumentationInfo(
-            summary = """
-Returns true if <code>x</code> is a function, false otherwise.
-""",
-            example = null,
-            deprecation = DeprecationInfo(version = "0.32.0", replacement = "fn?"),
-            links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L310",
-                docs = "",
-            ),
-        ),
-    ),
-    PhelFunction(
-        namespace = "core",
-        name = "hash-map?",
-        signature = "(hash-map? x)",
-        completion = CompletionInfo(
-            tailText = "Returns true if x is a hash map, false otherwise",
-            priority = PhelCompletionPriority.DEPRECATED_FUNCTIONS,
-        ),
-        documentation = DocumentationInfo(
-            summary = """
-Returns true if <code>x</code> is a hash map, false otherwise.
-""",
-            example = null,
-            deprecation = DeprecationInfo(version = "0.32.0", replacement = "map?"),
-            links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L330",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L297",
                 docs = "",
             ),
         ),
@@ -365,7 +326,7 @@ Returns true if <code>x</code> is a symbol or keyword.
 """,
             example = "(ident? 'x) ; =&gt; true\n(ident? :a) ; =&gt; true\n(ident? 42) ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L248",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L250",
                 docs = "",
             ),
         ),
@@ -384,7 +345,7 @@ Returns true if <code>x</code> can be invoked as a function. This includes funct
 """,
             example = "(ifn? inc) ; =&gt; true\n(ifn? :a) ; =&gt; true\n(ifn? {}) ; =&gt; true\n(ifn? 42) ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L302",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L304",
                 docs = "",
             ),
         ),
@@ -404,7 +365,7 @@ Indexed sequences include lists, vectors, and indexed PHP arrays.
 """,
             example = "(indexed? [1 2 3]) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L520",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L546",
                 docs = "",
             ),
         ),
@@ -425,9 +386,9 @@ Returns true if <code>x</code> is an instance of class <code>c</code>, false oth
   <code>DateTime</code> or a <code>:use</code>d short name; for runtime class names use<br />
   <code>(php/is_a x class-name)</code>.
 """,
-            example = "(instance? DateTime (php/new DateTime)) ; =&gt; true",
+            example = "(instance? DateTime (new DateTime)) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L391",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L381",
                 docs = "",
             ),
         ),
@@ -446,7 +407,7 @@ Returns true if <code>x</code> is a fixed-precision PHP integer. <code>BigInt</c
 """,
             example = "(int? 1) ; =&gt; true\n(int? 1.0) ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L147",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L149",
                 docs = "",
             ),
         ),
@@ -466,7 +427,7 @@ Returns true if <code>x</code> is a mathematical integer: a fixed-precision PHP<
 """,
             example = "(integer? 1) ; =&gt; true\n(integer? 1.0) ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L138",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L140",
                 docs = "",
             ),
         ),
@@ -485,7 +446,7 @@ Returns true if <code>x</code> is a keyword, false otherwise.
 """,
             example = "(keyword? :a) ; =&gt; true\n(keyword? 'a) ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L234",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L236",
                 docs = "",
             ),
         ),
@@ -505,7 +466,7 @@ Unlike <code>seq?</code>, this predicate is true only for lazy sequences, not fo
 """,
             example = "(lazy-seq? (map inc [1 2 3])) ; =&gt; true\n(lazy-seq? '(1 2 3))         ; =&gt; false\n(lazy-seq? [1 2 3])          ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L431",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L421",
                 docs = "",
             ),
         ),
@@ -524,7 +485,7 @@ Returns true if <code>x</code> is a list, false otherwise. Returns false for the
 """,
             example = "(list? '(1 2)) ; =&gt; true\n(list? [1 2]) ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L355",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L343",
                 docs = "",
             ),
         ),
@@ -545,7 +506,7 @@ Returns true if <code>x</code> is a map entry. Accepts both the typed<br />
 """,
             example = "(map-entry? [:a 1]) ; =&gt; true\n(map-entry? (map-entry :a 1)) ; =&gt; true\n(map-entry? [1 2 3]) ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L345",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L333",
                 docs = "",
             ),
         ),
@@ -564,7 +525,7 @@ Returns true if <code>x</code> is a hash map, false otherwise.
 """,
             example = "(map? {:a 1}) ; =&gt; true\n(map? [1 2]) ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L322",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L317",
                 docs = "",
             ),
         ),
@@ -583,7 +544,7 @@ Returns true if <code>x</code> is a non-negative integer (zero or positive). Acc
 """,
             example = "(nat-int? 0) ; =&gt; true\n(nat-int? 1) ; =&gt; true\n(nat-int? (bigint 5)) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L175",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L177",
                 docs = "",
             ),
         ),
@@ -602,7 +563,7 @@ Returns true if <code>x</code> is a negative integer. Accepts both fixed-precisi
 """,
             example = "(neg-int? -1) ; =&gt; true\n(neg-int? 0) ; =&gt; false\n(neg-int? (bigint -5)) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L161",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L163",
                 docs = "",
             ),
         ),
@@ -621,7 +582,7 @@ Returns <code>coll</code> if it contains elements, otherwise nil.
 """,
             example = "(not-empty [1 2]) ; =&gt; [1 2]\n(not-empty []) ; =&gt; nil",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L452",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L468",
                 docs = "",
             ),
         ),
@@ -640,7 +601,7 @@ Returns true if <code>x</code> is a number: int, float, <code>Ratio</code>, <cod
 """,
             example = "(number? 1) ; =&gt; true\n(number? \"a\") ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L182",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L184",
                 docs = "",
             ),
         ),
@@ -657,9 +618,9 @@ Returns true if <code>x</code> is a number: int, float, <code>Ratio</code>, <cod
             summary = """
 Returns true if <code>x</code> is a PHP Array, false otherwise.
 """,
-            example = "(php-array? (php/array 1 2)) ; =&gt; true\n(php-array? [1 2]) ; =&gt; false",
+            example = "(php-array? (php-indexed-array 1 2)) ; =&gt; true\n(php-array? [1 2]) ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L402",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L392",
                 docs = "",
             ),
         ),
@@ -676,9 +637,9 @@ Returns true if <code>x</code> is a PHP Array, false otherwise.
             summary = """
 Returns true if <code>x</code> is a PHP object, false otherwise.
 """,
-            example = "(php-object? (php/new \\stdClass)) ; =&gt; true",
+            example = "(php-object? (new stdClass)) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L414",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L404",
                 docs = "",
             ),
         ),
@@ -697,7 +658,7 @@ Returns true if <code>x</code> is a PHP resource, false otherwise.
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L409",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L399",
                 docs = "",
             ),
         ),
@@ -716,7 +677,7 @@ Returns true if <code>x</code> is a positive integer (greater than zero). Accept
 """,
             example = "(pos-int? 1) ; =&gt; true\n(pos-int? 0) ; =&gt; false\n(pos-int? (bigint 5)) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L168",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L170",
                 docs = "",
             ),
         ),
@@ -735,7 +696,7 @@ Returns true if <code>x</code> is a <code>Phel\Lang\Collections\Queue\Persistent
 """,
             example = "(queue? (queue 1 2 3)) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L363",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L353",
                 docs = "",
             ),
         ),
@@ -754,7 +715,7 @@ Returns true if <code>x</code> is a <code>Ratio</code> value. Integer-valued rat
 """,
             example = "(ratio? 1/2) ; =&gt; true\n(ratio? 0.5) ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L193",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L195",
                 docs = "",
             ),
         ),
@@ -773,7 +734,7 @@ Returns true if <code>x</code> is a rational number: an integer (<code>int</code
 """,
             example = "(rational? 1/2) ; =&gt; true\n(rational? 1.0) ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L207",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L209",
                 docs = "",
             ),
         ),
@@ -793,7 +754,7 @@ This function is useful for explicitly converting strings to sequences of charac
 """,
             example = "(seq \"hello\") ; =&gt; [\"h\" \"e\" \"l\" \"l\" \"o\"]\n(seq [1 2 3]) ; =&gt; (1 2 3)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L487",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L503",
                 docs = "",
             ),
         ),
@@ -813,7 +774,7 @@ Returns true if <code>x</code> is a seq (a list, a lazy sequence, or a realized<
 """,
             example = "(seq? '(1 2)) ; =&gt; true\n(seq? [1 2]) ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L421",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L411",
                 docs = "",
             ),
         ),
@@ -832,7 +793,7 @@ Returns true if <code>(seq x)</code> is supported: collections (vectors, lists, 
 """,
             example = "(seqable? [1 2]) ; =&gt; true\n(seqable? 42) ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L566",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L592",
                 docs = "",
             ),
         ),
@@ -851,7 +812,7 @@ Returns true if <code>x</code> is a sequential collection (vector, list, or lazy
 """,
             example = "(sequential? [1 2 3]) ; =&gt; true\n(sequential? {:a 1}) ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L542",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L568",
                 docs = "",
             ),
         ),
@@ -870,7 +831,7 @@ Returns true if <code>x</code> is a set, false otherwise.
 """,
             example = "(set? (hash-set 1 2)) ; =&gt; true\n(set? [1 2]) ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L591",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L617",
                 docs = "",
             ),
         ),
@@ -889,7 +850,7 @@ Returns true if <code>x</code> is a symbol or keyword without a namespace.
 """,
             example = "(simple-ident? 'a) ; =&gt; true\n(simple-ident? 'foo/bar) ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L269",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L271",
                 docs = "",
             ),
         ),
@@ -908,7 +869,7 @@ Returns true if <code>x</code> is a keyword without a namespace.
 """,
             example = "(simple-keyword? :a) ; =&gt; true\n(simple-keyword? :foo/bar) ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L262",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L264",
                 docs = "",
             ),
         ),
@@ -927,7 +888,7 @@ Returns true if <code>x</code> is a symbol without a namespace.
 """,
             example = "(simple-symbol? 'a) ; =&gt; true\n(simple-symbol? 'foo/bar) ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L255",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L257",
                 docs = "",
             ),
         ),
@@ -946,7 +907,7 @@ Returns true if <code>coll</code> is a sorted collection (sorted-map or sorted-s
 """,
             example = "(sorted? (sorted-set 1 2 3)) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L598",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L624",
                 docs = "",
             ),
         ),
@@ -965,7 +926,7 @@ Returns true if <code>s</code> names a special form.
 """,
             example = "(special-symbol? 'def) ; =&gt; true\n(special-symbol? 'map) ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L288",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L290",
                 docs = "",
             ),
         ),
@@ -984,7 +945,7 @@ Returns true if <code>x</code> is a string, false otherwise.
 """,
             example = "(string? \"a\") ; =&gt; true\n(string? :a) ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L214",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L216",
                 docs = "",
             ),
         ),
@@ -1003,7 +964,7 @@ Returns true if <code>x</code> is a struct, false otherwise.
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L317",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L312",
                 docs = "",
             ),
         ),
@@ -1022,7 +983,7 @@ Returns true if <code>x</code> is a symbol, false otherwise.
 """,
             example = "(symbol? 'a) ; =&gt; true\n(symbol? :a) ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L241",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L243",
                 docs = "",
             ),
         ),
@@ -1067,7 +1028,7 @@ Returns the type of <code>x</code>. The following types can be returned:<br /><b
 """,
             example = "(type [1 2]) ; =&gt; :vector\n(type :a) ; =&gt; :keyword",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L39",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L41",
                 docs = "",
             ),
         ),
@@ -1086,7 +1047,7 @@ Returns true if <code>x</code> is a vector. Map entries returned by iterating a 
 """,
             example = "(vector? [1 2]) ; =&gt; true\n(vector? '(1 2)) ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/predicates.phel#L337",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/predicates.phel#L325",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/core/registerCoreProtocolsFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/core/registerCoreProtocolsFunctions.kt
@@ -23,7 +23,7 @@ Returns the set of all transitive ancestors of tag, or nil. When a hierarchy is 
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L318",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L319",
                 docs = "",
             ),
         ),
@@ -42,7 +42,7 @@ Throws an exception if expr is falsy. Optional message string. Used for precondi
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L943",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L962",
                 docs = "",
             ),
         ),
@@ -59,7 +59,7 @@ Throws an exception if expr is falsy. Optional message string. Used for precondi
             summary = "Returns the compiled PHP code string for the given form.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L984",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L1013",
                 docs = "",
             ),
         ),
@@ -78,7 +78,7 @@ An interface in Phel defines an abstract set of functions. It is directly mapped
 """,
             example = "(definterface name &amp; fns)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L24",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L24",
                 docs = "",
             ),
         ),
@@ -103,7 +103,7 @@ Registers a method implementation for a multimethod.<br /><br />
 """,
             example = "(defmethod area :circle [{:radius r}] (* 3.14159 r r))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L763",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L775",
                 docs = "",
             ),
         ),
@@ -127,7 +127,7 @@ If no method matches the dispatch value, the <code>:default</code> method is use
 """,
             example = "(defmulti area \"Area of shape.\" :shape)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L709",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L706",
                 docs = "",
             ),
         ),
@@ -148,7 +148,7 @@ A <code>:default</code> type can be registered via <code>extend-type</code> as a
 """,
             example = "(defprotocol Stringable (to-string [this]))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L430",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L432",
                 docs = "",
             ),
         ),
@@ -176,7 +176,7 @@ An optional tail of protocol/method forms is spliced into an <code>extend-type</
 """,
             example = "(defrecord Point [x y] Drawable (draw [this canvas] ...))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L646",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L643",
                 docs = "",
             ),
         ),
@@ -206,7 +206,7 @@ Deviation from Clojure: Phel's <code>deftype</code> shares the map-backed<br />
 """,
             example = "(deftype PointT [x y] Drawable (draw [this canvas] ...))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L676",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L673",
                 docs = "",
             ),
         ),
@@ -225,7 +225,7 @@ Establishes a parent/child relationship between child and parent keywords. With 
 """,
             example = "(derive ::square ::shape)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L255",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L256",
                 docs = "",
             ),
         ),
@@ -247,7 +247,7 @@ Returns the set of all descendants of tag, or nil.<br />
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L329",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L330",
                 docs = "",
             ),
         ),
@@ -262,9 +262,9 @@ Returns the set of all descendants of tag, or nil.<br />
         ),
         documentation = DocumentationInfo(
             summary = "Evaluates a form and return the evaluated results.",
-            example = null,
+            example = "(eval '(+ 1 2)) ; =&gt; 3",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L978",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L1005",
                 docs = "",
             ),
         ),
@@ -284,7 +284,7 @@ Equivalent to multiple <code>extend-type</code> calls.
 """,
             example = "(extend-protocol Describable\n  :string (describe [s] s)\n  :int (describe [n] (str n)))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L576",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L576",
                 docs = "",
             ),
         ),
@@ -313,7 +313,7 @@ Note: <code>:struct</code> and <code>:php/object</code> cannot be used as type-s
 """,
             example = "(extend-type :string Stringable (to-string [s] s))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L498",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L499",
                 docs = "",
             ),
         ),
@@ -332,7 +332,7 @@ Returns true if the given type-key has implementations for all methods of the pr
 """,
             example = "(extends? Stringable :string)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L566",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L566",
                 docs = "",
             ),
         ),
@@ -354,7 +354,7 @@ Finds the best matching method for dispatch-val using the global hierarchy.<br /
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L368",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L369",
                 docs = "",
             ),
         ),
@@ -369,9 +369,9 @@ Finds the best matching method for dispatch-val using the global hierarchy.<br /
         ),
         documentation = DocumentationInfo(
             summary = "Return the namespace and name string of a string, keyword or symbol.",
-            example = null,
+            example = "(full-name :foo/bar) ; =&gt; \"foo/bar\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L964",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L987",
                 docs = "",
             ),
         ),
@@ -388,9 +388,9 @@ Finds the best matching method for dispatch-val using the global hierarchy.<br /
             summary = """
 If test is true, evaluates then with binding-form bound to the value of test, if not, yields else
 """,
-            example = null,
+            example = "(if-let [x (get {:a 1} :a)] x :none) ; =&gt; 1",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L820",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L832",
                 docs = "",
             ),
         ),
@@ -407,9 +407,9 @@ If test is true, evaluates then with binding-form bound to the value of test, if
             summary = """
 Binds name to the value of test. If test is not nil, evaluates then with binding-form bound to the value of test, if not, yields else. Unlike if-let, false and 0 are not treated as falsy — only nil triggers the else branch.
 """,
-            example = null,
+            example = "(if-some [x false] :yes :no) ; =&gt; :yes",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L859",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L875",
                 docs = "",
             ),
         ),
@@ -428,7 +428,7 @@ Returns true if child equals parent, or child is a descendant of parent. When a 
 """,
             example = "(do (derive ::square ::shape) (isa? ::square ::shape)) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L245",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L246",
                 docs = "",
             ),
         ),
@@ -448,7 +448,7 @@ bindings is a vector of function specs: (letfn [(f [params] body) (g [params] bo
 """,
             example = "(letfn [(my-even? [n] (if (zero? n) true (my-odd? (dec n))))\n        (my-odd? [n] (if (zero? n) false (my-even? (dec n))))]\n  (my-even? 10))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L907",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L926",
                 docs = "",
             ),
         ),
@@ -466,9 +466,9 @@ bindings is a vector of function specs: (letfn [(f [params] body) (g [params] bo
 Creates a fresh, empty hierarchy.<br /><br />
 Returns a map with <code>:parents</code>, <code>:descendants</code>, and <code>:ancestors</code> keys, each holding an empty map. Matches Clojure's hierarchy shape so consumers can destructure any of the three relationship views.
 """,
-            example = null,
+            example = "(make-hierarchy) ; =&gt; {:parents {}, :descendants {}, :ancestors {}}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L54",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L54",
                 docs = "",
             ),
         ),
@@ -483,9 +483,9 @@ Returns a map with <code>:parents</code>, <code>:descendants</code>, and <code>:
         ),
         documentation = DocumentationInfo(
             summary = "Returns the name string of a string, keyword or symbol.",
-            example = null,
+            example = "(name :foo) ; =&gt; \"foo\"\n(name 'bar) ; =&gt; \"bar\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L954",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L973",
                 docs = "",
             ),
         ),
@@ -500,9 +500,9 @@ Returns a map with <code>:parents</code>, <code>:descendants</code>, and <code>:
         ),
         documentation = DocumentationInfo(
             summary = "Return the namespace string of a symbol or keyword. Nil if not present.",
-            example = null,
+            example = "(namespace :foo/bar) ; =&gt; \"foo\"\n(namespace :foo) ; =&gt; nil",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L959",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L980",
                 docs = "",
             ),
         ),
@@ -521,7 +521,7 @@ Returns the set of immediate parents of tag, or nil. When a hierarchy is provide
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L307",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L308",
                 docs = "",
             ),
         ),
@@ -544,7 +544,7 @@ Throws if the new preference would create a cycle, i.e. <code>y</code> is alread
 """,
             example = "(prefer-method draw :drawable :shape)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L780",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L792",
                 docs = "",
             ),
         ),
@@ -563,7 +563,7 @@ Returns the preference map for a multimethod (built by <code>prefer-method</code
 """,
             example = "(prefers draw)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L809",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L821",
                 docs = "",
             ),
         ),
@@ -582,7 +582,7 @@ Returns true if dispatch value <code>x</code> is preferred over <code>y</code> i
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L350",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L351",
                 docs = "",
             ),
         ),
@@ -602,9 +602,9 @@ Returns the dispatch key for protocol dispatch. Returns a type keyword<br />
 Optimized to avoid the full <code>type</code> cond chain: checks scalars first<br />
   (most common in tight loops), then objects.
 """,
-            example = null,
+            example = "(protocol-type-key \"hi\") ; =&gt; :string\n(protocol-type-key 42) ; =&gt; :int",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L409",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L410",
                 docs = "",
             ),
         ),
@@ -619,9 +619,9 @@ Optimized to avoid the full <code>type</code> cond chain: checks scalars first<b
         ),
         documentation = DocumentationInfo(
             summary = "Reads the first phel expression from the string s.",
-            example = null,
+            example = "(read-string \"(+ 1 2)\") ; =&gt; (+ 1 2)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L969",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L994",
                 docs = "",
             ),
         ),
@@ -642,7 +642,7 @@ Records that <code>type-key</code> implements the protocol identified by both<br
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L126",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L127",
                 docs = "",
             ),
         ),
@@ -669,7 +669,7 @@ Syntax:<br />
 """,
             example = "(reify Speakable (speak [this] \"hello\"))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L590",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L590",
                 docs = "",
             ),
         ),
@@ -688,7 +688,7 @@ Resolves the given symbol in the current environment and returns a resolved Symb
 """,
             example = "(resolve 'map) ; =&gt; phel.core/map",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L996",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L1025",
                 docs = "",
             ),
         ),
@@ -705,7 +705,7 @@ Resolves the given symbol in the current environment and returns a resolved Symb
             summary = "Returns true if x's type implements all methods of the given protocol.",
             example = "(satisfies? Stringable \"hello\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L555",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L555",
                 docs = "",
             ),
         ),
@@ -722,7 +722,7 @@ Resolves the given symbol in the current environment and returns a resolved Symb
             summary = "Evaluates expr and prints the time it took. Returns the value of expr.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L935",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L954",
                 docs = "",
             ),
         ),
@@ -741,7 +741,7 @@ Removes a parent/child relationship. With two arguments, mutates the global hier
 """,
             example = "(underive :square :shape)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L282",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L283",
                 docs = "",
             ),
         ),
@@ -759,9 +759,9 @@ Removes a parent/child relationship. With two arguments, mutates the global hier
 Binds name to the first element of coll. When the collection is non-empty<br />
   (first returns non-nil), evaluates body with the binding.
 """,
-            example = null,
+            example = "(when-first [x [1 2 3]] x) ; =&gt; 1",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L886",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L904",
                 docs = "",
             ),
         ),
@@ -776,9 +776,9 @@ Binds name to the first element of coll. When the collection is non-empty<br />
         ),
         documentation = DocumentationInfo(
             summary = "When test is true, evaluates body with binding-form bound to the value of test",
-            example = null,
+            example = "(when-let [x (get {:a 1} :a)] (* x 10)) ; =&gt; 10",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L840",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L854",
                 docs = "",
             ),
         ),
@@ -795,9 +795,9 @@ Binds name to the first element of coll. When the collection is non-empty<br />
             summary = """
 Binds name to the value of test. When test is not nil, evaluates body with binding-form bound to the value of test. Unlike when-let, false and 0 are not treated as falsy — only nil causes the body to be skipped.
 """,
-            example = null,
+            example = "(when-some [x 0] (inc x)) ; =&gt; 1",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/protocols.phel#L880",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/protocols.phel#L897",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/core/registerCoreRootFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/core/registerCoreRootFunctions.kt
@@ -23,7 +23,7 @@ Vector of user arguments passed to the script (excludes program name). Use <em>p
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core.phel#L192",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core.phel#L240",
                 docs = "",
             ),
         ),
@@ -42,7 +42,7 @@ Controls whether <code>assert</code> expands to a runtime check. When logical fa
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core.phel#L21",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core.phel#L23",
                 docs = "",
             ),
         ),
@@ -93,7 +93,7 @@ Controls whether <code>assert</code> expands to a runtime check. When logical fa
             summary = "The script path or namespace being executed.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core.phel#L187",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core.phel#L235",
                 docs = "",
             ),
         ),
@@ -120,7 +120,7 @@ Calls the function with the given arguments. The last argument must be a list of
     PhelFunction(
         namespace = "core",
         name = "array-map",
-        signature = "",
+        signature = "(array-map)\n(array-map k)\n(array-map k v)\n(array-map k v k2)\n(array-map k v k2 v2)\n(array-map k v k2 v2 & more)",
         completion = CompletionInfo(
             tailText = "Constructs a map from the given key/value pairs",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -129,9 +129,9 @@ Calls the function with the given arguments. The last argument must be a list of
             summary = """
 Constructs a map from the given key/value pairs. If any keys are equal, later values replace earlier ones, as if by repeated <code>assoc</code>. Phel has no distinct array-map type, so the result is the same persistent map as <code>hash-map</code> — <code>array-map</code> exists for <code>.cljc</code> interop with Clojure sources.
 """,
-            example = "(array-map :a 1 :b 2) ; =&gt; {:a 1 :b 2}",
+            example = "(array-map :a 1 :b 2) ; =&gt; {:a 1, :b 2}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core.phel#L53",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core.phel#L91",
                 docs = "",
             ),
         ),
@@ -167,7 +167,7 @@ Pauses execution and opens an interactive debugger sub-REPL with access to the l
             summary = """
 Handle exceptions thrown in a <code>try</code> block by matching on the provided exception type. The caught exception is bound to exception-name while evaluating the expressions.
 """,
-            example = "(try (throw (php/new \\Exception \"error\")) (catch \\Exception e (php/-&gt; e (getMessage))))",
+            example = "(try (throw (new Exception \"error\")) (catch Exception e (.getMessage e)))",
             links = DocumentationLinks(
                 github = "",
                 docs = "/documentation/control-flow/#try-catch-and-finally",
@@ -196,7 +196,7 @@ Returns a new collection with values added. Appends to vectors/sets, prepends to
     PhelFunction(
         namespace = "core",
         name = "declare",
-        signature = "",
+        signature = "(declare name)",
         completion = CompletionInfo(
             tailText = "Declare a global symbol before it is defined",
             priority = PhelCompletionPriority.MACROS,
@@ -205,7 +205,7 @@ Returns a new collection with values added. Appends to vectors/sets, prepends to
             summary = "Declare a global symbol before it is defined.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core.phel#L175",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core.phel#L222",
                 docs = "",
             ),
         ),
@@ -332,7 +332,7 @@ Evaluates the expressions in order and returns the value of the last expression.
             summary = """
 Evaluate expressions after the try body and all matching catches have completed. The finally block runs regardless of whether an exception was thrown.
 """,
-            example = "(defn risky-operation [] (throw (php/new \\Exception \"Error!\")))\n(defn cleanup [] (println \"Cleanup!\"))\n(try (risky-operation) (catch \\Exception e nil) (finally (cleanup)))",
+            example = "(defn risky-operation [] (throw (new Exception \"Error!\")))\n(defn cleanup [] (println \"Cleanup!\"))\n(try (risky-operation) (catch Exception e nil) (finally (cleanup)))",
             links = DocumentationLinks(
                 github = "",
                 docs = "/documentation/control-flow/#try-catch-and-finally",
@@ -342,7 +342,7 @@ Evaluate expressions after the try body and all matching catches have completed.
     PhelFunction(
         namespace = "core",
         name = "first",
-        signature = "",
+        signature = "(first xs)",
         completion = CompletionInfo(
             tailText = "Returns the first element of a sequence, or nil if empty",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,
@@ -350,11 +350,12 @@ Evaluate expressions after the try body and all matching catches have completed.
         documentation = DocumentationInfo(
             summary = """
 Returns the first element of a sequence, or nil if empty.<br /><br />
-Maps are treated as a sequence of entries: <code>(first {:a 1})</code> returns a typed <code>MapEntry</code> equal by value to <code>[:a 1]</code>. Strings are treated as sequences of multibyte characters.
+Maps are treated as a sequence of entries: <code>(first {:a 1})</code> returns a typed <code>MapEntry</code> equal by value to <code>[:a 1]</code>. Strings are treated as sequences of multibyte characters.<br /><br />
+A lazily consumed source with no indexed access of its own (an <code>eduction</code> pipeline, a PHP generator, an iterator) is answered by pulling a single element, the same way <code>empty?</code> answers it. <code>count</code> is the one that refuses such a source, because counting means draining it.
 """,
             example = "(first [1 2 3]) ; =&gt; 1",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core.phel#L136",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core.phel#L180",
                 docs = "",
             ),
         ),
@@ -400,7 +401,7 @@ The foreach special form can be used to iterate over all kind of PHP datastructu
     PhelFunction(
         namespace = "core",
         name = "hash-map",
-        signature = "(hash-map & xs)",
+        signature = "(hash-map)\n(hash-map k)\n(hash-map k v)\n(hash-map k v k2)\n(hash-map k v k2 v2)\n(hash-map k v k2 v2 & more)",
         completion = CompletionInfo(
             tailText = "Creates a new hash map",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,
@@ -409,7 +410,7 @@ The foreach special form can be used to iterate over all kind of PHP datastructu
             summary = """
 Creates a new hash map. If no argument is provided, an empty hash map is created. The number of parameters must be even.
 """,
-            example = "(hash-map :name \"Alice\" :age 30) ; =&gt; {:name \"Alice\" :age 30}",
+            example = "(hash-map :name \"Alice\" :age 30) ; =&gt; {:name \"Alice\", :age 30}",
             links = DocumentationLinks(
                 github = "",
                 docs = "/documentation/data-structures/#maps",
@@ -440,12 +441,14 @@ A control flow structure. First evaluates test. If test evaluates to true, only 
         name = "in-ns",
         signature = "(in-ns namespace)",
         completion = CompletionInfo(
-            tailText = "Switches to an existing namespace without creating it (REPL-oriented)",
+            tailText = "Switches to an existing namespace without creating it (REPL, and load-ed files)",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
         ),
         documentation = DocumentationInfo(
-            summary = "Switches to an existing namespace without creating it (REPL-oriented).",
-            example = "(in-ns my-app\\core)",
+            summary = """
+Switches to an existing namespace without creating it (REPL, and <code>load</code>-ed files).
+""",
+            example = "(in-ns my-app.core)",
             links = DocumentationLinks(
                 github = "",
                 docs = "/documentation/namespaces/",
@@ -474,7 +477,7 @@ Creates a new lexical context with assignments defined in bindings. Afterwards t
     PhelFunction(
         namespace = "core",
         name = "list",
-        signature = "(list & xs)",
+        signature = "(list)\n(list a)\n(list a b)\n(list a b c)\n(list a b c & more)",
         completion = CompletionInfo(
             tailText = "Creates a new list",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,
@@ -529,7 +532,7 @@ Creates a new lexical context with variables defined in bindings and defines a r
     PhelFunction(
         namespace = "core",
         name = "next",
-        signature = "",
+        signature = "(next xs)",
         completion = CompletionInfo(
             tailText = "Returns the sequence after the first element, or nil if empty",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,
@@ -538,7 +541,7 @@ Creates a new lexical context with variables defined in bindings and defines a r
             summary = "Returns the sequence after the first element, or nil if empty.",
             example = "(next [1 2 3]) ; =&gt; [2 3]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core.phel#L84",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core.phel#L128",
                 docs = "",
             ),
         ),
@@ -555,7 +558,7 @@ Creates a new lexical context with variables defined in bindings and defines a r
             summary = """
 Defines the namespace for the current file and adds imports to the environment. Imports can either be uses or requires. The keyword :use is used to import PHP classes, the keyword :require is used to import Phel modules and the keyword :require-file is used to load php files.
 """,
-            example = "(ns my-app\\core (:require phel\\string :as str))",
+            example = "(ns my-app.core (:require phel.string :as str))",
             links = DocumentationLinks(
                 github = "",
                 docs = "/documentation/namespaces/#namespace-ns",
@@ -565,7 +568,7 @@ Defines the namespace for the current file and adds imports to the environment. 
     PhelFunction(
         namespace = "core",
         name = "queue",
-        signature = "",
+        signature = "(queue)\n(queue a)\n(queue a b)\n(queue a b c)\n(queue a b c & more)",
         completion = CompletionInfo(
             tailText = "Creates a persistent FIFO queue",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -574,9 +577,9 @@ Defines the namespace for the current file and adds imports to the environment. 
             summary = """
 Creates a persistent FIFO queue. With no arguments returns an empty queue; with arguments returns a queue with the values pushed in order so that the first argument is at the front.
 """,
-            example = "(queue 1 2 3) ; =&gt; first 1, then 2, then 3",
+            example = "(queue 1 2 3) ; =&gt; &lt;-(1 2 3)-&lt;",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core.phel#L41",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core.phel#L64",
                 docs = "",
             ),
         ),
@@ -646,7 +649,7 @@ Variables provide a way to manage mutable state that can be updated with <code>s
         ),
         documentation = DocumentationInfo(
             summary = "Throw an exception.",
-            example = "(throw (php/new \\InvalidArgumentException \"Invalid input\"))",
+            example = "(throw (new InvalidArgumentException \"Invalid input\"))",
             links = DocumentationLinks(
                 github = "",
                 docs = "/documentation/control-flow/#try-catch-and-finally",
@@ -665,7 +668,7 @@ Variables provide a way to manage mutable state that can be updated with <code>s
             summary = """
 All expressions are evaluated and if no exception is thrown the value of the last expression is returned. If an exception occurs and a matching catch-clause is provided, its expression is evaluated and the value is returned. If no matching catch-clause can be found the exception is propagated out of the function. Before returning normally or abnormally the optionally finally-clause is evaluated.
 """,
-            example = "(try (/ 1 0) (catch \\Exception e \"error\"))",
+            example = "(try (/ 1 0) (catch Exception e \"error\"))",
             links = DocumentationLinks(
                 github = "",
                 docs = "/documentation/control-flow/#try-catch-and-finally",
@@ -682,9 +685,9 @@ All expressions are evaluated and if no exception is thrown the value of the las
         ),
         documentation = DocumentationInfo(
             summary = """
-Values that should be evaluated in a macro are marked with the unquote function. Shortcut: ,
+Values that should be evaluated in a macro are marked with the unquote function. Shortcut: ~
 """,
-            example = "`(+ 1 ,(+ 2 3)) ; =&gt; (+ 1 5)",
+            example = "`(+ 1 ~(+ 2 3)) ; =&gt; (phel.core/+ 1 5)",
             links = DocumentationLinks(
                 github = "",
                 docs = "/documentation/macros/#quasiquote",
@@ -701,9 +704,9 @@ Values that should be evaluated in a macro are marked with the unquote function.
         ),
         documentation = DocumentationInfo(
             summary = """
-Values that should be evaluated in a macro are marked with the unquote function. Shortcut: ,@
+Values that should be evaluated in a macro are marked with the unquote function. Shortcut: ~@
 """,
-            example = "`(+ ,@[1 2 3]) ; =&gt; (+ 1 2 3)",
+            example = "`(+ ~@[1 2 3]) ; =&gt; (phel.core/+ 1 2 3)",
             links = DocumentationLinks(
                 github = "",
                 docs = "/documentation/macros/#quasiquote",
@@ -720,7 +723,7 @@ Values that should be evaluated in a macro are marked with the unquote function.
         ),
         documentation = DocumentationInfo(
             summary = "Registers PHP class aliases in the current namespace (compile-time only).",
-            example = "(use \\DateTimeImmutable :as Date)",
+            example = "(use DateTimeImmutable :as Date)",
             links = DocumentationLinks(
                 github = "",
                 docs = "/documentation/namespaces/",
@@ -747,7 +750,7 @@ Values that should be evaluated in a macro are marked with the unquote function.
     PhelFunction(
         namespace = "core",
         name = "vector",
-        signature = "(vector & xs)",
+        signature = "(vector)\n(vector a)\n(vector a b)\n(vector a b c)\n(vector a b c & more)",
         completion = CompletionInfo(
             tailText = "Creates a new vector",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,

--- a/src/main/kotlin/org/phellang/registry/data/core/registerCoreSeqBasicsFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/core/registerCoreSeqBasicsFunctions.kt
@@ -21,7 +21,7 @@ internal fun registerCoreSeqBasicsFunctions(): List<PhelFunction> = listOf(
             summary = "Prepends an element to the beginning of a collection.",
             example = "(cons 0 [1 2 3]) ; =&gt; [0 1 2 3]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-basics.phel#L64",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-basics.phel#L65",
                 docs = "",
             ),
         ),
@@ -37,11 +37,12 @@ internal fun registerCoreSeqBasicsFunctions(): List<PhelFunction> = listOf(
         documentation = DocumentationInfo(
             summary = """
 Counts the number of elements in a sequence. Can be used on everything that implements the PHP Countable interface.<br /><br />
-Works with lists, vectors, hash-maps, sets, strings, and PHP arrays. Returns 0 for nil.
+Works with lists, vectors, hash-maps, sets, strings, and PHP arrays. Returns 0 for nil.<br /><br />
+Throws for a lazily consumed source that has no size of its own — a transducer pipeline built by <code>eduction</code>, a PHP generator, an iterator. Counting one means draining it, which re-runs the whole pipeline (including its side effects) and still leaves nothing counted behind, so <code>count</code> refuses instead of doing it silently. Realize it first: <code>(count (into [] coll))</code>.
 """,
             example = "(count [1 2 3]) ; =&gt; 3",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-basics.phel#L121",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-basics.phel#L128",
                 docs = "",
             ),
         ),
@@ -58,9 +59,9 @@ Works with lists, vectors, hash-maps, sets, strings, and PHP arrays. Returns 0 f
             summary = """
 Same as <code>(first (first coll))</code>.
 """,
-            example = null,
+            example = "(ffirst [[1 2] [3 4]]) ; =&gt; 1",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-basics.phel#L77",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-basics.phel#L78",
                 docs = "",
             ),
         ),
@@ -79,7 +80,7 @@ Same as <code>(first (next coll))</code>.
 """,
             example = "(fnext [1 2 3]) ; =&gt; 2",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-basics.phel#L109",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-basics.phel#L114",
                 docs = "",
             ),
         ),
@@ -96,9 +97,9 @@ Same as <code>(first (next coll))</code>.
             summary = """
 Same as <code>(next (first coll))</code>.
 """,
-            example = null,
+            example = "(nfirst [[1 2 3] [4 5]]) ; =&gt; [2 3]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-basics.phel#L104",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-basics.phel#L107",
                 docs = "",
             ),
         ),
@@ -115,9 +116,9 @@ Same as <code>(next (first coll))</code>.
             summary = """
 Same as <code>(next (next coll))</code>.
 """,
-            example = null,
+            example = "(nnext [1 2 3 4]) ; =&gt; [3 4]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-basics.phel#L116",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-basics.phel#L121",
                 docs = "",
             ),
         ),
@@ -134,7 +135,7 @@ Same as <code>(next (next coll))</code>.
             summary = "Returns the sequence after the first element, or empty sequence if none.",
             example = "(rest [1 2 3]) ; =&gt; [2 3]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-basics.phel#L88",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-basics.phel#L91",
                 docs = "",
             ),
         ),
@@ -151,7 +152,7 @@ Same as <code>(next (next coll))</code>.
             summary = "Returns the second element of a sequence, or nil if not present.",
             example = "(second [1 2 3]) ; =&gt; 2",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-basics.phel#L82",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-basics.phel#L85",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/core/registerCoreSeqFnsFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/core/registerCoreSeqFnsFunctions.kt
@@ -24,7 +24,7 @@ Creates intermediate maps if they don't exist.
 """,
             example = "(assoc-in {:a {:b 1}} [:a :c] 2) ; =&gt; {:a {:b 1, :c 2}}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L342",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L409",
                 docs = "",
             ),
         ),
@@ -43,7 +43,7 @@ Returns a Phel map of the public properties of PHP object <code>obj</code>, with
 """,
             example = "(bean (hydrate \"My\\\\Dto\" {:id 1})) ; =&gt; {:id 1}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L940",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1002",
                 docs = "",
             ),
         ),
@@ -62,7 +62,7 @@ Returns the number of items in <code>coll</code>, but counts at most <code>n</co
 """,
             example = "(bounded-count 3 [1 2 3 4 5]) ; =&gt; 5\n(bounded-count 3 (map inc (range 100))) ; =&gt; 3",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L693",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L756",
                 docs = "",
             ),
         ),
@@ -80,9 +80,9 @@ Returns the number of items in <code>coll</code>, but counts at most <code>n</co
 Returns all but the last item in <code>coll</code>. Returns <code>nil</code> when <code>coll</code> is<br />
   <code>nil</code> or has fewer than two items.
 """,
-            example = "(butlast [1 2 3 4]) ; =&gt; @[1 2 3]\n(butlast [0]) ; =&gt; nil",
+            example = "(butlast [1 2 3 4]) ; =&gt; (1 2 3)\n(butlast [0]) ; =&gt; nil",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L440",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L493",
                 docs = "",
             ),
         ),
@@ -97,9 +97,9 @@ Returns all but the last item in <code>coll</code>. Returns <code>nil</code> whe
         ),
         documentation = DocumentationInfo(
             summary = "A transducer that concatenates the contents of each input into the reduction.",
-            example = null,
+            example = "(transduce cat conj [] [[1 2] [3 4]]) ; =&gt; [1 2 3 4]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L1131",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1330",
                 docs = "",
             ),
         ),
@@ -107,7 +107,7 @@ Returns all but the last item in <code>coll</code>. Returns <code>nil</code> whe
     PhelFunction(
         namespace = "core",
         name = "comp",
-        signature = "(comp & fs)",
+        signature = "(comp)\n(comp outer)\n(comp outer inner)\n(comp outer inner & fs)",
         completion = CompletionInfo(
             tailText = "Takes a list of functions and returns a function that is the composition of those functions",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -116,9 +116,9 @@ Returns all but the last item in <code>coll</code>. Returns <code>nil</code> whe
             summary = """
 Takes a list of functions and returns a function that is the composition of those functions.
 """,
-            example = null,
+            example = "((comp inc (fn [x] (* x 2))) 3) ; =&gt; 7",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L92",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L96",
                 docs = "",
             ),
         ),
@@ -135,9 +135,9 @@ Takes a list of functions and returns a function that is the composition of thos
             summary = """
 Returns a lazy sequence with specified values removed from <code>coll</code>. If no values are specified, removes nil values by default.
 """,
-            example = "(compact [1 nil 2 nil 3]) ; =&gt; @[1 2 3]",
+            example = "(compact [1 nil 2 nil 3]) ; =&gt; (1 2 3)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L1417",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1684",
                 docs = "",
             ),
         ),
@@ -145,16 +145,16 @@ Returns a lazy sequence with specified values removed from <code>coll</code>. If
     PhelFunction(
         namespace = "core",
         name = "concat",
-        signature = "(concat & colls)",
+        signature = "(concat)\n(concat coll)\n(concat coll1 coll2)\n(concat coll1 coll2 coll3)\n(concat coll1 coll2 coll3 & colls)",
         completion = CompletionInfo(
             tailText = "Concatenates multiple collections into a lazy sequence",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,
         ),
         documentation = DocumentationInfo(
             summary = "Concatenates multiple collections into a lazy sequence.",
-            example = "(concat [1 2] [3 4]) ; =&gt; @[1 2 3 4]",
+            example = "(concat [1 2] [3 4]) ; =&gt; (1 2 3 4)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L1116",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1302",
                 docs = "",
             ),
         ),
@@ -173,7 +173,7 @@ Returns true if the value is present in the given collection, otherwise returns 
 """,
             example = "(contains-value? {:a 1 :b 2} 2) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L961",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1023",
                 docs = "",
             ),
         ),
@@ -190,9 +190,9 @@ Returns true if the value is present in the given collection, otherwise returns 
             summary = """
 Returns an infinite lazy sequence that cycles through the elements of collection. Maps are iterated as <code>[key value]</code> pairs.
 """,
-            example = "(take 7 (cycle [1 2 3])) ; =&gt; @[1 2 3 1 2 3 1]",
+            example = "(take 7 (cycle [1 2 3])) ; =&gt; (1 2 3 1 2 3 1)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L1107",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1293",
                 docs = "",
             ),
         ),
@@ -200,7 +200,7 @@ Returns an infinite lazy sequence that cycles through the elements of collection
     PhelFunction(
         namespace = "core",
         name = "dedupe",
-        signature = "(dedupe & args)",
+        signature = "(dedupe)\n(dedupe coll)",
         completion = CompletionInfo(
             tailText = "Returns a lazy sequence with consecutive duplicate values removed in coll",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,
@@ -209,9 +209,9 @@ Returns an infinite lazy sequence that cycles through the elements of collection
             summary = """
 Returns a lazy sequence with consecutive duplicate values removed in <code>coll</code>. When called with no args, returns a transducer.
 """,
-            example = "(dedupe [1 1 2 2 2 3 1 1]) ; =&gt; @[1 2 3 1]",
+            example = "(dedupe [1 1 2 2 2 3 1 1]) ; =&gt; (1 2 3 1)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L1376",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1643",
                 docs = "",
             ),
         ),
@@ -230,7 +230,7 @@ Returns a new set that does not contain the given key(s). Works on hash-sets and
 """,
             example = "(disj #{1 2 3} 2) ; =&gt; #{1 3}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L237",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L283",
                 docs = "",
             ),
         ),
@@ -247,7 +247,7 @@ Returns a new set that does not contain the given key(s). Works on hash-sets and
             summary = "Dissociates a value from a nested data structure at the given path.",
             example = "(dissoc-in {:a {:b 1 :c 2}} [:a :b]) ; =&gt; {:a {:c 2}}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L377",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L437",
                 docs = "",
             ),
         ),
@@ -255,7 +255,7 @@ Returns a new set that does not contain the given key(s). Works on hash-sets and
     PhelFunction(
         namespace = "core",
         name = "distinct",
-        signature = "(distinct & args)",
+        signature = "(distinct)\n(distinct coll)",
         completion = CompletionInfo(
             tailText = "Returns a lazy sequence with duplicated values removed in coll",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,
@@ -264,9 +264,9 @@ Returns a new set that does not contain the given key(s). Works on hash-sets and
             summary = """
 Returns a lazy sequence with duplicated values removed in <code>coll</code>. When called with no args, returns a transducer.
 """,
-            example = "(distinct [1 2 1 3 2 4 3]) ; =&gt; @[1 2 3 4]",
+            example = "(distinct [1 2 1 3 2 4 3]) ; =&gt; (1 2 3 4)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L661",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L720",
                 docs = "",
             ),
         ),
@@ -285,7 +285,7 @@ Returns true if no two of the arguments are <code>=</code>. Requires at least on
 """,
             example = "(distinct? 1 2 3) ; =&gt; true\n(distinct? 1 2 1) ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L685",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L748",
                 docs = "",
             ),
         ),
@@ -302,7 +302,7 @@ Returns true if no two of the arguments are <code>=</code>. Requires at least on
             summary = "Forces realization of a lazy sequence and returns it as a vector.",
             example = "(doall (map println [1 2 3])) ; =&gt; [nil nil nil]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L1223",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1447",
                 docs = "",
             ),
         ),
@@ -319,7 +319,7 @@ Returns true if no two of the arguments are <code>=</code>. Requires at least on
             summary = "Forces realization of a lazy sequence for side effects, returns nil.",
             example = "(dorun (map println [1 2 3])) ; =&gt; nil",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L1231",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1455",
                 docs = "",
             ),
         ),
@@ -327,7 +327,7 @@ Returns true if no two of the arguments are <code>=</code>. Requires at least on
     PhelFunction(
         namespace = "core",
         name = "drop",
-        signature = "(drop n & args)",
+        signature = "(drop n)\n(drop n coll)",
         completion = CompletionInfo(
             tailText = "Drops the first n elements of coll",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,
@@ -336,9 +336,9 @@ Returns true if no two of the arguments are <code>=</code>. Requires at least on
             summary = """
 Drops the first <code>n</code> elements of <code>coll</code>. Returns a lazy sequence. When called with n only, returns a transducer.
 """,
-            example = "(drop 2 [1 2 3 4 5]) ; =&gt; @[3 4 5]",
+            example = "(drop 2 [1 2 3 4 5]) ; =&gt; (3 4 5)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L396",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L449",
                 docs = "",
             ),
         ),
@@ -355,9 +355,9 @@ Drops the first <code>n</code> elements of <code>coll</code>. Returns a lazy seq
             summary = """
 Drops the last <code>n</code> elements of <code>coll</code>. <code>n</code> defaults to <code>1</code> when omitted, matching Clojure's <code>(drop-last coll)</code> single-arity form. Returns an empty sequence when <code>coll</code> is <code>nil</code>. Works with any seqable collection including lazy sequences and ranges.
 """,
-            example = "(drop-last [1 2 3 4 5]) ; =&gt; @[1 2 3 4]\n(drop-last 2 [1 2 3 4 5]) ; =&gt; @[1 2 3]\n(drop-last 5 nil) ; =&gt; @[]",
+            example = "(drop-last [1 2 3 4 5]) ; =&gt; (1 2 3 4)\n(drop-last 2 [1 2 3 4 5]) ; =&gt; (1 2 3)\n(drop-last 5 nil) ; =&gt; ()",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L418",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L471",
                 docs = "",
             ),
         ),
@@ -365,7 +365,7 @@ Drops the last <code>n</code> elements of <code>coll</code>. <code>n</code> defa
     PhelFunction(
         namespace = "core",
         name = "drop-while",
-        signature = "(drop-while pred & args)",
+        signature = "(drop-while pred)\n(drop-while pred coll)",
         completion = CompletionInfo(
             tailText = "Drops all elements at the front of coll where (pred x) is true",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,
@@ -374,9 +374,9 @@ Drops the last <code>n</code> elements of <code>coll</code>. <code>n</code> defa
             summary = """
 Drops all elements at the front of <code>coll</code> where <code>(pred x)</code> is true. Returns a lazy sequence. When called with pred only, returns a transducer.
 """,
-            example = "(drop-while #(&lt; % 5) [1 2 3 4 5 6 3 2 1]) ; =&gt; @[5 6 3 2 1]",
+            example = "(drop-while #(&lt; % 5) [1 2 3 4 5 6 3 2 1]) ; =&gt; (5 6 3 2 1)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L449",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L502",
                 docs = "",
             ),
         ),
@@ -398,7 +398,7 @@ Returns a reducible/iterable applying transducers to <code>coll</code>. The last
 """,
             example = "(reduce + (eduction (map inc) (filter odd?) [1 2 3 4])) ; =&gt; 8",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L1402",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1669",
                 docs = "",
             ),
         ),
@@ -406,7 +406,7 @@ Returns a reducible/iterable applying transducers to <code>coll</code>. The last
     PhelFunction(
         namespace = "core",
         name = "filter",
-        signature = "(filter pred & args)",
+        signature = "(filter pred)\n(filter pred coll)\n(filter pred coll & more)",
         completion = CompletionInfo(
             tailText = "Returns a lazy sequence of elements where predicate returns true",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,
@@ -415,9 +415,9 @@ Returns a reducible/iterable applying transducers to <code>coll</code>. The last
             summary = """
 Returns a lazy sequence of elements where predicate returns true. When called with pred only, returns a transducer.
 """,
-            example = "(filter even? [1 2 3 4 5 6]) ; =&gt; @[2 4 6]",
+            example = "(filter even? [1 2 3 4 5 6]) ; =&gt; (2 4 6)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L549",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L604",
                 docs = "",
             ),
         ),
@@ -436,7 +436,7 @@ Returns a vector of the items in <code>coll</code> for which <code>(pred item)</
 """,
             example = "(filterv even? [1 2 3 4 5 6]) ; =&gt; [2 4 6]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L575",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L635",
                 docs = "",
             ),
         ),
@@ -455,7 +455,7 @@ When called with a collection first, returns <code>[key value]</code> when <code
 """,
             example = "(find {:a 1} :a) ; =&gt; [:a 1]\n(find #(&gt; % 5) [1 2 3 6 7 8]) ; =&gt; 6",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L640",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L699",
                 docs = "",
             ),
         ),
@@ -474,7 +474,7 @@ Returns the index of the first item in <code>coll</code> where <code>(pred item)
 """,
             example = "(find-index #(&gt; % 5) [1 2 3 6 7 8]) ; =&gt; 3",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L649",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L708",
                 docs = "",
             ),
         ),
@@ -494,7 +494,7 @@ Works with vectors, lists, sets, and strings.
 """,
             example = "(frequencies [:a :b :a :c :b :a]) ; =&gt; {:a 3, :b 2, :c 1}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L736",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L799",
                 docs = "",
             ),
         ),
@@ -502,7 +502,7 @@ Works with vectors, lists, sets, and strings.
     PhelFunction(
         namespace = "core",
         name = "get-in",
-        signature = "(get-in ds ks & [opt])",
+        signature = "(get-in ds ks)\n(get-in ds ks opt)",
         completion = CompletionInfo(
             tailText = "Accesses a value in a nested data structure via a sequence of keys",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,
@@ -514,7 +514,7 @@ Returns <code>opt</code> (default nil) when a key is missing mid-traversal. When
 """,
             example = "(get-in {:a {:b {:c 42}}} [:a :b :c]) ; =&gt; 42",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L320",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L380",
                 docs = "",
             ),
         ),
@@ -533,7 +533,7 @@ Returns a map of the elements of coll keyed by the result of <code>f</code> on e
 """,
             example = "(group-by count [\"a\" \"bb\" \"c\" \"ddd\" \"ee\"]) ; =&gt; {1 [\"a\" \"c\"], 2 [\"bb\" \"ee\"], 3 [\"ddd\"]}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L1255",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1479",
                 docs = "",
             ),
         ),
@@ -552,7 +552,7 @@ Creates an instance of PHP class <code>class-name</code> (a class-string) withou
 """,
             example = "(hydrate \"My\\\\Dto\" {:id 1 :name \"x\"})",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L950",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1012",
                 docs = "",
             ),
         ),
@@ -560,7 +560,7 @@ Creates an instance of PHP class <code>class-name</code> (a class-string) withou
     PhelFunction(
         namespace = "core",
         name = "interleave",
-        signature = "(interleave & colls)",
+        signature = "(interleave coll1 coll2)\n(interleave & colls)",
         completion = CompletionInfo(
             tailText = "Returns a lazy sequence of the first item in each colls, then the second item in each, until any ...",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,
@@ -569,9 +569,9 @@ Creates an instance of PHP class <code>class-name</code> (a class-string) withou
             summary = """
 Returns a lazy sequence of the first item in each <code>colls</code>, then the second item in each, until any one of the collections is exhausted. Any remaining items in the other collections are ignored. Returns an empty sequence when no collections are supplied or when any collection is empty or <code>nil</code>. Maps are iterated as <code>[key value]</code> pairs.
 """,
-            example = "(interleave [1 2 3] [:a :b :c]) ; =&gt; @[1 :a 2 :b 3 :c]\n(interleave [1 2 3] [:a :b]) ; =&gt; @[1 :a 2 :b]",
+            example = "(interleave [1 2 3] [:a :b :c]) ; =&gt; (1 :a 2 :b 3 :c)\n(interleave [1 2 3] [:a :b]) ; =&gt; (1 :a 2 :b)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L1206",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1409",
                 docs = "",
             ),
         ),
@@ -579,7 +579,7 @@ Returns a lazy sequence of the first item in each <code>colls</code>, then the s
     PhelFunction(
         namespace = "core",
         name = "interpose",
-        signature = "(interpose sep & args)",
+        signature = "(interpose sep)\n(interpose sep coll)",
         completion = CompletionInfo(
             tailText = "Returns elements separated by a separator",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,
@@ -588,9 +588,9 @@ Returns a lazy sequence of the first item in each <code>colls</code>, then the s
             summary = """
 Returns elements separated by a separator. Returns a lazy sequence. When called with sep only, returns a transducer.
 """,
-            example = "(interpose 0 [1 2 3]) ; =&gt; @[1 0 2 0 3]",
+            example = "(interpose 0 [1 2 3]) ; =&gt; (1 0 2 0 3)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L1162",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1364",
                 docs = "",
             ),
         ),
@@ -598,7 +598,7 @@ Returns elements separated by a separator. Returns a lazy sequence. When called 
     PhelFunction(
         namespace = "core",
         name = "into",
-        signature = "(into to & rest)",
+        signature = "(into to)\n(into to from)\n(into to xf from)",
         completion = CompletionInfo(
             tailText = "Returns to with all elements of from added",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,
@@ -610,7 +610,7 @@ When <code>from</code> is associative, it is treated as a sequence of key-value 
 """,
             example = "(into [] '(1 2 3)) ; =&gt; [1 2 3]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L132",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L148",
                 docs = "",
             ),
         ),
@@ -630,7 +630,7 @@ If map has duplicated values, some keys will be ignored.
 """,
             example = "(invert {:a 1 :b 2 :c 3}) ; =&gt; {1 :a, 2 :b, 3 :c}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L1334",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1597",
                 docs = "",
             ),
         ),
@@ -645,9 +645,9 @@ If map has duplicated values, some keys will be ignored.
         ),
         documentation = DocumentationInfo(
             summary = "Returns an infinite lazy sequence of x, (f x), (f (f x)), and so on.",
-            example = "(take 5 (iterate inc 0)) ; =&gt; @[0 1 2 3 4]",
+            example = "(take 5 (iterate inc 0)) ; =&gt; (0 1 2 3 4)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L1074",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1254",
                 docs = "",
             ),
         ),
@@ -664,9 +664,9 @@ If map has duplicated values, some keys will be ignored.
             summary = """
 Returns a lazy sequence over a PHP <code>Traversable</code> (Iterator, Generator, IteratorAggregate, ...), pulling one element at a time. Unlike the eager coercion that materialises a <code>Traversable</code> via <code>iterator_to_array</code>, this streams a large or infinite source (DB cursor, stream reader, paginated API), so <code>take</code>/<code>map</code>/<code>filter</code> only pull what they consume.
 """,
-            example = "(take 3 (iterator-seq (php/new \\ArrayIterator (php/array 1 2 3 4 5)))) ; =&gt; @[1 2 3]",
+            example = "(take 3 (iterator-seq (new ArrayIterator (php-indexed-array 1 2 3 4 5)))) ; =&gt; (1 2 3)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L1100",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1286",
                 docs = "",
             ),
         ),
@@ -674,7 +674,7 @@ Returns a lazy sequence over a PHP <code>Traversable</code> (Iterator, Generator
     PhelFunction(
         namespace = "core",
         name = "keep",
-        signature = "(keep pred & args)",
+        signature = "(keep pred)\n(keep pred coll)",
         completion = CompletionInfo(
             tailText = "Returns a lazy sequence of non-nil results of applying function to elements",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,
@@ -683,9 +683,9 @@ Returns a lazy sequence over a PHP <code>Traversable</code> (Iterator, Generator
             summary = """
 Returns a lazy sequence of non-nil results of applying function to elements. When called with f only, returns a transducer.
 """,
-            example = "(keep #(when (even? %) (* % %)) [1 2 3 4 5]) ; =&gt; @[4 16]",
+            example = "(keep #(when (even? %) (* % %)) [1 2 3 4 5]) ; =&gt; (4 16)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L592",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L651",
                 docs = "",
             ),
         ),
@@ -693,7 +693,7 @@ Returns a lazy sequence of non-nil results of applying function to elements. Whe
     PhelFunction(
         namespace = "core",
         name = "keep-indexed",
-        signature = "(keep-indexed pred & args)",
+        signature = "(keep-indexed pred)\n(keep-indexed pred coll)",
         completion = CompletionInfo(
             tailText = "Returns a lazy sequence of non-nil results of (pred i x)",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,
@@ -702,9 +702,9 @@ Returns a lazy sequence of non-nil results of applying function to elements. Whe
             summary = """
 Returns a lazy sequence of non-nil results of <code>(pred i x)</code>. When called with f only, returns a transducer.
 """,
-            example = "(keep-indexed #(when (even? %1) %2) [\"a\" \"b\" \"c\" \"d\"]) ; =&gt; @[\"a\" \"c\"]",
+            example = "(keep-indexed #(when (even? %1) %2) [\"a\" \"b\" \"c\" \"d\"]) ; =&gt; (\"a\" \"c\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L609",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L668",
                 docs = "",
             ),
         ),
@@ -725,7 +725,7 @@ Returns the key of a map entry. Accepts a typed<br />
 """,
             example = "(key (first (pairs {:a 1}))) ; =&gt; :a",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L770",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L838",
                 docs = "",
             ),
         ),
@@ -744,7 +744,7 @@ Returns a sequence of all keys in a map, or <code>nil</code> when the map is <co
 """,
             example = "(keys {:a 1 :b 2}) ; =&gt; [:a :b]\n(keys nil) ; =&gt; nil",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L749",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L817",
                 docs = "",
             ),
         ),
@@ -763,7 +763,7 @@ Returns a vector of key-value pairs like <code>[k1 v1 k2 v2 k3 v3 ...]</code>.
 """,
             example = "(kvs {:a 1 :b 2}) ; =&gt; [:a 1 :b 2]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L855",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L915",
                 docs = "",
             ),
         ),
@@ -782,7 +782,7 @@ Returns the last element of <code>coll</code> or nil if <code>coll</code> is emp
 """,
             example = "(last [1 2 3]) ; =&gt; 3",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L426",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L479",
                 docs = "",
             ),
         ),
@@ -797,9 +797,9 @@ Returns the last element of <code>coll</code> or nil if <code>coll</code> is emp
         ),
         documentation = DocumentationInfo(
             summary = "Concatenates collections into a lazy sequence (expands to concat).",
-            example = "(lazy-cat [1 2] [3 4]) ; =&gt; @[1 2 3 4]",
+            example = "(lazy-cat [1 2] [3 4]) ; =&gt; (1 2 3 4)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L1068",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1248",
                 docs = "",
             ),
         ),
@@ -814,9 +814,9 @@ Returns the last element of <code>coll</code> or nil if <code>coll</code> is emp
         ),
         documentation = DocumentationInfo(
             summary = "Creates a lazy sequence that evaluates the body only when accessed.",
-            example = "(lazy-seq (cons 1 (lazy-seq nil))) ; =&gt; @[1]",
+            example = "(lazy-seq (cons 1 (lazy-seq nil))) ; =&gt; (1)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L1059",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1239",
                 docs = "",
             ),
         ),
@@ -824,7 +824,7 @@ Returns the last element of <code>coll</code> or nil if <code>coll</code> is emp
     PhelFunction(
         namespace = "core",
         name = "map",
-        signature = "(map f & colls)",
+        signature = "(map f)\n(map f coll)\n(map f coll & more)",
         completion = CompletionInfo(
             tailText = "Returns a lazy sequence of the result of applying f to all of the first items in each coll, follo...",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,
@@ -839,9 +839,9 @@ When given a single collection, applies the function to each element.<br />
   With multiple collections, applies the function to corresponding elements from each collection,<br />
   stopping when the shortest collection is exhausted.
 """,
-            example = "(map inc [1 2 3]) ; =&gt; @[2 3 4]",
+            example = "(map inc [1 2 3]) ; =&gt; (2 3 4)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L59",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L59",
                 docs = "",
             ),
         ),
@@ -860,7 +860,7 @@ Returns a typed <code>Phel\Lang\Collections\Map\MapEntry</code> for <code>k</cod
 """,
             example = "(map-entry :a 1) ; =&gt; [:a 1]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L763",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L831",
                 docs = "",
             ),
         ),
@@ -878,9 +878,9 @@ Returns a typed <code>Phel\Lang\Collections\Map\MapEntry</code> for <code>k</cod
 Maps a function over a collection with index. Returns a lazy sequence.<br /><br />
 Applies <code>f</code> to each element in <code>xs</code>. <code>f</code> is a two-argument function where the first argument is the index (0-based) and the second is the element itself. Works with infinite sequences.
 """,
-            example = "(map-indexed vector [:a :b :c]) ; =&gt; @[[0 :a] [1 :b] [2 :c]]",
+            example = "(map-indexed vector [:a :b :c]) ; =&gt; ([0 :a] [1 :b] [2 :c])",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L1192",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1395",
                 docs = "",
             ),
         ),
@@ -888,7 +888,7 @@ Applies <code>f</code> to each element in <code>xs</code>. <code>f</code> is a t
     PhelFunction(
         namespace = "core",
         name = "mapcat",
-        signature = "(mapcat f & args)",
+        signature = "(mapcat f)\n(mapcat f coll)\n(mapcat f coll & colls)",
         completion = CompletionInfo(
             tailText = "Maps a function over one or more collections and concatenates the results",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,
@@ -902,9 +902,9 @@ With a single collection behaves like <code>(apply concat (map f coll))</code>. 
   (stopping when the shortest is exhausted) and the resulting sequences are<br />
   concatenated.
 """,
-            example = "(mapcat reverse [[1 2] [3 4]]) ; =&gt; @[2 1 4 3]\n(mapcat list [:a :b :c] [1 2 3]) ; =&gt; @[:a 1 :b 2 :c 3]",
+            example = "(mapcat reverse [[1 2] [3 4]]) ; =&gt; (2 1 4 3)\n(mapcat list [:a :b :c] [1 2 3]) ; =&gt; (:a 1 :b 2 :c 3)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L1138",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1338",
                 docs = "",
             ),
         ),
@@ -923,7 +923,7 @@ Returns a vector consisting of the result of applying <code>f</code> to the set 
 """,
             example = "(mapv inc [1 2 3]) ; =&gt; [2 3 4]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L568",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L628",
                 docs = "",
             ),
         ),
@@ -943,7 +943,7 @@ If a key appears in more than one collection, later values replace previous ones
 """,
             example = "(merge {:a 1 :b 2} {:b 3 :c 4}) ; =&gt; {:a 1, :b 3, :c 4}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L1301",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1543",
                 docs = "",
             ),
         ),
@@ -960,7 +960,7 @@ If a key appears in more than one collection, later values replace previous ones
             summary = "Gets the pairs of an associative data structure.",
             example = "(pairs {:a 1 :b 2}) ; =&gt; [[:a 1] [:b 2]]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L847",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L907",
                 docs = "",
             ),
         ),
@@ -978,9 +978,9 @@ If a key appears in more than one collection, later values replace previous ones
 Partitions <code>coll</code> into chunks of <code>n</code> elements.<br /><br />
 With one collection argument, returns consecutive non-overlapping chunks and drops any incomplete final chunk. <code>step</code> (default <code>n</code>) is how far to advance between chunks, so a <code>step</code> smaller than <code>n</code> yields overlapping chunks. With a <code>pad</code> collection, a final incomplete chunk is filled from <code>pad</code> up to <code>n</code> elements (kept even when <code>pad</code> runs short); without <code>pad</code> the incomplete final chunk is dropped. Each chunk is a vector.
 """,
-            example = "(partition 3 [1 2 3 4 5 6 7]) ; =&gt; @[[1 2 3] [4 5 6]]\n(partition 2 1 [1 2 3]) ; =&gt; @[[1 2] [2 3]]\n(partition 3 3 [:x] [1 2 3 4]) ; =&gt; @[[1 2 3] [4 :x]]",
+            example = "(partition 3 [1 2 3 4 5 6 7]) ; =&gt; ([1 2 3] [4 5 6])\n(partition 2 1 [1 2 3]) ; =&gt; ([1 2] [2 3])\n(partition 3 3 [:x] [1 2 3 4]) ; =&gt; ([1 2 3] [4 :x])",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L1429",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1696",
                 docs = "",
             ),
         ),
@@ -997,9 +997,9 @@ With one collection argument, returns consecutive non-overlapping chunks and dro
             summary = """
 Partitions collection into chunks of size <code>n</code>, including any incomplete trailing chunks. <code>step</code> (default <code>n</code>) is how far to advance between chunks, so a <code>step</code> smaller than <code>n</code> yields overlapping chunks. Each chunk is a vector.
 """,
-            example = "(partition-all 3 [1 2 3 4 5 6 7]) ; =&gt; @[[1 2 3] [4 5 6] [7]]\n(partition-all 3 2 [0 1 2 3 4]) ; =&gt; @[[0 1 2] [2 3 4] [4]]",
+            example = "(partition-all 3 [1 2 3 4 5 6 7]) ; =&gt; ([1 2 3] [4 5 6] [7])\n(partition-all 3 2 [0 1 2 3 4]) ; =&gt; ([0 1 2] [2 3 4] [4])",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L1459",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1726",
                 docs = "",
             ),
         ),
@@ -1016,9 +1016,9 @@ Partitions collection into chunks of size <code>n</code>, including any incomple
             summary = """
 Returns a lazy sequence of partitions. Applies <code>f</code> to each value in <code>coll</code>, splitting them each time the return value changes.
 """,
-            example = "(partition-by #(&lt; % 3) [1 2 3 4 5 1 2]) ; =&gt; @[[1 2] [3 4 5] [1 2]]",
+            example = "(partition-by #(&lt; % 3) [1 2 3 4 5 1 2]) ; =&gt; ([1 2] [3 4 5] [1 2])",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L1366",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1633",
                 docs = "",
             ),
         ),
@@ -1035,7 +1035,7 @@ Returns a lazy sequence of partitions. Applies <code>f</code> to each value in <
             summary = "Recursively converts a Phel data structure to a PHP array.",
             example = "(phel-&gt;php {:a [1 2 3] :b {:c 4}}) ; =&gt; &lt;PHP-Array [\"a\":&lt;PHP-Array [1, 2, 3]&gt;, \"b\":&lt;PHP-Array [\"c\":4]&gt;]&gt;",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L886",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L947",
                 docs = "",
             ),
         ),
@@ -1055,7 +1055,7 @@ Indexed PHP arrays become vectors, associative PHP arrays become maps.
 """,
             example = "(php-&gt;phel (php-associative-array \"a\" 1 \"b\" 2)) ; =&gt; {\"a\" 1, \"b\" 2}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L918",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L979",
                 docs = "",
             ),
         ),
@@ -1072,25 +1072,7 @@ Indexed PHP arrays become vectors, associative PHP arrays become maps.
             summary = "Converts a PHP Array to a Phel map.",
             example = "(php-array-to-map (php-associative-array \"a\" 1 \"b\" 2)) ; =&gt; {\"a\" 1, \"b\" 2}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L866",
-                docs = "",
-            ),
-        ),
-    ),
-    PhelFunction(
-        namespace = "core",
-        name = "put-in",
-        signature = "(put-in ds ks v)",
-        completion = CompletionInfo(
-            tailText = "Puts a value into a nested data structure",
-            priority = PhelCompletionPriority.DEPRECATED_FUNCTIONS,
-        ),
-        documentation = DocumentationInfo(
-            summary = "Puts a value into a nested data structure.",
-            example = null,
-            deprecation = DeprecationInfo(version = "0.25.0", replacement = "assoc-in"),
-            links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L353",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L927",
                 docs = "",
             ),
         ),
@@ -1109,7 +1091,7 @@ Returns true if a lazy sequence, delay, promise, or future has been realized, fa
 """,
             example = "(realized? (lazy-seq (cons 1 nil))) ; =&gt; false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L1241",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1465",
                 docs = "",
             ),
         ),
@@ -1126,9 +1108,9 @@ Returns true if a lazy sequence, delay, promise, or future has been realized, fa
             summary = """
 Returns a lazy sequence of the intermediate values of the reduction (as per reduce) of coll by f, starting with init when supplied.
 """,
-            example = "(reductions + [1 2 3 4]) ; =&gt; @[1 3 6 10]\n(reductions + 0 [1 2 3 4]) ; =&gt; @[0 1 3 6 10]",
+            example = "(reductions + [1 2 3 4]) ; =&gt; (1 3 6 10)\n(reductions + 0 [1 2 3 4]) ; =&gt; (0 1 3 6 10)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L1081",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1261",
                 docs = "",
             ),
         ),
@@ -1136,7 +1118,7 @@ Returns a lazy sequence of the intermediate values of the reduction (as per redu
     PhelFunction(
         namespace = "core",
         name = "remove",
-        signature = "(remove pred & args)",
+        signature = "(remove pred)\n(remove pred coll)",
         completion = CompletionInfo(
             tailText = "Returns a lazy sequence of elements where predicate returns false",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,
@@ -1145,9 +1127,9 @@ Returns a lazy sequence of the intermediate values of the reduction (as per redu
             summary = """
 Returns a lazy sequence of elements where predicate returns false. Opposite of filter. When called with pred only, returns a transducer.
 """,
-            example = "(remove even? [1 2 3 4 5 6]) ; =&gt; @[1 3 5]",
+            example = "(remove even? [1 2 3 4 5 6]) ; =&gt; (1 3 5)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L582",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L642",
                 docs = "",
             ),
         ),
@@ -1166,7 +1148,7 @@ Returns the map with keys renamed according to kmap. Keys not present in kmap ar
 """,
             example = "(rename-keys {:a 1 :b 2 :c 3} {:a :x :b :y}) ; =&gt; {:x 1, :y 2, :c 3}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L1324",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1585",
                 docs = "",
             ),
         ),
@@ -1174,7 +1156,7 @@ Returns the map with keys renamed according to kmap. Keys not present in kmap ar
     PhelFunction(
         namespace = "core",
         name = "repeat",
-        signature = "(repeat a & rest)",
+        signature = "(repeat x)\n(repeat n x)",
         completion = CompletionInfo(
             tailText = "Returns a vector of length n where every element is x",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,
@@ -1186,7 +1168,7 @@ With one argument returns an infinite lazy sequence of x.
 """,
             example = "(repeat 3 :a) ; =&gt; [:a :a :a]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L1027",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1212",
                 docs = "",
             ),
         ),
@@ -1194,7 +1176,7 @@ With one argument returns an infinite lazy sequence of x.
     PhelFunction(
         namespace = "core",
         name = "repeatedly",
-        signature = "(repeatedly a & rest)",
+        signature = "(repeatedly f)\n(repeatedly n f)",
         completion = CompletionInfo(
             tailText = "Returns a vector of length n with values produced by repeatedly calling f",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,
@@ -1204,9 +1186,9 @@ With one argument returns an infinite lazy sequence of x.
 Returns a vector of length n with values produced by repeatedly calling f.<br /><br />
 With one argument returns an infinite lazy sequence of calls to f.
 """,
-            example = "(repeatedly 3 rand) ; =&gt; [0.234 0.892 0.456] (random values)",
+            example = "(repeatedly 3 rand) ; =&gt; (0.234 0.892 0.456) (random values)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L1039",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1223",
                 docs = "",
             ),
         ),
@@ -1223,7 +1205,7 @@ With one argument returns an infinite lazy sequence of calls to f.
             summary = "Reverses the order of the elements in the given sequence.",
             example = "(reverse [1 2 3 4]) ; =&gt; [4 3 2 1]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L706",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L769",
                 docs = "",
             ),
         ),
@@ -1242,7 +1224,7 @@ Returns true if <code>coll</code> can be reverse-iterated in constant time. Curr
 """,
             example = "(reversible? [1 2 3]) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L717",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L780",
                 docs = "",
             ),
         ),
@@ -1261,7 +1243,7 @@ Returns, in constant time, a sequence of the items in <code>rev</code> in revers
 """,
             example = "(rseq [1 2 3]) ; =&gt; (3 2 1)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L725",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L788",
                 docs = "",
             ),
         ),
@@ -1280,7 +1262,7 @@ Like <code>subseq</code>, but returns the matching entries in descending order. 
 """,
             example = "(rsubseq (sorted-map 1 :a 2 :b 3 :c) &lt;= 2) ; =&gt; ([2 :b] [1 :a])",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L823",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L891",
                 docs = "",
             ),
         ),
@@ -1299,7 +1281,7 @@ Returns a new map including key value pairs from <code>m</code> selected with ke
 """,
             example = "(select-keys {:a 1 :b 2 :c 3} [:a :c]) ; =&gt; {:a 1, :c 3}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L1310",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1552",
                 docs = "",
             ),
         ),
@@ -1318,7 +1300,7 @@ Applies transducer <code>xform</code> to <code>coll</code>, returning a vector o
 """,
             example = "(sequence (comp (filter even?) (map inc)) [1 2 3 4 5]) ; =&gt; [3 5]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L1395",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1662",
                 docs = "",
             ),
         ),
@@ -1337,7 +1319,7 @@ Coerces a collection to a set. Returns a set containing the distinct elements of
 """,
             example = "(set [1 2 3 2 1]) ; =&gt; #{1 2 3}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L289",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L339",
                 docs = "",
             ),
         ),
@@ -1354,7 +1336,7 @@ Coerces a collection to a set. Returns a set containing the distinct elements of
             summary = "Returns a random permutation of coll.",
             example = "(shuffle [1 2 3 4 5]) ; =&gt; [2 3 5 1 4]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L1019",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1204",
                 docs = "",
             ),
         ),
@@ -1362,7 +1344,7 @@ Coerces a collection to a set. Returns a set containing the distinct elements of
     PhelFunction(
         namespace = "core",
         name = "slice",
-        signature = "(slice coll & [offset & [length]])",
+        signature = "(slice coll offset)\n(slice coll offset length)",
         completion = CompletionInfo(
             tailText = "Extracts a slice of coll starting at offset with optional length",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,
@@ -1373,7 +1355,7 @@ Extracts a slice of <code>coll</code> starting at <code>offset</code> with optio
 """,
             example = "(slice [1 2 3 4 5] 1 3) ; =&gt; [2 3 4]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L247",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L293",
                 docs = "",
             ),
         ),
@@ -1390,7 +1372,7 @@ Extracts a slice of <code>coll</code> starting at <code>offset</code> with optio
             summary = "Returns a sorted vector. If no comparator is supplied compare is used.",
             example = "(sort [3 1 4 1 5 9 2 6]) ; =&gt; [1 1 2 3 4 5 6 9]\n(sort (fn [a b] (compare b a)) [1 2 3]) ; =&gt; [3 2 1]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L995",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1180",
                 docs = "",
             ),
         ),
@@ -1410,7 +1392,7 @@ If no comparator is supplied compare is used.
 """,
             example = "(sort-by count [\"aaa\" \"c\" \"bb\"]) ; =&gt; [\"c\" \"bb\" \"aaa\"]\n(sort-by count compare [\"aaa\" \"c\" \"bb\"]) ; =&gt; [\"c\" \"bb\" \"aaa\"]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L1006",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1191",
                 docs = "",
             ),
         ),
@@ -1427,9 +1409,9 @@ If no comparator is supplied compare is used.
             summary = """
 Returns a vector of <code>[(take n coll) (drop n coll)]</code>.
 """,
-            example = "(split-at 2 [1 2 3 4 5]) ; =&gt; [@[1 2] @[3 4 5]]",
+            example = "(split-at 2 [1 2 3 4 5]) ; =&gt; [(1 2) (3 4 5)]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L1345",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1612",
                 docs = "",
             ),
         ),
@@ -1446,9 +1428,9 @@ Returns a vector of <code>[(take n coll) (drop n coll)]</code>.
             summary = """
 Returns a vector of <code>[(take-while pred coll) (drop-while pred coll)]</code>.
 """,
-            example = "(split-with #(&lt; % 4) [1 2 3 4 5 6]) ; =&gt; [@[1 2 3] @[4 5 6]]",
+            example = "(split-with #(&lt; % 4) [1 2 3 4 5 6]) ; =&gt; [(1 2 3) (4 5 6)]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L1359",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1626",
                 docs = "",
             ),
         ),
@@ -1467,7 +1449,7 @@ Returns a vector <code>[(vec (take n coll)) (vec (drop n coll))]</code>. Like <c
 """,
             example = "(splitv-at 2 [1 2 3 4 5]) ; =&gt; [[1 2] [3 4 5]]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L1352",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1619",
                 docs = "",
             ),
         ),
@@ -1486,7 +1468,7 @@ Returns a lazy sequence of the entries of the sorted collection <code>sc</code> 
 """,
             example = "(subseq (sorted-map 1 :a 2 :b 3 :c) &gt;= 2) ; =&gt; ([2 :b] [3 :c])",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L807",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L875",
                 docs = "",
             ),
         ),
@@ -1505,7 +1487,7 @@ Returns a persistent vector of the items in <code>v</code> from <code>start</cod
 """,
             example = "(subvec [1 2 3 4 5] 1 3) ; =&gt; [2 3]\n(subvec [1 2 3 4 5] 2) ; =&gt; [3 4 5]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L273",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L323",
                 docs = "",
             ),
         ),
@@ -1513,7 +1495,7 @@ Returns a persistent vector of the items in <code>v</code> from <code>start</cod
     PhelFunction(
         namespace = "core",
         name = "take",
-        signature = "(take n & args)",
+        signature = "(take n)\n(take n coll)",
         completion = CompletionInfo(
             tailText = "Takes the first n elements of coll",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,
@@ -1522,9 +1504,9 @@ Returns a persistent vector of the items in <code>v</code> from <code>start</cod
             summary = """
 Takes the first <code>n</code> elements of <code>coll</code>. When called with n only, returns a transducer.
 """,
-            example = null,
+            example = "(take 2 [1 2 3 4]) ; =&gt; (1 2)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L468",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L521",
                 docs = "",
             ),
         ),
@@ -1543,7 +1525,7 @@ Takes the last <code>n</code> elements of <code>coll</code>.
 """,
             example = "(take-last 3 [1 2 3 4 5]) ; =&gt; [3 4 5]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L500",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L555",
                 docs = "",
             ),
         ),
@@ -1551,7 +1533,7 @@ Takes the last <code>n</code> elements of <code>coll</code>.
     PhelFunction(
         namespace = "core",
         name = "take-nth",
-        signature = "(take-nth n & args)",
+        signature = "(take-nth n)\n(take-nth n coll)",
         completion = CompletionInfo(
             tailText = "Returns every nth item in coll",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,
@@ -1560,9 +1542,9 @@ Takes the last <code>n</code> elements of <code>coll</code>.
             summary = """
 Returns every nth item in <code>coll</code>. Returns a lazy sequence. When called with n only, returns a transducer.
 """,
-            example = "(take-nth 2 [0 1 2 3 4 5 6 7 8]) ; =&gt; @[0 2 4 6 8]",
+            example = "(take-nth 2 [0 1 2 3 4 5 6 7 8]) ; =&gt; (0 2 4 6 8)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L528",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L583",
                 docs = "",
             ),
         ),
@@ -1570,7 +1552,7 @@ Returns every nth item in <code>coll</code>. Returns a lazy sequence. When calle
     PhelFunction(
         namespace = "core",
         name = "take-while",
-        signature = "(take-while pred & args)",
+        signature = "(take-while pred)\n(take-while pred coll)",
         completion = CompletionInfo(
             tailText = "Takes all elements at the front of coll where (pred x) is true",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,
@@ -1579,27 +1561,9 @@ Returns every nth item in <code>coll</code>. Returns a lazy sequence. When calle
             summary = """
 Takes all elements at the front of <code>coll</code> where <code>(pred x)</code> is true. Returns a lazy sequence. When called with pred only, returns a transducer.
 """,
-            example = "(take-while #(&lt; % 5) [1 2 3 4 5 6 3 2 1]) ; =&gt; @[1 2 3 4]",
+            example = "(take-while #(&lt; % 5) [1 2 3 4 5 6 3 2 1]) ; =&gt; (1 2 3 4)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L512",
-                docs = "",
-            ),
-        ),
-    ),
-    PhelFunction(
-        namespace = "core",
-        name = "unset-in",
-        signature = "(unset-in ds ks)",
-        completion = CompletionInfo(
-            tailText = "Removes a value from a nested data structure",
-            priority = PhelCompletionPriority.DEPRECATED_FUNCTIONS,
-        ),
-        documentation = DocumentationInfo(
-            summary = "Removes a value from a nested data structure.",
-            example = null,
-            deprecation = DeprecationInfo(version = "0.25.0", replacement = "dissoc-in"),
-            links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L389",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L567",
                 docs = "",
             ),
         ),
@@ -1618,7 +1582,7 @@ Updates a value in a datastructure by applying <code>f</code> to the current val
 """,
             example = "(update {:count 5} :count inc) ; =&gt; {:count 6}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L360",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L420",
                 docs = "",
             ),
         ),
@@ -1637,7 +1601,7 @@ Updates a value in a nested data structure by applying <code>f</code> to the val
 """,
             example = "(update-in {:a {:b 5}} [:a :b] inc) ; =&gt; {:a {:b 6}}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L367",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L427",
                 docs = "",
             ),
         ),
@@ -1658,7 +1622,7 @@ Returns the value of a map entry. Accepts a typed<br />
 """,
             example = "(val (first (pairs {:a 1}))) ; =&gt; 1",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L781",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L849",
                 docs = "",
             ),
         ),
@@ -1677,25 +1641,7 @@ Returns a sequence of all values in a map, or <code>nil</code> when the map is <
 """,
             example = "(vals {:a 1 :b 2}) ; =&gt; [1 2]\n(vals nil) ; =&gt; nil",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L756",
-                docs = "",
-            ),
-        ),
-    ),
-    PhelFunction(
-        namespace = "core",
-        name = "values",
-        signature = "(values coll)",
-        completion = CompletionInfo(
-            tailText = "Returns a sequence of all values in a map",
-            priority = PhelCompletionPriority.DEPRECATED_FUNCTIONS,
-        ),
-        documentation = DocumentationInfo(
-            summary = "Returns a sequence of all values in a map.",
-            example = "(values {:a 1 :b 2}) ; =&gt; [1 2]",
-            deprecation = DeprecationInfo(version = "0.32.0", replacement = "vals"),
-            links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L839",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L824",
                 docs = "",
             ),
         ),
@@ -1714,7 +1660,7 @@ Coerces a collection to a vector. For hash-maps and structs, entries are returne
 """,
             example = "(vec {:a 1 :b 2}) ; =&gt; [[:a 1] [:b 2]]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L300",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L353",
                 docs = "",
             ),
         ),
@@ -1731,7 +1677,7 @@ Coerces a collection to a vector. For hash-maps and structs, entries are returne
             summary = "Creates a map from two sequential data structures. Returns a new map.",
             example = "(zipcoll [:a :b :c] [1 2 3]) ; =&gt; {:a 1, :b 2, :c 3}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L1287",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1525",
                 docs = "",
             ),
         ),
@@ -1751,7 +1697,7 @@ Stops when the shorter of <code>keys</code> or <code>vals</code> is exhausted. W
 """,
             example = "(zipmap [:a :b :c] [1 2 3]) ; =&gt; {:a 1, :b 2, :c 3}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/seq-fns.phel#L1273",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/seq-fns.phel#L1506",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/core/registerCoreSequencesFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/core/registerCoreSequencesFunctions.kt
@@ -12,7 +12,7 @@ internal fun registerCoreSequencesFunctions(): List<PhelFunction> = listOf(
     PhelFunction(
         namespace = "core",
         name = "assoc",
-        signature = "(assoc ds key value & more)",
+        signature = "(assoc ds key value)\n(assoc ds key value & more)",
         completion = CompletionInfo(
             tailText = "Associates one or more key-value pairs with a collection",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,
@@ -23,7 +23,7 @@ Associates one or more key-value pairs with a collection. Additional key-value p
 """,
             example = "(assoc {:a 1} :b 2) ; =&gt; {:a 1, :b 2}\n(assoc {:a 1} :b 2 :c 3) ; =&gt; {:a 1, :b 2, :c 3}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/sequences.phel#L278",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/sequences.phel#L343",
                 docs = "",
             ),
         ),
@@ -31,7 +31,7 @@ Associates one or more key-value pairs with a collection. Additional key-value p
     PhelFunction(
         namespace = "core",
         name = "dissoc",
-        signature = "(dissoc ds & ks)",
+        signature = "(dissoc ds)\n(dissoc ds k)\n(dissoc ds k & ks)",
         completion = CompletionInfo(
             tailText = "Returns ds without the given keys",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,
@@ -42,7 +42,7 @@ Returns <code>ds</code> without the given keys. With no keys returns <code>ds</c
 """,
             example = "(dissoc {:a 1 :b 2} :b) ; =&gt; {:a 1}\n(dissoc {:a 1 :b 2 :c 3} :a :c) ; =&gt; {:b 2}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/sequences.phel#L318",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/sequences.phel#L393",
                 docs = "",
             ),
         ),
@@ -50,7 +50,7 @@ Returns <code>ds</code> without the given keys. With no keys returns <code>ds</c
     PhelFunction(
         namespace = "core",
         name = "get",
-        signature = "(get ds k & [opt])",
+        signature = "(get ds k)\n(get ds k opt)",
         completion = CompletionInfo(
             tailText = "Gets the value at key in a collection",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,
@@ -59,7 +59,7 @@ Returns <code>ds</code> without the given keys. With no keys returns <code>ds</c
             summary = "Gets the value at key in a collection. Returns default if not found.",
             example = "(get {:a 1} :a) ; =&gt; 1",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/sequences.phel#L91",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/sequences.phel#L86",
                 docs = "",
             ),
         ),
@@ -81,7 +81,7 @@ Returns the value at <code>index</code> in <code>coll</code>. Throws an<br />
 """,
             example = "(nth [1 2 3] 1) ; =&gt; 2\n(nth [1 2 3] 5 :default) ; =&gt; :default",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/sequences.phel#L136",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/sequences.phel#L197",
                 docs = "",
             ),
         ),
@@ -100,7 +100,7 @@ Returns the nth next of <code>coll</code>, <code>(seq coll)</code> when <code>n<
 """,
             example = "(nthnext [1 2 3 4 5] 2) ; =&gt; (3 4 5)\n(nthnext [1 2] 5) ; =&gt; nil",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/sequences.phel#L207",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/sequences.phel#L268",
                 docs = "",
             ),
         ),
@@ -119,7 +119,7 @@ Returns the nth rest of <code>coll</code>, <code>coll</code> when <code>n</code>
 """,
             example = "(nthrest [1 2 3 4 5] 2) ; =&gt; [3 4 5]\n(nthrest [1 2] 5) ; =&gt; ()\n(nthrest nil 0) ; =&gt; nil\n(nthrest nil 3) ; =&gt; ()",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/sequences.phel#L194",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/sequences.phel#L255",
                 docs = "",
             ),
         ),
@@ -138,7 +138,7 @@ Returns the head of a vector / PHP array (the last element) or the head of a lis
 """,
             example = "(peek [1 2 3]) ; =&gt; 3\n(peek '(:a :b :c)) ; =&gt; :a",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/sequences.phel#L27",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/sequences.phel#L27",
                 docs = "",
             ),
         ),
@@ -153,69 +153,9 @@ Returns the head of a vector / PHP array (the last element) or the head of a lis
         ),
         documentation = DocumentationInfo(
             summary = "Removes the last element of a collection. Returns nil for nil.",
-            example = null,
+            example = "(pop [1 2 3]) ; =&gt; [1 2]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/sequences.phel#L66",
-                docs = "",
-            ),
-        ),
-    ),
-    PhelFunction(
-        namespace = "core",
-        name = "push",
-        signature = "(push coll x)",
-        completion = CompletionInfo(
-            tailText = "Inserts x at the end of the sequence coll",
-            priority = PhelCompletionPriority.DEPRECATED_FUNCTIONS,
-        ),
-        documentation = DocumentationInfo(
-            summary = """
-Inserts <code>x</code> at the end of the sequence <code>coll</code>.
-""",
-            example = null,
-            deprecation = DeprecationInfo(version = "0.25.0", replacement = "conj"),
-            links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/sequences.phel#L50",
-                docs = "",
-            ),
-        ),
-    ),
-    PhelFunction(
-        namespace = "core",
-        name = "put",
-        signature = "(put ds key value)",
-        completion = CompletionInfo(
-            tailText = "Puts value mapped to key on the datastructure ds",
-            priority = PhelCompletionPriority.DEPRECATED_FUNCTIONS,
-        ),
-        documentation = DocumentationInfo(
-            summary = """
-Puts <code>value</code> mapped to <code>key</code> on the datastructure <code>ds</code>. Returns <code>ds</code>.
-""",
-            example = null,
-            deprecation = DeprecationInfo(version = "0.25.0", replacement = "assoc"),
-            links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/sequences.phel#L293",
-                docs = "",
-            ),
-        ),
-    ),
-    PhelFunction(
-        namespace = "core",
-        name = "unset",
-        signature = "(unset ds key)",
-        completion = CompletionInfo(
-            tailText = "Returns ds without key",
-            priority = PhelCompletionPriority.DEPRECATED_FUNCTIONS,
-        ),
-        documentation = DocumentationInfo(
-            summary = """
-Returns <code>ds</code> without <code>key</code>.
-""",
-            example = null,
-            deprecation = DeprecationInfo(version = "0.25.0", replacement = "dissoc"),
-            links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/sequences.phel#L328",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/sequences.phel#L59",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/core/registerCoreStringsFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/core/registerCoreStringsFunctions.kt
@@ -19,9 +19,9 @@ internal fun registerCoreStringsFunctions(): List<PhelFunction> = listOf(
         ),
         documentation = DocumentationInfo(
             summary = "Generates a new unique symbol.",
-            example = null,
+            example = "(gensym) ; =&gt; __phel_1",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/strings.phel#L74",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/strings.phel#L74",
                 docs = "",
             ),
         ),
@@ -29,7 +29,7 @@ internal fun registerCoreStringsFunctions(): List<PhelFunction> = listOf(
     PhelFunction(
         namespace = "core",
         name = "str",
-        signature = "(str & args)",
+        signature = "(str)\n(str x)\n(str x y)\n(str x y z)\n(str x y z a)\n(str x y z a b)\n(str x y z a b & more)",
         completion = CompletionInfo(
             tailText = "Creates a string by concatenating values together",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -38,9 +38,9 @@ internal fun registerCoreStringsFunctions(): List<PhelFunction> = listOf(
             summary = """
 Creates a string by concatenating values together. If no arguments are provided an empty string is returned. Nil is represented as an empty string. Booleans are represented as "true" or "false" (matching Clojure semantics). Otherwise, it tries to call <code>__toString</code>.
 """,
-            example = null,
+            example = "(str \"a\" \"b\" \"c\") ; =&gt; \"abc\"\n(str 1 2 3) ; =&gt; \"123\"\n(str 1 nil true) ; =&gt; \"1true\"\n(str) ; =&gt; \"\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/strings.phel#L100",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/strings.phel#L105",
                 docs = "",
             ),
         ),
@@ -61,7 +61,7 @@ Throws <code>InvalidArgumentException</code> for any other input (including func
 """,
             example = "(symbol \"foo\") ; =&gt; foo\n(symbol :abc) ; =&gt; abc\n(symbol nil \"foo\") ; =&gt; foo\n(symbol #'phel.core/+) ; =&gt; phel.core/+",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/strings.phel#L46",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/strings.phel#L46",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/core/registerCoreTapFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/core/registerCoreTapFunctions.kt
@@ -23,7 +23,7 @@ Registers <code>f</code> as a tap. Every call to <code>tap></code> invokes each 
 """,
             example = "(add-tap println)\n(tap&gt; 42) ; prints 42",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/tap.phel#L15",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/tap.phel#L15",
                 docs = "",
             ),
         ),
@@ -42,7 +42,7 @@ Removes <code>f</code> from the tap set. Returns nil.
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/tap.phel#L23",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/tap.phel#L23",
                 docs = "",
             ),
         ),
@@ -61,7 +61,7 @@ Sends <code>x</code> to every registered tap. Exceptions thrown by individual ta
 """,
             example = "(add-tap println)\n(tap&gt; {:event :login :user \"alice\"})",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/tap.phel#L30",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/tap.phel#L30",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/core/registerCoreTransducersFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/core/registerCoreTransducersFunctions.kt
@@ -12,7 +12,7 @@ internal fun registerCoreTransducersFunctions(): List<PhelFunction> = listOf(
     PhelFunction(
         namespace = "core",
         name = "completing",
-        signature = "(completing f & args)",
+        signature = "(completing f)\n(completing f cf)",
         completion = CompletionInfo(
             tailText = "Takes a reducing function f of 2 args and returns a fn suitable for transduce by adding a 1-arity...",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -21,9 +21,9 @@ internal fun registerCoreTransducersFunctions(): List<PhelFunction> = listOf(
             summary = """
 Takes a reducing function <code>f</code> of 2 args and returns a fn suitable for transduce by adding a 1-arity (completion) that calls <code>cf</code> (default: identity).
 """,
-            example = null,
+            example = "(transduce (filter even?) (completing conj) [] [1 2 3 4]) ; =&gt; [2 4]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/transducers.phel#L88",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/transducers.phel#L101",
                 docs = "",
             ),
         ),
@@ -31,7 +31,7 @@ Takes a reducing function <code>f</code> of 2 args and returns a fn suitable for
     PhelFunction(
         namespace = "core",
         name = "reduce",
-        signature = "(reduce f & args)",
+        signature = "(reduce f coll)\n(reduce f init coll)",
         completion = CompletionInfo(
             tailText = "Reduces collection to a single value by repeatedly applying function to accumulator and elements",
             priority = PhelCompletionPriority.COLLECTION_FUNCTIONS,
@@ -42,7 +42,7 @@ Reduces collection to a single value by repeatedly applying function to accumula
 """,
             example = "(reduce + [1 2 3 4]) ; =&gt; 10",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/transducers.phel#L50",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/transducers.phel#L52",
                 docs = "",
             ),
         ),
@@ -61,7 +61,7 @@ Reduces an associative collection by applying <code>f</code> to the accumulator,
 """,
             example = "(reduce-kv (fn [m k v] (assoc m v k)) {} {:a 1 :b 2}) ; =&gt; {1 :a, 2 :b}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/transducers.phel#L73",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/transducers.phel#L85",
                 docs = "",
             ),
         ),
@@ -78,9 +78,9 @@ Reduces an associative collection by applying <code>f</code> to the accumulator,
             summary = """
 Wraps <code>x</code> in a Reduced, signaling early termination from reduce/transduce.
 """,
-            example = null,
+            example = "(reduce (fn [acc x] (if (= x 3) (reduced acc) (+ acc x))) 0 [1 2 3 4]) ; =&gt; 3",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/transducers.phel#L18",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/transducers.phel#L17",
                 docs = "",
             ),
         ),
@@ -97,9 +97,9 @@ Wraps <code>x</code> in a Reduced, signaling early termination from reduce/trans
             summary = """
 Returns true if <code>x</code> is a Reduced value.
 """,
-            example = null,
+            example = "(reduced? (reduced 1)) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/transducers.phel#L24",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/transducers.phel#L24",
                 docs = "",
             ),
         ),
@@ -107,7 +107,7 @@ Returns true if <code>x</code> is a Reduced value.
     PhelFunction(
         namespace = "core",
         name = "transduce",
-        signature = "(transduce xform f & args)",
+        signature = "(transduce xform f coll)\n(transduce xform f init coll)",
         completion = CompletionInfo(
             tailText = "Reduce with a transformation of f (xf)",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -120,7 +120,7 @@ Reduce with a transformation of <code>f</code> (xf). If init is not supplied,<br
 """,
             example = "(transduce (map inc) + [1 2 3]) ; =&gt; 9",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/transducers.phel#L99",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/transducers.phel#L115",
                 docs = "",
             ),
         ),
@@ -137,9 +137,9 @@ Reduce with a transformation of <code>f</code> (xf). If init is not supplied,<br
             summary = """
 If <code>x</code> is Reduced, returns the unwrapped value; otherwise returns <code>x</code>.
 """,
-            example = null,
+            example = "(unreduced (reduced 1)) ; =&gt; 1\n(unreduced 1) ; =&gt; 1",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/transducers.phel#L30",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/transducers.phel#L31",
                 docs = "",
             ),
         ),
@@ -156,9 +156,9 @@ If <code>x</code> is Reduced, returns the unwrapped value; otherwise returns <co
             summary = """
 Creates a volatile mutable reference with initial value <code>val</code>. Use for transducer state that needs fast mutation without watches.
 """,
-            example = null,
+            example = "(let [v (volatile! 0)] (vreset! v 5) @v) ; =&gt; 5",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/transducers.phel#L116",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/transducers.phel#L131",
                 docs = "",
             ),
         ),
@@ -175,9 +175,9 @@ Creates a volatile mutable reference with initial value <code>val</code>. Use fo
             summary = """
 Returns true if <code>x</code> is a Volatile.
 """,
-            example = null,
+            example = "(volatile? (volatile! 0)) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/transducers.phel#L134",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/transducers.phel#L152",
                 docs = "",
             ),
         ),
@@ -194,9 +194,9 @@ Returns true if <code>x</code> is a Volatile.
             summary = """
 Sets the value of volatile <code>vol</code> to <code>val</code>. Returns <code>val</code>.
 """,
-            example = null,
+            example = "(let [v (volatile! 0)] (vreset! v 9)) ; =&gt; 9",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/transducers.phel#L122",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/transducers.phel#L138",
                 docs = "",
             ),
         ),
@@ -213,9 +213,9 @@ Sets the value of volatile <code>vol</code> to <code>val</code>. Returns <code>v
             summary = """
 Applies <code>f</code> to the current value of volatile <code>vol</code> plus <code>args</code>, and sets the new value. Returns the new value.
 """,
-            example = null,
+            example = "(let [v (volatile! 10)] (vswap! v + 5)) ; =&gt; 15",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/transducers.phel#L128",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/transducers.phel#L145",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/core/registerCoreTransientsFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/core/registerCoreTransientsFunctions.kt
@@ -12,7 +12,7 @@ internal fun registerCoreTransientsFunctions(): List<PhelFunction> = listOf(
     PhelFunction(
         namespace = "core",
         name = "assoc!",
-        signature = "(assoc! tcoll key value & more)",
+        signature = "(assoc! tcoll key value)\n(assoc! tcoll key value & more)",
         completion = CompletionInfo(
             tailText = "Associates one or more key-value pairs with a transient collection, mutating it in place",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -28,7 +28,7 @@ Associates one or more key-value pairs with a transient collection,<br />
 """,
             example = "(persistent! (assoc! (transient {}) :a 1 :b 2)) ; =&gt; {:a 1, :b 2}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/transients.phel#L103",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/transients.phel#L103",
                 docs = "",
             ),
         ),
@@ -47,7 +47,7 @@ Adds <code>value</code> to the transient collection <code>tcoll</code>, mutating
 """,
             example = "(persistent (conj! (transient [1 2]) 3)) ; =&gt; [1 2 3]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/transients.phel#L80",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/transients.phel#L80",
                 docs = "",
             ),
         ),
@@ -66,7 +66,7 @@ Removes one or more elements from a transient set, mutating it in place. Raises 
 """,
             example = "(persistent! (disj! (transient #{1 2 3}) 2)) ; =&gt; #{1 3}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/transients.phel#L153",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/transients.phel#L158",
                 docs = "",
             ),
         ),
@@ -85,7 +85,7 @@ Dissociates one or more keys from a transient map, mutating it in place. Raises 
 """,
             example = "(persistent! (dissoc! (transient {:a 1 :b 2}) :a)) ; =&gt; {:b 2}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/transients.phel#L134",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/transients.phel#L139",
                 docs = "",
             ),
         ),
@@ -102,7 +102,7 @@ Dissociates one or more keys from a transient map, mutating it in place. Raises 
             summary = "Converts a transient collection back to a persistent collection.",
             example = "(def t (transient {}))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/transients.phel#L27",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/transients.phel#L27",
                 docs = "",
             ),
         ),
@@ -121,7 +121,7 @@ Converts a transient collection back to a persistent collection. Alias for <code
 """,
             example = "(persistent! (conj! (transient []) 1 2 3)) ; =&gt; [1 2 3]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/transients.phel#L34",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/transients.phel#L34",
                 docs = "",
             ),
         ),
@@ -140,7 +140,7 @@ Removes the last element from a transient vector, mutating it in place. Raises <
 """,
             example = "(persistent! (pop! (transient [1 2 3]))) ; =&gt; [1 2]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/transients.phel#L162",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/transients.phel#L167",
                 docs = "",
             ),
         ),
@@ -160,7 +160,7 @@ Transient collections provide faster performance for multiple sequential updates
 """,
             example = "(def t (transient []))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/transients.phel#L18",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/transients.phel#L18",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/core/registerCoreUuidFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/core/registerCoreUuidFunctions.kt
@@ -25,7 +25,7 @@ Parses <code>s</code> as a canonical UUID string and returns a <code>Phel\Lang\U
 """,
             example = "(parse-uuid \"550E8400-E29B-41D4-A716-446655440000\")\n  ; =&gt; #uuid \"550e8400-e29b-41d4-a716-446655440000\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/uuid.phel#L27",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/uuid.phel#L27",
                 docs = "",
             ),
         ),
@@ -44,7 +44,7 @@ Returns a random version 4 UUID as a <code>Phel\Lang\UUID</code> value.
 """,
             example = "(random-uuid) ; =&gt; #uuid \"550e8400-e29b-41d4-a716-446655440000\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/uuid.phel#L20",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/uuid.phel#L20",
                 docs = "",
             ),
         ),
@@ -63,7 +63,7 @@ Returns true if <code>x</code> is the nil UUID (all zeros), false otherwise.
 """,
             example = "(uuid-nil? #uuid \"00000000-0000-0000-0000-000000000000\") ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/uuid.phel#L50",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/uuid.phel#L50",
                 docs = "",
             ),
         ),
@@ -84,7 +84,7 @@ Returns a keyword describing the variant field of UUID <code>x</code>: <code>:nc
 """,
             example = "(uuid-variant #uuid \"550e8400-e29b-41d4-a716-446655440000\") ; =&gt; :rfc-4122",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/uuid.phel#L66",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/uuid.phel#L66",
                 docs = "",
             ),
         ),
@@ -103,7 +103,7 @@ Returns the version digit (1-5) encoded in UUID <code>x</code>, or nil if <code>
 """,
             example = "(uuid-version #uuid \"550e8400-e29b-41d4-a716-446655440000\") ; =&gt; 4",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/uuid.phel#L58",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/uuid.phel#L58",
                 docs = "",
             ),
         ),
@@ -122,7 +122,7 @@ Returns true if <code>a</code> and <code>b</code> are <code>Phel\Lang\UUID</code
 """,
             example = "(uuid= #uuid \"550e8400-e29b-41d4-a716-446655440000\"\n         #uuid \"550E8400-E29B-41D4-A716-446655440000\") ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/uuid.phel#L42",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/uuid.phel#L42",
                 docs = "",
             ),
         ),
@@ -141,7 +141,7 @@ Returns true if <code>x</code> is a <code>Phel\Lang\UUID</code> value, false oth
 """,
             example = "(uuid? #uuid \"550e8400-e29b-41d4-a716-446655440000\") ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/core/uuid.phel#L13",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/core/uuid.phel#L13",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/registerAiFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/registerAiFunctions.kt
@@ -23,7 +23,7 @@ HTTP POST seam. Rebind with <code>binding</code> in tests to inject a fake trans
 """,
             example = "(binding [*http-post* (fn [url opts] {:status 200 :body \"...\"})] ...)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/ai.phel#L24",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/ai.phel#L25",
                 docs = "",
             ),
         ),
@@ -44,7 +44,7 @@ Options are passed through to <code>embed</code>.
 """,
             example = "(build-index [\"hello\" \"world\"])",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/ai.phel#L691",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/ai.phel#L696",
                 docs = "",
             ),
         ),
@@ -73,7 +73,7 @@ Accepts an optional options map:<br />
 """,
             example = "(chat [{:role \"user\" :content \"Hello!\"}])",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/ai.phel#L286",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/ai.phel#L287",
                 docs = "",
             ),
         ),
@@ -93,7 +93,7 @@ Useful for building multi-turn conversations.
 """,
             example = "(chat-with-history [{:role \"user\" :content \"Hi\"}\n                              {:role \"assistant\" :content \"Hello!\"}]\n                             \"How are you?\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/ai.phel#L321",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/ai.phel#L322",
                 docs = "",
             ),
         ),
@@ -118,7 +118,7 @@ Options map accepts the same keys as <code>chat</code>.
 """,
             example = "(chat-with-tools [{:role \"user\" :content \"What's the weather?\"}] [(tool \"get-weather\" \"Gets weather\" {:city {:type \"string\"}})])",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/ai.phel#L480",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/ai.phel#L485",
                 docs = "",
             ),
         ),
@@ -138,7 +138,7 @@ Takes a prompt string and returns the assistant's text response. This is a conve
 """,
             example = "(complete \"Explain monads in one sentence\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/ai.phel#L312",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/ai.phel#L313",
                 docs = "",
             ),
         ),
@@ -157,7 +157,7 @@ Current AI configuration atom. Use <code>configure</code> to update.
 """,
             example = "@ai/config",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/ai.phel#L19",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/ai.phel#L20",
                 docs = "",
             ),
         ),
@@ -184,7 +184,7 @@ Supported keys:<br />
 """,
             example = "(configure {:api-key \"sk-ant-...\" :model \"claude-sonnet-4-6\"})",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/ai.phel#L29",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/ai.phel#L30",
                 docs = "",
             ),
         ),
@@ -201,9 +201,9 @@ Supported keys:<br />
             summary = """
 Computes the cosine similarity between two numeric vectors. Returns a float between -1.0 and 1.0, where 1.0 means identical direction.
 """,
-            example = "(cosine-similarity [1 0] [0 1]) ; =&gt; 0",
+            example = "(cosine-similarity [1 0] [0 1]) ; =&gt; 0.0",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/ai.phel#L616",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/ai.phel#L621",
                 docs = "",
             ),
         ),
@@ -220,7 +220,7 @@ Computes the cosine similarity between two numeric vectors. Returns a float betw
             summary = "Computes the dot product of two numeric vectors.",
             example = "(dot-product [1 2 3] [4 5 6]) ; =&gt; 32",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/ai.phel#L593",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/ai.phel#L598",
                 docs = "",
             ),
         ),
@@ -244,7 +244,7 @@ Options:<br />
 """,
             example = "(embed [\"hello world\"]) ; =&gt; [[0.123 -0.456 ...]]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/ai.phel#L648",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/ai.phel#L653",
                 docs = "",
             ),
         ),
@@ -263,7 +263,7 @@ Generates an embedding for a single text string. Returns a single embedding vect
 """,
             example = "(embed-one \"hello world\") ; =&gt; [0.123 -0.456 ...]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/ai.phel#L662",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/ai.phel#L667",
                 docs = "",
             ),
         ),
@@ -289,7 +289,7 @@ Options:<br />
 """,
             example = "(extract {:name \"string\" :age \"integer\"} \"John is 30 years old\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/ai.phel#L424",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/ai.phel#L429",
                 docs = "",
             ),
         ),
@@ -309,7 +309,7 @@ Similar to <code>extract</code>, but returns a vector of maps when the text cont
 """,
             example = "(extract-many {:name \"string\" :role \"string\"} \"Alice is CEO, Bob is CTO\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/ai.phel#L446",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/ai.phel#L451",
                 docs = "",
             ),
         ),
@@ -324,9 +324,9 @@ Similar to <code>extract</code>, but returns a vector of maps when the text cont
         ),
         documentation = DocumentationInfo(
             summary = "Computes the magnitude (L2 norm) of a numeric vector.",
-            example = "(magnitude [3 4]) ; =&gt; 5",
+            example = "(magnitude [3 4]) ; =&gt; 5.0",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/ai.phel#L602",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/ai.phel#L607",
                 docs = "",
             ),
         ),
@@ -348,7 +348,7 @@ Finds the k nearest items to a query embedding from an index.<br /><br />
 """,
             example = "(nearest query-embedding index 5)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/ai.phel#L673",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/ai.phel#L678",
                 docs = "",
             ),
         ),
@@ -377,7 +377,7 @@ Returns the assistant's final text. Throws if a tool name has no handler<br />
 """,
             example = "(run-tools [{:role \"user\" :content \"weather?\"}] [(tool \"get-weather\" \"...\" {:city \"string\"})] {\"get-weather\" (fn [args] \"72F\")})",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/ai.phel#L550",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/ai.phel#L555",
                 docs = "",
             ),
         ),
@@ -397,7 +397,7 @@ Returns a vector of {:text, :embedding, :similarity} maps.
 """,
             example = "(search \"greeting\" my-index 3)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/ai.phel#L705",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/ai.phel#L710",
                 docs = "",
             ),
         ),
@@ -421,7 +421,7 @@ The returned map is provider-agnostic; <code>chat-with-tools</code> converts it 
 """,
             example = "(tool \"get-weather\" \"Gets weather for a city\" {:location {:type \"string\"}})",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/ai.phel#L464",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/ai.phel#L469",
                 docs = "",
             ),
         ),
@@ -442,7 +442,7 @@ Accepts either a raw provider response body or a map produced by<br />
 """,
             example = "(tool-calls response)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/ai.phel#L510",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/ai.phel#L515",
                 docs = "",
             ),
         ),
@@ -464,7 +464,7 @@ Optional <code>opts</code> can set :provider (defaults to current config).
 """,
             example = "(tool-result \"call_abc\" \"72F sunny\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/ai.phel#L523",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/ai.phel#L528",
                 docs = "",
             ),
         ),
@@ -483,7 +483,7 @@ Temporarily merges <code>opts</code> into the global config for the duration of 
 """,
             example = "(with-config {:provider :openai :model \"gpt-4o\"} (complete \"hi\"))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/ai.phel#L45",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/ai.phel#L46",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/registerAsyncFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/registerAsyncFunctions.kt
@@ -35,7 +35,7 @@ At the top level this behaves like <code>php/sleep</code> / <code>php/usleep</co
 """,
             example = "(delay 0.5) ; suspends current fiber for 500ms\n  (async (delay 1.0) :done) ; =&gt; future that resolves after 1s\n  (delay (/ 1 1000)) ; ratio collapses to a float",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/async.phel#L18",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/async.phel#L18",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/registerBase64Functions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/registerBase64Functions.kt
@@ -12,7 +12,7 @@ internal fun registerBase64Functions(): List<PhelFunction> = listOf(
     PhelFunction(
         namespace = "base64",
         name = "base64/decode",
-        signature = "(decode s & [strict?])",
+        signature = "(decode s)\n(decode s strict?)",
         completion = CompletionInfo(
             tailText = "Decodes a Base64 string",
             priority = PhelCompletionPriority.BASE64_FUNCTIONS,
@@ -23,7 +23,7 @@ Decodes a Base64 string. When <code>strict?</code> is true, validates that the i
 """,
             example = "(decode \"SGVsbG8=\") ; =&gt; \"Hello\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/base64.phel#L10",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/base64.phel#L9",
                 docs = "",
             ),
         ),
@@ -31,7 +31,7 @@ Decodes a Base64 string. When <code>strict?</code> is true, validates that the i
     PhelFunction(
         namespace = "base64",
         name = "base64/decode-url",
-        signature = "(decode-url s & [strict?])",
+        signature = "(decode-url s)\n(decode-url s strict?)",
         completion = CompletionInfo(
             tailText = "Decodes a URL-safe Base64 string, adding padding automatically",
             priority = PhelCompletionPriority.BASE64_FUNCTIONS,
@@ -44,7 +44,7 @@ Decodes a URL-safe Base64 string, adding padding automatically. When<br />
 """,
             example = "(decode-url \"SGVsbG8\") ; =&gt; \"Hello\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/base64.phel#L25",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/base64.phel#L27",
                 docs = "",
             ),
         ),
@@ -61,7 +61,7 @@ Decodes a URL-safe Base64 string, adding padding automatically. When<br />
             summary = "Encodes a string to Base64.",
             example = "(encode \"Hello\") ; =&gt; \"SGVsbG8=\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/base64.phel#L4",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/base64.phel#L3",
                 docs = "",
             ),
         ),
@@ -78,7 +78,7 @@ Decodes a URL-safe Base64 string, adding padding automatically. When<br />
             summary = "Encodes a string to URL-safe Base64 (no padding).",
             example = "(encode-url \"Hello\") ; =&gt; \"SGVsbG8\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/base64.phel#L16",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/base64.phel#L15",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/registerBenchFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/registerBenchFunctions.kt
@@ -1,0 +1,65 @@
+package org.phellang.registry.data
+
+import org.phellang.registry.CompletionInfo
+import org.phellang.registry.DocumentationInfo
+import org.phellang.registry.DocumentationLinks
+import org.phellang.registry.DeprecationInfo
+import org.phellang.registry.PhelFunction
+
+import org.phellang.registry.PhelCompletionPriority
+
+internal fun registerBenchFunctions(): List<PhelFunction> = listOf(
+    PhelFunction(
+        namespace = "bench",
+        name = "bench/defbench",
+        signature = "(defbench bench-name & body)",
+        completion = CompletionInfo(
+            tailText = "Defines a benchmark function",
+            priority = PhelCompletionPriority.MACROS,
+        ),
+        documentation = DocumentationInfo(
+            summary = """
+Defines a benchmark function.<br /><br />
+The body is timed, not asserted. An optional option map may follow the name:<br />
+<code>:revs</code> (calls per measured iteration), <code>:iterations</code> (measured iterations),<br />
+<code>:warmup</code> (unmeasured iterations first). Anything omitted falls back to the<br />
+default. A run-wide option of the same name, such as a <code>phel bench --revs</code><br />
+flag, overrides what the benchmark asks for.<br /><br />
+Metadata attached to <code>bench-name</code> is forwarded to the defined function, so<br />
+<code>^:slow</code> and <code>^{:tags [:io]}</code> work here exactly as they do on <code>deftest</code>.
+""",
+            example = "(defbench bench-sum {:revs 10000}\n  (reduce + 0 (range 100)))",
+            links = DocumentationLinks(
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/bench.phel#L30",
+                docs = "",
+            ),
+        ),
+    ),
+    PhelFunction(
+        namespace = "bench",
+        name = "bench/run-benchmarks",
+        signature = "(run-benchmarks options & namespaces)",
+        completion = CompletionInfo(
+            tailText = "Runs every defbench in the given namespaces and prints a table",
+            priority = PhelCompletionPriority.CORE_FUNCTIONS,
+        ),
+        documentation = DocumentationInfo(
+            summary = """
+Runs every <code>defbench</code> in the given namespaces and prints a table.<br /><br />
+Recognized option keys: <code>:revs</code>, <code>:iterations</code>, <code>:warmup</code> (each overrides the<br />
+per-benchmark option of the same name), <code>:filter</code> (substring match against<br />
+the benchmark name), <code>:store</code> (path to write the results to as a baseline),<br />
+<code>:ref</code> (path to a stored baseline to compare against), and <code>:tolerance</code> (a<br />
+percentage; when set, a benchmark slower than its baseline by more than this<br />
+makes the run unsuccessful).<br /><br />
+Returns true when the run is within tolerance, which is always the case when no<br />
+tolerance is set.
+""",
+            example = "(run-benchmarks {:revs 100} 'my-app.bench)",
+            links = DocumentationLinks(
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/bench.phel#L285",
+                docs = "",
+            ),
+        ),
+    )
+)

--- a/src/main/kotlin/org/phellang/registry/data/registerCliFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/registerCliFunctions.kt
@@ -35,7 +35,7 @@ Two-arity convenience:<br />
 """,
             example = "(application {:name \"mytool\" :commands [spec]})",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/cli.phel#L407",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/cli.phel#L402",
                 docs = "",
             ),
         ),
@@ -52,7 +52,7 @@ Two-arity convenience:<br />
             summary = "Read (and coerce) an argument value by name.",
             example = "(arg ctx \"port\") ; coerced when spec has :coerce :int",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/cli.phel#L102",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/cli.phel#L103",
                 docs = "",
             ),
         ),
@@ -71,7 +71,7 @@ Build an <code>ArgvInput</code> from a vector of string tokens. Positional args 
 """,
             example = "(argv [\"greet\" \"--loud\" \"alice\"])",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/cli.phel#L466",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/cli.phel#L461",
                 docs = "",
             ),
         ),
@@ -90,7 +90,7 @@ Like <code>argv</code> but also wires a STDIN stream so <code>ask</code>/<code>c
 """,
             example = "(argv-with-stdin [\"greet\"] \"alice\\n\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/cli.phel#L473",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/cli.phel#L468",
                 docs = "",
             ),
         ),
@@ -109,7 +109,7 @@ Free-text prompt. <code>default</code> optional.
 """,
             example = "(ask ctx \"Your name?\" \"alice\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/cli.phel#L167",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/cli.phel#L168",
                 docs = "",
             ),
         ),
@@ -126,7 +126,7 @@ Free-text prompt. <code>default</code> optional.
             summary = "Prompt without echoing (passwords).",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/cli.phel#L174",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/cli.phel#L175",
                 docs = "",
             ),
         ),
@@ -145,7 +145,7 @@ Build a <code>BufferedOutput</code> that captures writes into a string.
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/cli.phel#L484",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/cli.phel#L479",
                 docs = "",
             ),
         ),
@@ -162,7 +162,7 @@ Build a <code>BufferedOutput</code> that captures writes into a string.
             summary = "Boxed caution message.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/cli.phel#L164",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/cli.phel#L165",
                 docs = "",
             ),
         ),
@@ -179,7 +179,7 @@ Build a <code>BufferedOutput</code> that captures writes into a string.
             summary = "Single-choice prompt over a vector of options.",
             example = "(choice ctx \"Env?\" [\"dev\" \"stg\" \"prod\"] \"dev\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/cli.phel#L186",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/cli.phel#L187",
                 docs = "",
             ),
         ),
@@ -212,7 +212,7 @@ Modes     :required :optional :array (:args) + :none :negatable (:opts)<br />
 """,
             example = "(command {:name \"greet\" :run (fn [ctx] (success ctx \"Hi!\"))})",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/cli.phel#L344",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/cli.phel#L341",
                 docs = "",
             ),
         ),
@@ -229,7 +229,7 @@ Modes     :required :optional :array (:args) + :none :negatable (:opts)<br />
             summary = "Yellow comment line.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/cli.phel#L143",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/cli.phel#L144",
                 docs = "",
             ),
         ),
@@ -248,7 +248,7 @@ Yes/no prompt. <code>default?</code> defaults to true.
 """,
             example = "(when (confirm ctx \"Deploy?\") ...)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/cli.phel#L179",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/cli.phel#L180",
                 docs = "",
             ),
         ),
@@ -265,7 +265,7 @@ Yes/no prompt. <code>default?</code> defaults to true.
             summary = "Write only when -vvv (debug).",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/cli.phel#L137",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/cli.phel#L138",
                 docs = "",
             ),
         ),
@@ -282,7 +282,7 @@ Yes/no prompt. <code>default?</code> defaults to true.
             summary = "Red error line.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/cli.phel#L144",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/cli.phel#L145",
                 docs = "",
             ),
         ),
@@ -299,7 +299,7 @@ Yes/no prompt. <code>default?</code> defaults to true.
             summary = "Green info line.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/cli.phel#L142",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/cli.phel#L143",
                 docs = "",
             ),
         ),
@@ -316,7 +316,7 @@ Yes/no prompt. <code>default?</code> defaults to true.
             summary = "Write only when -v or higher.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/cli.phel#L135",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/cli.phel#L136",
                 docs = "",
             ),
         ),
@@ -333,7 +333,7 @@ Yes/no prompt. <code>default?</code> defaults to true.
             summary = "Write only when -vv or higher.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/cli.phel#L136",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/cli.phel#L137",
                 docs = "",
             ),
         ),
@@ -350,7 +350,7 @@ Yes/no prompt. <code>default?</code> defaults to true.
             summary = "Bulleted list of items.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/cli.phel#L165",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/cli.phel#L166",
                 docs = "",
             ),
         ),
@@ -367,7 +367,7 @@ Yes/no prompt. <code>default?</code> defaults to true.
             summary = "Boxed note.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/cli.phel#L163",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/cli.phel#L164",
                 docs = "",
             ),
         ),
@@ -386,7 +386,7 @@ Build a <code>NullOutput</code> that discards writes.
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/cli.phel#L488",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/cli.phel#L483",
                 docs = "",
             ),
         ),
@@ -403,7 +403,7 @@ Build a <code>NullOutput</code> that discards writes.
             summary = "Read (and coerce) an option value by name.",
             example = "(opt ctx \"verbose\") ; true when --verbose present and :mode :none",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/cli.phel#L110",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/cli.phel#L111",
                 docs = "",
             ),
         ),
@@ -422,7 +422,7 @@ Drain a <code>BufferedOutput</code> into a string.
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/cli.phel#L492",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/cli.phel#L487",
                 docs = "",
             ),
         ),
@@ -441,7 +441,7 @@ Test helper. Accepts a <code>BufferedOutput</code>, a string, or a map <code>{:o
 """,
             example = "(is (output-contains? res \"hello\"))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/cli.phel#L497",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/cli.phel#L492",
                 docs = "",
             ),
         ),
@@ -458,7 +458,7 @@ Test helper. Accepts a <code>BufferedOutput</code>, a string, or a map <code>{:o
             summary = "Advance by n.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/cli.phel#L251",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/cli.phel#L252",
                 docs = "",
             ),
         ),
@@ -480,7 +480,7 @@ Options:<br />
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/cli.phel#L236",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/cli.phel#L237",
                 docs = "",
             ),
         ),
@@ -497,7 +497,7 @@ Options:<br />
             summary = "Finish + newline.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/cli.phel#L252",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/cli.phel#L253",
                 docs = "",
             ),
         ),
@@ -514,7 +514,7 @@ Options:<br />
             summary = "Start the bar.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/cli.phel#L250",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/cli.phel#L251",
                 docs = "",
             ),
         ),
@@ -536,7 +536,7 @@ Run an Application and return its exit code.<br /><br />
 """,
             example = "(run (application \"t\" [spec]))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/cli.phel#L448",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/cli.phel#L443",
                 docs = "",
             ),
         ),
@@ -555,7 +555,7 @@ Iterate <code>coll</code> and invoke <code>(step-fn item bar)</code> for each, h
 """,
             example = "(run-with-progress ctx files (fn [f _] (process f)))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/cli.phel#L254",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/cli.phel#L255",
                 docs = "",
             ),
         ),
@@ -572,7 +572,7 @@ Iterate <code>coll</code> and invoke <code>(step-fn item bar)</code> for each, h
             summary = "Sub-heading.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/cli.phel#L160",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/cli.phel#L161",
                 docs = "",
             ),
         ),
@@ -592,7 +592,7 @@ Return a vector of lines from STDIN (trailing <code>\r\n</code> stripped).<br />
 """,
             example = "(for [l :in (stdin-lines) :when (not= l \"\")] l)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/cli.phel#L269",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/cli.phel#L270",
                 docs = "",
             ),
         ),
@@ -610,9 +610,9 @@ Return a vector of lines from STDIN (trailing <code>\r\n</code> stripped).<br />
 Return a cached <code>SymfonyStyle</code> bound to the context so successive<br />
   <code>ask</code>/<code>confirm</code>/progress calls share state.
 """,
-            example = "(-&gt; (style ctx) (php/-&gt; (success \"Done!\")))",
+            example = "(-&gt; (style ctx) (.success \"Done!\"))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/cli.phel#L150",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/cli.phel#L151",
                 docs = "",
             ),
         ),
@@ -629,7 +629,7 @@ Return a cached <code>SymfonyStyle</code> bound to the context so successive<br 
             summary = "Boxed success message.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/cli.phel#L161",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/cli.phel#L162",
                 docs = "",
             ),
         ),
@@ -651,7 +651,7 @@ Options:<br />
 """,
             example = "(table ctx [\"id\" \"name\"] [[1 \"alice\"] [2 \"bob\"]])",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/cli.phel#L206",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/cli.phel#L207",
                 docs = "",
             ),
         ),
@@ -668,7 +668,7 @@ Options:<br />
             summary = "Heavy heading.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/cli.phel#L159",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/cli.phel#L160",
                 docs = "",
             ),
         ),
@@ -685,7 +685,7 @@ Options:<br />
             summary = "Boxed warning message.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/cli.phel#L162",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/cli.phel#L163",
                 docs = "",
             ),
         ),
@@ -702,7 +702,7 @@ Options:<br />
             summary = "Write text without trailing newline.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/cli.phel#L125",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/cli.phel#L126",
                 docs = "",
             ),
         ),
@@ -719,7 +719,7 @@ Options:<br />
             summary = "Write a line.",
             example = "(writeln ctx \"ready\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/cli.phel#L118",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/cli.phel#L119",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/registerCoreFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/registerCoreFunctions.kt
@@ -11,6 +11,7 @@ import org.phellang.registry.data.core.registerCoreDefsFunctions
 import org.phellang.registry.data.core.registerCoreExceptionsFunctions
 import org.phellang.registry.data.core.registerCoreFnsSetsFunctions
 import org.phellang.registry.data.core.registerCoreFuturesFunctions
+import org.phellang.registry.data.core.registerCoreInteropFunctions
 import org.phellang.registry.data.core.registerCoreIoFunctions
 import org.phellang.registry.data.core.registerCoreLazyFunctions
 import org.phellang.registry.data.core.registerCoreLoopsFunctions
@@ -42,6 +43,7 @@ internal fun registerCoreFunctions(): List<PhelFunction> =
         registerCoreExceptionsFunctions() +
         registerCoreFnsSetsFunctions() +
         registerCoreFuturesFunctions() +
+        registerCoreInteropFunctions() +
         registerCoreIoFunctions() +
         registerCoreLazyFunctions() +
         registerCoreLoopsFunctions() +

--- a/src/main/kotlin/org/phellang/registry/data/registerEdnFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/registerEdnFunctions.kt
@@ -28,7 +28,7 @@ Options:<br />
 """,
             example = "(read-string \"{:a 1 :b 2}\") ; =&gt; {:a 1, :b 2}\n(read-string \"\" {:eof :default}) ; =&gt; :default",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/edn.phel#L105",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/edn.phel#L105",
                 docs = "",
             ),
         ),
@@ -49,7 +49,7 @@ Options:<br />
 """,
             example = "(read-string-all \"1 2 3\") ; =&gt; [1 2 3]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/edn.phel#L123",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/edn.phel#L123",
                 docs = "",
             ),
         ),
@@ -68,7 +68,7 @@ Serialises <code>value</code> to its EDN string representation. Uses Phel's read
 """,
             example = "(write-string {:a 1}) ; =&gt; \"{:a 1}\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/edn.phel#L137",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/edn.phel#L137",
                 docs = "",
             ),
         ),
@@ -87,7 +87,7 @@ Serialises a sequence of values to EDN, separating top-level forms with a single
 """,
             example = "(write-string-all [1 2 3]) ; =&gt; \"1 2 3\"\n(write-string-all [1 \"hi\" :kw]) ; =&gt; \"1 \\\"hi\\\" :kw\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/edn.phel#L144",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/edn.phel#L144",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/registerHtmlFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/registerHtmlFunctions.kt
@@ -22,9 +22,9 @@ internal fun registerHtmlFunctions(): List<PhelFunction> = listOf(
 Returns an HTML doctype declaration for the given type. Supports <code>:html4</code>,<br />
   <code>:xhtml-strict</code>, <code>:xhtml-transitional</code>, and <code>:html5</code>. Defaults to <code>:html5</code>.
 """,
-            example = "(doctype :html5) ; =&gt; \"&lt;!DOCTYPE html&gt;\\n\"",
+            example = "(doctype :html5) ; =&gt; (phel.html.raw_string \"&lt;!DOCTYPE html&gt;\\n\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/html.phel#L175",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/html.phel#L255",
                 docs = "",
             ),
         ),
@@ -41,7 +41,7 @@ Returns an HTML doctype declaration for the given type. Supports <code>:html4</c
             summary = "Escapes HTML special characters to prevent XSS.",
             example = "(escape-html \"&lt;div&gt;\") ; =&gt; \"&amp;lt;div&amp;gt;\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/html.phel#L6",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/html.phel#L24",
                 docs = "",
             ),
         ),
@@ -64,7 +64,7 @@ Compiles nested Phel vectors to HTML strings at compile-time. A vector<br />
 """,
             example = "(html [:div \"Hello\"]) ; =&gt; \"&lt;div&gt;Hello&lt;/div&gt;\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/html.phel#L155",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/html.phel#L235",
                 docs = "",
             ),
         ),
@@ -81,7 +81,7 @@ Compiles nested Phel vectors to HTML strings at compile-time. A vector<br />
             summary = "Creates a new raw-string struct.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/html.phel#L4",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/html.phel#L4",
                 docs = "",
             ),
         ),
@@ -100,7 +100,7 @@ Checks if <code>x</code> is an instance of the raw-string struct.
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/html.phel#L4",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/html.phel#L4",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/registerHttpClientFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/registerHttpClientFunctions.kt
@@ -21,7 +21,7 @@ internal fun registerHttpClientFunctions(): List<PhelFunction> = listOf(
             summary = "Makes a DELETE request. Returns an http/response struct.",
             example = "(delete \"https://api.example.com/1\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/http-client.phel#L128",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/http-client.phel#L128",
                 docs = "",
             ),
         ),
@@ -38,7 +38,7 @@ internal fun registerHttpClientFunctions(): List<PhelFunction> = listOf(
             summary = "Makes a GET request. Returns an http/response struct.",
             example = "(get \"https://example.com\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/http-client.phel#L104",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/http-client.phel#L104",
                 docs = "",
             ),
         ),
@@ -55,7 +55,7 @@ internal fun registerHttpClientFunctions(): List<PhelFunction> = listOf(
             summary = "Makes a HEAD request. Returns an http/response struct.",
             example = "(head \"https://example.com\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/http-client.phel#L144",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/http-client.phel#L144",
                 docs = "",
             ),
         ),
@@ -72,7 +72,7 @@ internal fun registerHttpClientFunctions(): List<PhelFunction> = listOf(
             summary = "Makes a PATCH request. Returns an http/response struct.",
             example = "(patch \"https://api.example.com/1\" {:json {:name \"Charlie\"}})",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/http-client.phel#L136",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/http-client.phel#L136",
                 docs = "",
             ),
         ),
@@ -89,7 +89,7 @@ internal fun registerHttpClientFunctions(): List<PhelFunction> = listOf(
             summary = "Makes a POST request. Returns an http/response struct.",
             example = "(post \"https://api.example.com\" {:json {:name \"Alice\"}})",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/http-client.phel#L112",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/http-client.phel#L112",
                 docs = "",
             ),
         ),
@@ -106,7 +106,7 @@ internal fun registerHttpClientFunctions(): List<PhelFunction> = listOf(
             summary = "Makes a PUT request. Returns an http/response struct.",
             example = "(put \"https://api.example.com/1\" {:json {:name \"Bob\"}})",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/http-client.phel#L120",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/http-client.phel#L120",
                 docs = "",
             ),
         ),
@@ -123,7 +123,7 @@ internal fun registerHttpClientFunctions(): List<PhelFunction> = listOf(
             summary = "Makes an HTTP request. Returns an http/response struct.",
             example = "(request :get \"https://example.com\" {:headers {:accept \"application/json\"}})",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/http-client.phel#L69",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/http-client.phel#L70",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/registerHttpFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/registerHttpFunctions.kt
@@ -21,7 +21,7 @@ internal fun registerHttpFunctions(): List<PhelFunction> = listOf(
             summary = "Emits the response by sending headers and outputting the body.",
             example = "(emit-response (response-from-string \"Hello World\")) ; =&gt; nil",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/http.phel#L465",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/http.phel#L475",
                 docs = "",
             ),
         ),
@@ -40,7 +40,7 @@ Extracts uploaded files from <code>${'$'}_FILES</code> and normalizes them to up
 """,
             example = "(files-from-globals) ; =&gt; {:avatar (uploaded-file \"/tmp/phpYzdqkD\" 1024 0 \"photo.jpg\" \"image/jpeg\")}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/http.phel#L151",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/http.phel#L152",
                 docs = "",
             ),
         ),
@@ -59,7 +59,7 @@ Extracts all HTTP headers from the <code>${'$'}<em>SERVER</code> variable. Strip
 """,
             example = "(headers-from-server) ; =&gt; {:host \"example.com\" :content-type \"application/json\"}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/http.phel#L162",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/http.phel#L163",
                 docs = "",
             ),
         ),
@@ -77,9 +77,9 @@ Extracts all HTTP headers from the <code>${'$'}<em>SERVER</code> variable. Strip
 Creates a response with <code>status</code> and an HTML <code>body</code> and a<br />
   <code>Content-Type: text/html; charset=utf-8</code> header.
 """,
-            example = "(html-response 200 \"&lt;h1&gt;Hi&lt;/h1&gt;\") ; =&gt; (response 200 {:content-type \"text/html; charset=utf-8\"} \"&lt;h1&gt;Hi&lt;/h1&gt;\" \"1.1\" \"OK\")",
+            example = "(html-response 200 \"&lt;h1&gt;Hi&lt;/h1&gt;\") ; =&gt; (phel.http.response 200 {:content-type \"text/html; charset=utf-8\"} \"&lt;h1&gt;Hi&lt;/h1&gt;\" \"1.1\" \"OK\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/http.phel#L416",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/http.phel#L426",
                 docs = "",
             ),
         ),
@@ -97,9 +97,9 @@ Creates a response with <code>status</code> and an HTML <code>body</code> and a<
 Creates a response with <code>status</code> and a JSON-encoded <code>data</code> body and a<br />
   <code>Content-Type: application/json</code> header.
 """,
-            example = "(json-response 200 {:message \"pong\"}) ; =&gt; (response 200 {:content-type \"application/json\"} \"{\\\"message\\\":\\\"pong\\\"}\" \"1.1\" \"OK\")",
+            example = "(json-response 200 {:message \"pong\"}) ; =&gt; (phel.http.response 200 {:content-type \"application/json\"} \"{\\\"message\\\":\\\"pong\\\"}\" \"1.1\" \"OK\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/http.phel#L405",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/http.phel#L415",
                 docs = "",
             ),
         ),
@@ -116,7 +116,7 @@ Creates a response with <code>status</code> and a JSON-encoded <code>data</code>
             summary = "Creates a new request struct.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/http.phel#L188",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/http.phel#L194",
                 docs = "",
             ),
         ),
@@ -133,9 +133,9 @@ Creates a response with <code>status</code> and a JSON-encoded <code>data</code>
             summary = """
 Extracts a request from <code>${'$'}_SERVER</code>, <code>${'$'}_GET</code>, <code>${'$'}_POST</code>, <code>${'$'}_COOKIE</code>, <code>${'$'}_FILES</code> and, for JSON requests, the raw request body (<code>php://input</code>). Requires a web request context (PHP-FPM, mod_php, or <code>php -S</code>); it cannot be used from the REPL or a CLI script - use <code>request-from-map</code> for testing.
 """,
-            example = "(request-from-globals) ; =&gt; (request \"GET\" (uri ...) {...} nil {...} {...} {...} {...} \"1.1\" {})",
+            example = "(request-from-globals) ; =&gt; (phel.http.request \"GET\" (phel.http.uri ...) {...} nil {...} {...} {...} {...} \"1.1\" {})",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/http.phel#L272",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/http.phel#L282",
                 docs = "",
             ),
         ),
@@ -154,9 +154,9 @@ Extracts a request from args. The optional <code>raw-body</code> (the raw reques
   string) is decoded into <code>:parsed-body</code> when the <code>Content-Type</code> is<br />
   <code>application/json</code>; form bodies still come from <code>post-parameter</code>.
 """,
-            example = "(request-from-globals-args php/\$_SERVER php/\$_GET php/\$_POST php/\$_COOKIE php/\$_FILES (php/file_get_contents \"php://input\")) ; =&gt; (request \"GET\" (uri ...) {...} nil {...} {...} {...} {...} \"1.1\" {})",
+            example = "(request-from-globals-args php/\$_SERVER php/\$_GET php/\$_POST php/\$_COOKIE php/\$_FILES (php/file_get_contents \"php://input\")) ; =&gt; (phel.http.request \"GET\" (phel.http.uri ...) {...} nil {...} {...} {...} {...} \"1.1\" {})",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/http.phel#L237",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/http.phel#L247",
                 docs = "",
             ),
         ),
@@ -177,9 +177,9 @@ Creates a request struct from a map. Supports the optional keys <code>:method</c
   <code>:server-params</code>, <code>:uploaded-files</code>, <code>:version</code>, and <code>:attributes</code>. Missing<br />
   keys default to nil, <code>{}</code>, <code>[]</code>, or <code>"1.1"</code> as appropriate.
 """,
-            example = "(request-from-map {:method \"POST\" :uri \"https://api.example.com/users\"}) ; =&gt; (request \"POST\" (uri ...) {} nil {} {} {} [] \"1.1\" {})",
+            example = "(request-from-map {:method \"POST\" :uri \"https://api.example.com/users\"}) ; =&gt; (phel.http.request \"POST\" (phel.http.uri \"https\" nil \"api.example.com\" nil \"/users\" nil nil) {} nil {} {} {} [] \"1.1\" {})",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/http.phel#L280",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/http.phel#L290",
                 docs = "",
             ),
         ),
@@ -198,7 +198,7 @@ Checks if <code>x</code> is an instance of the request struct.
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/http.phel#L188",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/http.phel#L194",
                 docs = "",
             ),
         ),
@@ -215,7 +215,7 @@ Checks if <code>x</code> is an instance of the request struct.
             summary = "Creates a new response struct.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/http.phel#L318",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/http.phel#L328",
                 docs = "",
             ),
         ),
@@ -234,9 +234,9 @@ Creates a response struct from a map. Optional keys: <code>:status</code> (defau
   200), <code>:headers</code> (<code>{}</code>), <code>:body</code> (<code>""</code>), <code>:version</code> (<code>"1.1"</code>), and<br />
   <code>:reason</code> (auto-filled from the HTTP status code when omitted).
 """,
-            example = "(response-from-map {:status 200 :body \"Hello World\"}) ; =&gt; (response 200 {} \"Hello World\" \"1.1\" \"OK\")",
+            example = "(response-from-map {:status 200 :body \"Hello World\"}) ; =&gt; (phel.http.response 200 {} \"Hello World\" \"1.1\" \"OK\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/http.phel#L383",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/http.phel#L393",
                 docs = "",
             ),
         ),
@@ -254,9 +254,9 @@ Creates a response struct from a map. Optional keys: <code>:status</code> (defau
 Creates a 200 OK response with the given body string. Shorthand for<br />
   <code>(response-from-map {:body s})</code>.
 """,
-            example = "(response-from-string \"Hello World\") ; =&gt; (response 200 {} \"Hello World\" \"1.1\" \"OK\")",
+            example = "(response-from-string \"Hello World\") ; =&gt; (phel.http.response 200 {} \"Hello World\" \"1.1\" \"OK\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/http.phel#L397",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/http.phel#L407",
                 docs = "",
             ),
         ),
@@ -275,7 +275,7 @@ Checks if <code>x</code> is an instance of the response struct.
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/http.phel#L318",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/http.phel#L328",
                 docs = "",
             ),
         ),
@@ -292,7 +292,7 @@ Checks if <code>x</code> is an instance of the response struct.
             summary = "Creates a new uploaded-file struct.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/http.phel#L111",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/http.phel#L112",
                 docs = "",
             ),
         ),
@@ -311,7 +311,7 @@ Checks if <code>x</code> is an instance of the uploaded-file struct.
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/http.phel#L111",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/http.phel#L112",
                 docs = "",
             ),
         ),
@@ -328,7 +328,7 @@ Checks if <code>x</code> is an instance of the uploaded-file struct.
             summary = "Creates a new uri struct.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/http.phel#L10",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/http.phel#L11",
                 docs = "",
             ),
         ),
@@ -348,9 +348,9 @@ Extracts the URI from the <code>${'$'}_SERVER</code> variable. The scheme is rea
   <code>REQUEST_URI</code>; and the host/port via the <code>${'$'}_SERVER</code> host fields. Returns a<br />
   uri struct.
 """,
-            example = "(uri-from-globals) ; =&gt; (uri \"https\" nil \"example.com\" 443 \"/path\" \"foo=bar\" nil)",
+            example = "(uri-from-globals) ; =&gt; (phel.http.uri \"https\" nil \"example.com\" 443 \"/path\" \"foo=bar\" nil)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/http.phel#L54",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/http.phel#L55",
                 docs = "",
             ),
         ),
@@ -367,9 +367,9 @@ Extracts the URI from the <code>${'$'}_SERVER</code> variable. The scheme is rea
             summary = """
 Parses a URI string into a uri struct. Handles UTF-8 URLs and IPv6 addresses in brackets. Throws <code>InvalidArgumentException</code> on a malformed string.
 """,
-            example = "(uri-from-string \"https://example.com/path?foo=bar\") ; =&gt; (uri \"https\" nil \"example.com\" nil \"/path\" \"foo=bar\" nil)",
+            example = "(uri-from-string \"https://example.com/path?foo=bar\") ; =&gt; (phel.http.uri \"https\" nil \"example.com\" nil \"/path\" \"foo=bar\" nil)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/http.phel#L82",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/http.phel#L83",
                 docs = "",
             ),
         ),
@@ -388,7 +388,7 @@ Checks if <code>x</code> is an instance of the uri struct.
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/http.phel#L10",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/http.phel#L11",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/registerJsonFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/registerJsonFunctions.kt
@@ -12,7 +12,7 @@ internal fun registerJsonFunctions(): List<PhelFunction> = listOf(
     PhelFunction(
         namespace = "json",
         name = "json/decode",
-        signature = "(decode json & [{:flags flags, :depth depth}])",
+        signature = "(decode json)\n(decode json {:flags flags, :depth depth})",
         completion = CompletionInfo(
             tailText = "Decodes a JSON string to a Phel value",
             priority = PhelCompletionPriority.JSON_FUNCTIONS,
@@ -21,7 +21,7 @@ internal fun registerJsonFunctions(): List<PhelFunction> = listOf(
             summary = "Decodes a JSON string to a Phel value.",
             example = "(decode \"{\\\"name\\\":\\\"Alice\\\"}\") ; =&gt; {:name \"Alice\"}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/json.phel#L71",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/json.phel#L80",
                 docs = "",
             ),
         ),
@@ -38,7 +38,7 @@ internal fun registerJsonFunctions(): List<PhelFunction> = listOf(
             summary = "Converts a JSON value to Phel format.",
             example = "(decode-value [1 2 3]) ; =&gt; [1 2 3]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/json.phel#L55",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/json.phel#L64",
                 docs = "",
             ),
         ),
@@ -46,7 +46,7 @@ internal fun registerJsonFunctions(): List<PhelFunction> = listOf(
     PhelFunction(
         namespace = "json",
         name = "json/encode",
-        signature = "(encode value & [{:flags flags, :depth depth}])",
+        signature = "(encode value)\n(encode value {:flags flags, :depth depth})",
         completion = CompletionInfo(
             tailText = "Encodes a Phel value to a JSON string",
             priority = PhelCompletionPriority.JSON_FUNCTIONS,
@@ -55,7 +55,7 @@ internal fun registerJsonFunctions(): List<PhelFunction> = listOf(
             summary = "Encodes a Phel value to a JSON string.",
             example = "(encode {:name \"Alice\"}) ; =&gt; \"{\\\"name\\\":\\\"Alice\\\"}\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/json.phel#L43",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/json.phel#L45",
                 docs = "",
             ),
         ),
@@ -72,7 +72,7 @@ internal fun registerJsonFunctions(): List<PhelFunction> = listOf(
             summary = "Converts a Phel value to JSON-compatible format.",
             example = "(encode-value :name) ; =&gt; \"name\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/json.phel#L29",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/json.phel#L31",
                 docs = "",
             ),
         ),
@@ -89,7 +89,7 @@ internal fun registerJsonFunctions(): List<PhelFunction> = listOf(
             summary = "Checks if a value can be used as a JSON key.",
             example = "(valid-key? :name) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/json.phel#L4",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/json.phel#L4",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/registerMatchFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/registerMatchFunctions.kt
@@ -21,7 +21,7 @@ internal fun registerMatchFunctions(): List<PhelFunction> = listOf(
             summary = "Pattern matching over a vector of targets.",
             example = "(match [x y] [0 _] :zero-x [_ 0] :zero-y [a b] [:both a b])",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/match.phel#L280",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/match.phel#L280",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/registerMockFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/registerMockFunctions.kt
@@ -21,7 +21,7 @@ internal fun registerMockFunctions(): List<PhelFunction> = listOf(
             summary = "Returns the number of times the mock was called.",
             example = "(def my-mock (mock :result))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/mock.phel#L107",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/mock.phel#L107",
                 docs = "",
             ),
         ),
@@ -38,7 +38,7 @@ internal fun registerMockFunctions(): List<PhelFunction> = listOf(
             summary = "Returns true if the mock was called exactly once.",
             example = "(def my-mock (mock :result))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/mock.phel#L126",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/mock.phel#L126",
                 docs = "",
             ),
         ),
@@ -55,7 +55,7 @@ internal fun registerMockFunctions(): List<PhelFunction> = listOf(
             summary = "Returns true if the mock was called exactly n times.",
             example = "(def my-mock (mock :result))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/mock.phel#L132",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/mock.phel#L132",
                 docs = "",
             ),
         ),
@@ -72,7 +72,7 @@ internal fun registerMockFunctions(): List<PhelFunction> = listOf(
             summary = "Returns true if the mock was called with the exact arguments.",
             example = "(def my-mock (mock :result))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/mock.phel#L119",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/mock.phel#L119",
                 docs = "",
             ),
         ),
@@ -89,7 +89,7 @@ internal fun registerMockFunctions(): List<PhelFunction> = listOf(
             summary = "Returns true if the mock was called at least once.",
             example = "(def my-mock (mock :result))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/mock.phel#L113",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/mock.phel#L113",
                 docs = "",
             ),
         ),
@@ -106,7 +106,7 @@ internal fun registerMockFunctions(): List<PhelFunction> = listOf(
             summary = "Returns a list of all argument lists the mock was called with.",
             example = "(def my-mock (mock :result))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/mock.phel#L98",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/mock.phel#L98",
                 docs = "",
             ),
         ),
@@ -125,7 +125,7 @@ Clears the entire mock registry. Useful for cleanup between test suites in long-
 """,
             example = "(clear-all-mocks!) ; All mocks removed from registry",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/mock.phel#L168",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/mock.phel#L168",
                 docs = "",
             ),
         ),
@@ -142,7 +142,7 @@ Clears the entire mock registry. Useful for cleanup between test suites in long-
             summary = "Returns the arguments from the first call.",
             example = "(def my-mock (mock :result))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/mock.phel#L150",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/mock.phel#L150",
                 docs = "",
             ),
         ),
@@ -159,7 +159,7 @@ Clears the entire mock registry. Useful for cleanup between test suites in long-
             summary = "Returns the arguments from the most recent call.",
             example = "(def my-mock (mock :result))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/mock.phel#L144",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/mock.phel#L144",
                 docs = "",
             ),
         ),
@@ -176,7 +176,7 @@ Clears the entire mock registry. Useful for cleanup between test suites in long-
             summary = "Creates a mock function that returns a fixed value and tracks all calls.",
             example = "(def my-mock (mock :return-value))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/mock.phel#L30",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/mock.phel#L30",
                 docs = "",
             ),
         ),
@@ -193,7 +193,7 @@ Clears the entire mock registry. Useful for cleanup between test suites in long-
             summary = "Creates a mock function with custom behavior that tracks all calls.",
             example = "(def my-mock (mock-fn (fn [x] (* x 2))))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/mock.phel#L41",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/mock.phel#L41",
                 docs = "",
             ),
         ),
@@ -212,7 +212,7 @@ Creates a mock that returns different values for consecutive calls. After exhaus
 """,
             example = "(def my-mock (mock-returning [1 2 3]))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/mock.phel#L59",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/mock.phel#L59",
                 docs = "",
             ),
         ),
@@ -227,9 +227,9 @@ Creates a mock that returns different values for consecutive calls. After exhaus
         ),
         documentation = DocumentationInfo(
             summary = "Creates a mock that throws an exception when called.",
-            example = "(def my-mock (mock-throwing (php/new \\RuntimeException \"API unavailable\")))",
+            example = "(def my-mock (mock-throwing (new RuntimeException \"API unavailable\")))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/mock.phel#L78",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/mock.phel#L78",
                 docs = "",
             ),
         ),
@@ -246,7 +246,7 @@ Creates a mock that returns different values for consecutive calls. After exhaus
             summary = "Returns true if the function is a mock.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/mock.phel#L93",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/mock.phel#L93",
                 docs = "",
             ),
         ),
@@ -263,7 +263,7 @@ Creates a mock that returns different values for consecutive calls. After exhaus
             summary = "Returns true if the mock was never called.",
             example = "(def my-mock (mock :result))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/mock.phel#L138",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/mock.phel#L138",
                 docs = "",
             ),
         ),
@@ -282,7 +282,7 @@ Resets the call history of a mock without removing it from the registry. The moc
 """,
             example = "(def my-mock (mock :result))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/mock.phel#L156",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/mock.phel#L156",
                 docs = "",
             ),
         ),
@@ -301,7 +301,7 @@ Wraps an existing function to track calls while preserving original behavior. Al
 """,
             example = "(def original-fn (fn [x] (* x 2)))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/mock.phel#L52",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/mock.phel#L52",
                 docs = "",
             ),
         ),
@@ -332,7 +332,7 @@ Multiple wrappers:<br />
 """,
             example = "(with-mock-wrapper [http mock-http identity] (http \"test\"))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/mock.phel#L214",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/mock.phel#L214",
                 docs = "",
             ),
         ),
@@ -371,7 +371,7 @@ If you need to wrap the mock in a function (e.g., to adapt arguments),<br />
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/mock.phel#L178",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/mock.phel#L178",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/registerPhpInteropFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/registerPhpInteropFunctions.kt
@@ -14,12 +14,14 @@ internal fun registerPhpInteropFunctions(): List<PhelFunction> = listOf(
         name = "php/->",
         signature = "(php/-> object call*)\n(php/:: class call*)",
         completion = CompletionInfo(
-            tailText = "Access to an object property or result of chained calls",
+            tailText = "Deprecated",
             priority = PhelCompletionPriority.SPECIAL_FORMS,
         ),
         documentation = DocumentationInfo(
-            summary = "Access to an object property or result of chained calls.",
-            example = "(php/-&gt; date (format \"Y-m-d\"))",
+            summary = """
+Deprecated. Reaches an instance member; write <code>(.method obj arg)</code> or <code>(.-field obj)</code> instead.
+""",
+            example = "(.format date \"Y-m-d\")",
             links = DocumentationLinks(
                 github = "",
                 docs = "/documentation/php-interop/#php-set-object-properties",
@@ -31,14 +33,14 @@ internal fun registerPhpInteropFunctions(): List<PhelFunction> = listOf(
         name = "php/::",
         signature = "(php/:: class (method-name expr*))\n(php/:: class call*)",
         completion = CompletionInfo(
-            tailText = "Calls a static method or property from a PHP class",
+            tailText = "Deprecated",
             priority = PhelCompletionPriority.SPECIAL_FORMS,
         ),
         documentation = DocumentationInfo(
             summary = """
-Calls a static method or property from a PHP class. Both method-name and property must be symbols and cannot be an evaluated value.
+Deprecated. Reaches a static member; write <code>(Foo/method arg)</code> or <code>Foo/CONST</code> instead.
 """,
-            example = "(php/:: DateTime (createFromFormat \"Y-m-d\" \"2024-01-01\"))",
+            example = "(DateTime/createFromFormat \"Y-m-d\" \"2024-01-01\")",
             links = DocumentationLinks(
                 github = "",
                 docs = "/documentation/php-interop/#php-static-method-and-property-call",
@@ -219,14 +221,14 @@ Builds a native PHP first-class callable from a function or method, without an f
         name = "php/new",
         signature = "(php/new expr args*)",
         completion = CompletionInfo(
-            tailText = "Evaluates expr and creates a new PHP class using the arguments",
+            tailText = "Deprecated",
             priority = PhelCompletionPriority.SPECIAL_FORMS,
         ),
         documentation = DocumentationInfo(
             summary = """
-Evaluates expr and creates a new PHP class using the arguments. The instance of the class is returned.
+Deprecated. Creates a PHP object; write <code>(new Foo arg)</code> instead.
 """,
-            example = "(php/new DateTime \"2024-01-01\")",
+            example = "(new DateTime \"2024-01-01\")",
             links = DocumentationLinks(
                 github = "",
                 docs = "/documentation/php-interop/#php-class-instantiation",
@@ -236,16 +238,16 @@ Evaluates expr and creates a new PHP class using the arguments. The instance of 
     PhelFunction(
         namespace = "php",
         name = "php/oset",
-        signature = "(php/oset (php/-> object property) value)\n(php/oset (php/:: class property) value)",
+        signature = "(php/oset (.-property object) value)\n(php/oset (php/:: class property) value)",
         completion = CompletionInfo(
-            tailText = "Use php/oset to set a value to a class/object property",
+            tailText = "Sets a class/object property",
             priority = PhelCompletionPriority.SPECIAL_FORMS,
         ),
         documentation = DocumentationInfo(
             summary = """
-Use <code>php/oset</code> to set a value to a class/object property.
+Sets a class/object property. <code>set!</code> is the top-level name for the same thing.
 """,
-            example = "(php/oset (php/-&gt; obj name) \"Alice\")",
+            example = "(php/oset (.-name obj) \"Alice\")",
             links = DocumentationLinks(
                 github = "",
                 docs = "/documentation/php-interop/#php-set-object-properties",
@@ -262,7 +264,7 @@ Use <code>php/oset</code> to set a value to a class/object property.
         ),
         documentation = DocumentationInfo(
             summary = "Passes a local variable by reference into a PHP interop call.",
-            example = "(php/-&gt; stmt (bindColumn 1 (php/ref out)))",
+            example = "(.bindColumn stmt 1 (php/ref out))",
             links = DocumentationLinks(
                 github = "",
                 docs = "/documentation/php-interop/",

--- a/src/main/kotlin/org/phellang/registry/data/registerPprintFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/registerPprintFunctions.kt
@@ -23,7 +23,7 @@ Pretty-print a value for humans (colored when stdout is a terminal) and return i
 """,
             example = "(-&gt; {:a [1 2 3]} inspect (get :a))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/pprint.phel#L119",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/pprint.phel#L97",
                 docs = "",
             ),
         ),
@@ -40,7 +40,7 @@ Pretty-print a value for humans (colored when stdout is a terminal) and return i
             summary = "Pretty-print a data structure to stdout with line breaks and indentation.",
             example = "(pprint {:a [1 2 3] :b {:c 4 :d 5}})",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/pprint.phel#L100",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/pprint.phel#L78",
                 docs = "",
             ),
         ),
@@ -57,7 +57,7 @@ Pretty-print a value for humans (colored when stdout is a terminal) and return i
             summary = "Pretty-print a data structure to a string with line breaks and indentation.",
             example = "(pprint-str {:a [1 2 3] :b {:c 4 :d 5}})",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/pprint.phel#L91",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/pprint.phel#L69",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/registerReaderFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/registerReaderFunctions.kt
@@ -24,7 +24,7 @@ Re-registering an existing tag overwrites the previous handler.
 """,
             example = "(register-tag \"date\" my-ns/parse-date)\n  ; later: #date \"2026-04-20\" =&gt; (my-ns/parse-date \"2026-04-20\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/reader.phel#L19",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/reader.phel#L19",
                 docs = "",
             ),
         ),
@@ -41,7 +41,7 @@ Re-registering an existing tag overwrites the previous handler.
             summary = "Returns a sorted vector of the currently registered reader tag names.",
             example = "(registered-tags) ; =&gt; [\"inst\" \"regex\" \"uuid\"]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/reader.phel#L45",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/reader.phel#L45",
                 docs = "",
             ),
         ),
@@ -60,7 +60,7 @@ Returns true if a handler is registered for reader tag <code>tag-name</code>.
 """,
             example = "(tag-registered? \"inst\") ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/reader.phel#L30",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/reader.phel#L30",
                 docs = "",
             ),
         ),
@@ -79,7 +79,7 @@ Removes any handler registered for reader tag <code>tag-name</code>. Built-in ta
 """,
             example = "(unregister-tag \"date\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/reader.phel#L37",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/reader.phel#L37",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/registerReflectFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/registerReflectFunctions.kt
@@ -23,7 +23,7 @@ Returns the class-level attribute maps for <code>obj-or-class</code>; an instanc
 """,
             example = "(attributes my-controller)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/reflect.phel#L117",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/reflect.phel#L117",
                 docs = "",
             ),
         ),
@@ -40,9 +40,9 @@ Returns the class-level attribute maps for <code>obj-or-class</code>; an instanc
             summary = """
 Returns a vector of attribute maps for the class <code>class-or-name</code> (string FQN or object). Each map is <code>{:name <attribute-fqcn> :args {...}}</code>, where <code>:args</code> keys named arguments as keywords and positional arguments by index.
 """,
-            example = "(class-attributes \\App\\Controller\\ProductController)",
+            example = "(class-attributes App.Controller.ProductController)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/reflect.phel#L96",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/reflect.phel#L96",
                 docs = "",
             ),
         ),
@@ -60,9 +60,9 @@ Returns a vector of attribute maps for the class <code>class-or-name</code> (str
 Returns a map describing <code>class-or-name</code> with <code>:name</code>, <code>:methods</code>,<br />
   <code>:properties</code>, <code>:parents</code>, and <code>:interfaces</code> keys.
 """,
-            example = "(class-info \\DateTime)",
+            example = "(class-info DateTime)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/reflect.phel#L124",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/reflect.phel#L124",
                 docs = "",
             ),
         ),
@@ -82,7 +82,7 @@ Returns the keyword for a native PHP enum <code>enum-case</code>, using the case
 """,
             example = "(enum-&gt;keyword Status/Active)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/reflect.phel#L147",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/reflect.phel#L147",
                 docs = "",
             ),
         ),
@@ -100,9 +100,9 @@ Returns the keyword for a native PHP enum <code>enum-case</code>, using the case
 Returns a vector of keywords, one per case of the native PHP enum<br />
   <code>enum-class</code> (string FQN), in declaration order.
 """,
-            example = "(enum-values \\App\\Status)",
+            example = "(enum-values App.Status)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/reflect.phel#L164",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/reflect.phel#L164",
                 docs = "",
             ),
         ),
@@ -119,9 +119,9 @@ Returns a vector of keywords, one per case of the native PHP enum<br />
             summary = """
 Returns the case of the native PHP enum <code>enum-class</code> (string FQN) whose name matches keyword <code>kw</code>, or nil when no case matches. Inverse of <code>enum->keyword</code>.
 """,
-            example = "(keyword-&gt;enum \\App\\Status :Active)",
+            example = "(keyword-&gt;enum App.Status :Active)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/reflect.phel#L155",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/reflect.phel#L155",
                 docs = "",
             ),
         ),
@@ -138,9 +138,9 @@ Returns the case of the native PHP enum <code>enum-class</code> (string FQN) who
             summary = """
 Returns a vector of attribute maps for method <code>method-name</code> on <code>class-or-name</code>.
 """,
-            example = "(method-attributes \\App\\Foo \"handle\")",
+            example = "(method-attributes App.Foo \"handle\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/reflect.phel#L103",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/reflect.phel#L103",
                 docs = "",
             ),
         ),
@@ -160,7 +160,7 @@ Returns a vector of method maps for <code>class-or-name</code>. Each map contain
 """,
             example = "(methods DateTime)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/reflect.phel#L46",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/reflect.phel#L46",
                 docs = "",
             ),
         ),
@@ -178,9 +178,9 @@ Returns a vector of method maps for <code>class-or-name</code>. Each map contain
 Returns a vector of property maps for <code>class-or-name</code>. Each map contains<br />
   <code>:name</code>, <code>:type</code>, <code>:static?</code>, <code>:readonly?</code>, and <code>:visibility</code>.
 """,
-            example = "(properties \\DateInterval)",
+            example = "(properties DateInterval)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/reflect.phel#L55",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/reflect.phel#L55",
                 docs = "",
             ),
         ),
@@ -197,9 +197,9 @@ Returns a vector of property maps for <code>class-or-name</code>. Each map conta
             summary = """
 Returns a vector of attribute maps for property <code>property-name</code> on <code>class-or-name</code>.
 """,
-            example = "(property-attributes \\App\\Foo \"id\")",
+            example = "(property-attributes App.Foo \"id\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/reflect.phel#L110",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/reflect.phel#L110",
                 docs = "",
             ),
         ),
@@ -216,9 +216,9 @@ Returns a vector of attribute maps for property <code>property-name</code> on <c
             summary = """
 Returns a set of fully qualified parent classes and implemented interfaces for <code>class-or-name</code>.
 """,
-            example = "(supers \\RuntimeException)",
+            example = "(supers RuntimeException)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/reflect.phel#L64",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/reflect.phel#L64",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/registerReplFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/registerReplFunctions.kt
@@ -23,7 +23,7 @@ Returns a vector of symbols whose name contains the given search string. Searche
 """,
             example = "(apropos \"map\") ; =&gt; [phel.core/flat-map phel.core/map ...]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L313",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L319",
                 docs = "",
             ),
         ),
@@ -33,14 +33,17 @@ Returns a vector of symbols whose name contains the given search string. Searche
         name = "repl/compile-str",
         signature = "(compile-str s)",
         completion = CompletionInfo(
-            tailText = "Compiles a Phel expression string to PHP code",
+            tailText = "Compiles a Phel expression string to PHP code and returns it, without evaluating it",
             priority = PhelCompletionPriority.REPL_FUNCTIONS,
         ),
         documentation = DocumentationInfo(
-            summary = "Compiles a Phel expression string to PHP code.",
-            example = "(compile-str \"(+ 1 2)\") ; =&gt; \"(1 + 2)\"",
+            summary = """
+Compiles a Phel expression string to PHP code and returns it, without evaluating it.<br /><br />
+Compilation happens in expression context, so a bare top-level expression yields the PHP it reduces to rather than the empty string a statement-context compile would produce for a value nobody binds. Constant folding still applies, so <code>(+ 1 2)</code> compiles to <code>3</code>. Use <code>eval-str</code> to run the code instead of reading it.
+""",
+            example = "(compile-str \"(+ 1 2)\") ; =&gt; \"3\"\n(compile-str \"[1 2 3]\") ; =&gt; \"\\\\Phel::vector([1, 2, 3])\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L209",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L208",
                 docs = "",
             ),
         ),
@@ -59,7 +62,7 @@ Creates the given namespace if it does not already exist. Returns the namespace 
 """,
             example = "(create-ns \"my-app.tmp\") ; =&gt; \"my-app.tmp\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L396",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L402",
                 docs = "",
             ),
         ),
@@ -79,7 +82,7 @@ Returns nil. Prints one name per line, sorted alphabetically.
 """,
             example = "(dir phel\\string)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L303",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L309",
                 docs = "",
             ),
         ),
@@ -96,7 +99,7 @@ Returns nil. Prints one name per line, sorted alphabetically.
             summary = "Prints the documentation for the given symbol.",
             example = "(doc map)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L84",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L84",
                 docs = "",
             ),
         ),
@@ -113,7 +116,7 @@ Returns nil. Prints one name per line, sorted alphabetically.
             summary = "Builds a searchable index of public functions in a namespace.",
             example = "(embed-ns \"phel\\core\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L827",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L835",
                 docs = "",
             ),
         ),
@@ -134,9 +137,9 @@ Evaluates a string of Phel code while capturing stdout. Returns a hash-map<br />
 Useful for nREPL and other tooling that needs to separate printed output from<br />
   return values.
 """,
-            example = "(eval-capturing \"(do (println \\\"hello\\\") 42)\") ; =&gt; {:value 42 :out \"hello\\n\" :success true :error nil}",
+            example = "(eval-capturing \"(do (println \\\"hello\\\") 42)\") ; =&gt; {:value 42, :out \"hello\\n\", :success true, :error nil}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L504",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L510",
                 docs = "",
             ),
         ),
@@ -155,7 +158,7 @@ Evaluates a string of Phel code and returns the result. If the string contains m
 """,
             example = "(eval-str \"(+ 1 2)\") ; =&gt; 3",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L218",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L224",
                 docs = "",
             ),
         ),
@@ -172,7 +175,7 @@ Evaluates a string of Phel code and returns the result. If the string contains m
             summary = "Explains a Phel expression using AI and REPL introspection.",
             example = "(explain \"(map inc [1 2 3])\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L751",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L759",
                 docs = "",
             ),
         ),
@@ -189,7 +192,7 @@ Evaluates a string of Phel code and returns the result. If the string contains m
             summary = "Explains a symbol using AI with source code and docs as context.",
             example = "(explain-sym map)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L771",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L779",
                 docs = "",
             ),
         ),
@@ -208,7 +211,7 @@ Searches for functions whose name or docstring contains the search string. Retur
 """,
             example = "(find-fn \"map\") ; =&gt; [{:ns \"phel.core\" :name \"map\" ...} ...]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L331",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L337",
                 docs = "",
             ),
         ),
@@ -227,7 +230,7 @@ Returns the namespace name in display form if it is loaded, or nil if no namespa
 """,
             example = "(find-ns \"phel.core\") ; =&gt; \"phel.core\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L387",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L393",
                 docs = "",
             ),
         ),
@@ -244,7 +247,7 @@ Returns the namespace name in display form if it is loaded, or nil if no namespa
             summary = "Suggests a fix for Phel code that produced an error.",
             example = "(fix \"(+ 1 \\\"a\\\")\" \"Cannot add string to integer\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L798",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L806",
                 docs = "",
             ),
         ),
@@ -263,7 +266,7 @@ Returns the source code of the definition identified by namespace and name strin
 """,
             example = "(get-source-code \"phel\\core\" \"map\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L362",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L368",
                 docs = "",
             ),
         ),
@@ -285,7 +288,7 @@ Keys: :doc, :file, :line, :column, :end-line, :end-column, :private,<br />
 """,
             example = "(get-symbol-info \"phel\\core\" \"map\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L243",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L249",
                 docs = "",
             ),
         ),
@@ -304,7 +307,7 @@ Finds or creates a definition named by name-str in namespace ns-str, setting its
 """,
             example = "(intern \"user\" \"x\" 42) ; =&gt; user/x",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L413",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L419",
                 docs = "",
             ),
         ),
@@ -323,7 +326,7 @@ Loads and evaluates a Phel source file in the current REPL session. Reads the fi
 """,
             example = "(load-file \"src/my-module.phel\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L227",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L233",
                 docs = "",
             ),
         ),
@@ -342,7 +345,7 @@ Returns all namespaces currently loaded in the REPL, in dot-separated display fo
 """,
             example = "(loaded-namespaces) ; =&gt; [\"phel.core\" \"phel.repl\"]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L26",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L26",
                 docs = "",
             ),
         ),
@@ -361,7 +364,7 @@ Recursively expands the given form until it is no longer a macro call. The form 
 """,
             example = "(macroexpand '(when true 1 2))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L710",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L718",
                 docs = "",
             ),
         ),
@@ -380,7 +383,7 @@ Expands the given form once if it is a macro call. The form must be quoted to pr
 """,
             example = "(macroexpand-1 '(when true 1 2))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L703",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L711",
                 docs = "",
             ),
         ),
@@ -399,7 +402,7 @@ Expands the given form once if it is a macro call. Takes a quoted form and retur
 """,
             example = "(macroexpand-1-form '(defn foo [x] x))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L687",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L695",
                 docs = "",
             ),
         ),
@@ -418,7 +421,7 @@ Recursively expands the given form until it is no longer a macro call. Takes a q
 """,
             example = "(macroexpand-form '(defn foo [x] x))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L695",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L703",
                 docs = "",
             ),
         ),
@@ -438,7 +441,7 @@ Returns a hash-map of {alias => namespace} for all require aliases in the<br />
 """,
             example = "(ns-aliases *ns*) ; =&gt; {\"repl\" \"phel.repl\" ...}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L455",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L461",
                 docs = "",
             ),
         ),
@@ -459,7 +462,7 @@ Returns a hash-map of {name => value} for every definition in the<br />
 """,
             example = "(ns-interns \"phel\\core\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L425",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L431",
                 docs = "",
             ),
         ),
@@ -476,7 +479,7 @@ Returns a hash-map of {name => value} for every definition in the<br />
             summary = "Returns a sorted vector of all loaded namespace names in display form.",
             example = "(ns-list) ; =&gt; [\"phel.core\" \"phel.repl\" ...]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L37",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L37",
                 docs = "",
             ),
         ),
@@ -496,7 +499,7 @@ Returns a hash-map of {name => value} for all public definitions in the<br />
 """,
             example = "(ns-publics \"phel\\core\") ; =&gt; {\"map\" &lt;fn&gt; \"filter\" &lt;fn&gt; ...}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L439",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L445",
                 docs = "",
             ),
         ),
@@ -516,7 +519,7 @@ Returns a hash-map of {name => source-namespace} for all referred symbols<br />
 """,
             example = "(ns-refers *ns*) ; =&gt; {\"doc\" \"phel.repl\" ...}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L468",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L474",
                 docs = "",
             ),
         ),
@@ -533,7 +536,7 @@ Returns a hash-map of {name => source-namespace} for all referred symbols<br />
             summary = "Prints arguments with colored output.",
             example = "(print-colorful [1 2 3])",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L186",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L185",
                 docs = "",
             ),
         ),
@@ -552,7 +555,7 @@ Default REPL tap handler: prints a tapped value as <code>tap> value</code> with 
 """,
             example = "(tap&gt; {:a 1}) ; prints: tap&gt; {:a 1}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L201",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L200",
                 docs = "",
             ),
         ),
@@ -569,7 +572,7 @@ Default REPL tap handler: prints a tapped value as <code>tap> value</code> with 
             summary = "Prints arguments with colored output followed by a newline.",
             example = "(println-colorful [1 2 3])",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L193",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L192",
                 docs = "",
             ),
         ),
@@ -594,7 +597,7 @@ Re-evaluates project namespaces whose source files changed since the last<br />
 """,
             example = "(reload!) ; =&gt; [\"my-app.lib\" \"my-app.core\"]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L602",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L610",
                 docs = "",
             ),
         ),
@@ -614,7 +617,7 @@ Force-reloads every loaded project namespace in dependency order, ignoring<br />
 """,
             example = "(reload-all!) ; =&gt; [\"my-app.lib\" \"my-app.core\"]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L615",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L623",
                 docs = "",
             ),
         ),
@@ -633,7 +636,7 @@ Removes the namespace and all of its definitions from the registry. Use with cau
 """,
             example = "(remove-ns \"my-app.tmp\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L405",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L411",
                 docs = "",
             ),
         ),
@@ -656,7 +659,7 @@ Requires a Phel module into the environment.<br />
 """,
             example = "(require '[phel\\string :as str]) ; =&gt; phel.string",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L140",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L140",
                 docs = "",
             ),
         ),
@@ -673,7 +676,7 @@ Requires a Phel module into the environment.<br />
             summary = "Gets an AI code review for Phel code.",
             example = "(review \"(defn add [a b] (+ a b))\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L813",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L821",
                 docs = "",
             ),
         ),
@@ -694,7 +697,7 @@ Runs a single test from the REPL, identified by a fully qualified symbol<br />
 """,
             example = "(run-test 'my-app.foo-test/my-test)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L666",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L674",
                 docs = "",
             ),
         ),
@@ -716,7 +719,7 @@ Runs all tests in the given namespaces from the REPL, loading each namespace<br 
 """,
             example = "(run-tests 'my-app.foo-test 'my-app.bar-test)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L653",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L661",
                 docs = "",
             ),
         ),
@@ -735,7 +738,7 @@ Searches docstrings across all loaded namespaces for the given string. Prints ma
 """,
             example = "(search-doc \"reduce\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L481",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L487",
                 docs = "",
             ),
         ),
@@ -752,7 +755,7 @@ Searches docstrings across all loaded namespaces for the given string. Prints ma
             summary = "Searches a namespace index for functions matching a query.",
             example = "(search-ns \"transform collections\" my-ns-index 5)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L851",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L859",
                 docs = "",
             ),
         ),
@@ -769,7 +772,7 @@ Searches docstrings across all loaded namespaces for the given string. Prints ma
             summary = "Returns the source code of the given symbol as a string, or nil if unavailable.",
             example = "(source map)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L378",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L384",
                 docs = "",
             ),
         ),
@@ -786,7 +789,7 @@ Searches docstrings across all loaded namespaces for the given string. Prints ma
             summary = "Get AI-suggested Phel code for a natural language description.",
             example = "(suggest \"filter even numbers from a vector\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L784",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L792",
                 docs = "",
             ),
         ),
@@ -808,7 +811,7 @@ Keys: :doc, :file, :line, :column, :end-line, :end-column, :private,<br />
 """,
             example = "(symbol-info map) ; =&gt; {:doc \"...\" :ns \"phel.core\" :name \"map\" ...}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L273",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L279",
                 docs = "",
             ),
         ),
@@ -827,7 +830,7 @@ Runs all tests in a given namespace from the REPL. Requires the namespace if not
 """,
             example = "(test-ns \"phel-test\\test\\core\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L679",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L687",
                 docs = "",
             ),
         ),
@@ -844,7 +847,7 @@ Runs all tests in a given namespace from the REPL. Requires the namespace if not
             summary = "Adds a use statement to the environment.",
             example = "(use DateTime :as DT) ; =&gt; DateTime",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/repl.phel#L162",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/repl.phel#L162",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/registerRouterFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/registerRouterFunctions.kt
@@ -21,7 +21,7 @@ internal fun registerRouterFunctions(): List<PhelFunction> = listOf(
             summary = "Creates a new CompiledSymfonyRouter struct.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/router.phel#L238",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/router.phel#L239",
                 docs = "",
             ),
         ),
@@ -40,7 +40,7 @@ Checks if <code>x</code> is an instance of the CompiledSymfonyRouter struct.
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/router.phel#L238",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/router.phel#L239",
                 docs = "",
             ),
         ),
@@ -57,7 +57,7 @@ Checks if <code>x</code> is an instance of the CompiledSymfonyRouter struct.
             summary = "Creates a new SymfonyRouter struct.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/router.phel#L197",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/router.phel#L198",
                 docs = "",
             ),
         ),
@@ -76,7 +76,7 @@ Checks if <code>x</code> is an instance of the SymfonyRouter struct.
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/router.phel#L197",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/router.phel#L198",
                 docs = "",
             ),
         ),
@@ -98,7 +98,7 @@ Runtime constructor for <code>compiled-router</code> expansions. Builds the norm
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/router.phel#L248",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/router.phel#L249",
                 docs = "",
             ),
         ),
@@ -118,7 +118,7 @@ Because compilation runs during macro expansion, <code>raw-routes</code> must be
 """,
             example = "(compiled-router [[\"/ping\" {:get {:handler pong}}]])",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/router.phel#L266",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/router.phel#L267",
                 docs = "",
             ),
         ),
@@ -141,7 +141,7 @@ Parent paths are concatenated with their children's paths and parent data<br />
 """,
             example = "(flatten-routes [\"/api\" {:middleware [:auth]}\n                 [\"/ping\" {:handler :ping}]] \"\" {})\n; =&gt; [[\"/api/ping\" {:middleware [:auth] :handler :ping}]]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/router.phel#L51",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/router.phel#L52",
                 docs = "",
             ),
         ),
@@ -158,7 +158,7 @@ Parent paths are concatenated with their children's paths and parent data<br />
             summary = "Generate a url for a route",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/router.phel#L137",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/router.phel#L138",
                 docs = "",
             ),
         ),
@@ -194,7 +194,7 @@ Dispatch is precompiled at handler construction time, so per-request work<br />
 """,
             example = "(handler (router [[\"/ping\" {:get {:handler pong}}]])\n         {:middleware [logging-mw]\n          :not-found  (fn [_] {:status 404 :body \"nope\"})})",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/router.phel#L283",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/router.phel#L284",
                 docs = "",
             ),
         ),
@@ -211,7 +211,7 @@ Dispatch is precompiled at handler construction time, so per-request work<br />
             summary = "Matches a route given a route name. Returns nil if route can't be found.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/router.phel#L137",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/router.phel#L138",
                 docs = "",
             ),
         ),
@@ -228,7 +228,7 @@ Dispatch is precompiled at handler construction time, so per-request work<br />
             summary = "Matches a route given a path. Returns nil if path doesn't match.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/router.phel#L137",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/router.phel#L138",
                 docs = "",
             ),
         ),
@@ -257,7 +257,7 @@ Routes are described as <code>[path data children*]</code> where <code>data</cod
 """,
             example = "(router [[\"/ping\" {:get {:handler pong}}]])",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/router.phel#L213",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/router.phel#L214",
                 docs = "",
             ),
         ),
@@ -274,7 +274,7 @@ Routes are described as <code>[path data children*]</code> where <code>data</cod
             summary = "Returns all registered routes as a vector of [path data] tuples.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/router.phel#L137",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/router.phel#L138",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/registerStringFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/registerStringFunctions.kt
@@ -23,7 +23,7 @@ True if s is nil, empty, or contains only whitespace. Non-breaking separators (<
 """,
             example = "(blank? \"   \") ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/string.phel#L155",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/string.phel#L220",
                 docs = "",
             ),
         ),
@@ -40,7 +40,7 @@ True if s is nil, empty, or contains only whitespace. Non-breaking separators (<
             summary = "Converts first character to upper-case and all other characters to lower-case.",
             example = "(capitalize \"hELLO wORLD\") ; =&gt; \"Hello world\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/string.phel#L110",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/string.phel#L166",
                 docs = "",
             ),
         ),
@@ -60,7 +60,7 @@ This is a convenience function for converting strings to character sequences. Pr
 """,
             example = "(chars \"hello\") ; =&gt; [\"h\" \"e\" \"l\" \"l\" \"o\"]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/string.phel#L21",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/string.phel#L69",
                 docs = "",
             ),
         ),
@@ -79,7 +79,7 @@ True if s contains substr. Synonym for <code>includes?</code>.
 """,
             example = "(contains? \"hello world\" \"lo wo\") ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/string.phel#L191",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/string.phel#L269",
                 docs = "",
             ),
         ),
@@ -96,7 +96,7 @@ True if s contains substr. Synonym for <code>includes?</code>.
             summary = "True if s ends with substr.",
             example = "(ends-with? \"hello world\" \"world\") ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/string.phel#L174",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/string.phel#L252",
                 docs = "",
             ),
         ),
@@ -113,7 +113,7 @@ True if s contains substr. Synonym for <code>includes?</code>.
             summary = "Returns a new string with each character escaped according to cmap.",
             example = "(escape \"hello\" {\"h\" \"H\" \"o\" \"O\"}) ; =&gt; \"HellO\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/string.phel#L205",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/string.phel#L287",
                 docs = "",
             ),
         ),
@@ -130,7 +130,7 @@ True if s contains substr. Synonym for <code>includes?</code>.
             summary = "True if s includes substr.",
             example = "(includes? \"hello world\" \"world\") ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/string.phel#L182",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/string.phel#L260",
                 docs = "",
             ),
         ),
@@ -138,7 +138,7 @@ True if s contains substr. Synonym for <code>includes?</code>.
     PhelFunction(
         namespace = "string",
         name = "string/index-of",
-        signature = "(index-of s value & [from-index])",
+        signature = "(index-of s value)\n(index-of s value from-index)",
         completion = CompletionInfo(
             tailText = "Returns the index of the first occurrence of value in s, or nil if not found",
             priority = PhelCompletionPriority.STRING_FUNCTIONS,
@@ -149,7 +149,7 @@ Returns the index of the first occurrence of value in s, or nil if not found. Th
 """,
             example = "(index-of \"hello world\" \"world\") ; =&gt; 6",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/string.phel#L214",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/string.phel#L296",
                 docs = "",
             ),
         ),
@@ -157,7 +157,7 @@ Returns the index of the first occurrence of value in s, or nil if not found. Th
     PhelFunction(
         namespace = "string",
         name = "string/join",
-        signature = "(join separator & [coll])",
+        signature = "(join coll)\n(join separator coll)",
         completion = CompletionInfo(
             tailText = "Returns a string of all elements in coll, separated by an optional separator",
             priority = PhelCompletionPriority.STRING_FUNCTIONS,
@@ -166,7 +166,7 @@ Returns the index of the first occurrence of value in s, or nil if not found. Th
             summary = "Returns a string of all elements in coll, separated by an optional separator.",
             example = "(join \", \" [\"apple\" \"banana\" \"cherry\"]) ; =&gt; \"apple, banana, cherry\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/string.phel#L31",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/string.phel#L79",
                 docs = "",
             ),
         ),
@@ -174,7 +174,7 @@ Returns the index of the first occurrence of value in s, or nil if not found. Th
     PhelFunction(
         namespace = "string",
         name = "string/last-index-of",
-        signature = "(last-index-of s value & [from-index])",
+        signature = "(last-index-of s value)\n(last-index-of s value from-index)",
         completion = CompletionInfo(
             tailText = "Returns the index of the last occurrence of value in s, or nil if not found",
             priority = PhelCompletionPriority.STRING_FUNCTIONS,
@@ -185,7 +185,7 @@ Returns the index of the last occurrence of value in s, or nil if not found. The
 """,
             example = "(last-index-of \"hello world world\" \"world\") ; =&gt; 12",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/string.phel#L233",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/string.phel#L322",
                 docs = "",
             ),
         ),
@@ -202,7 +202,7 @@ Returns the index of the last occurrence of value in s, or nil if not found. The
             summary = "Converts string to all lower-case.",
             example = "(lower-case \"HELLO World\") ; =&gt; \"hello world\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/string.phel#L120",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/string.phel#L176",
                 docs = "",
             ),
         ),
@@ -210,7 +210,7 @@ Returns the index of the last occurrence of value in s, or nil if not found. The
     PhelFunction(
         namespace = "string",
         name = "string/pad-both",
-        signature = "(pad-both s len & [pad-str])",
+        signature = "(pad-both s len)\n(pad-both s len pad-str)",
         completion = CompletionInfo(
             tailText = "Returns a string padded on both sides to length len",
             priority = PhelCompletionPriority.STRING_FUNCTIONS,
@@ -219,7 +219,7 @@ Returns the index of the last occurrence of value in s, or nil if not found. The
             summary = "Returns a string padded on both sides to length len.",
             example = "(pad-both \"hello\" 11) ; =&gt; \"   hello   \"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/string.phel#L283",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/string.phel#L376",
                 docs = "",
             ),
         ),
@@ -227,7 +227,7 @@ Returns the index of the last occurrence of value in s, or nil if not found. The
     PhelFunction(
         namespace = "string",
         name = "string/pad-left",
-        signature = "(pad-left s len & [pad-str])",
+        signature = "(pad-left s len)\n(pad-left s len pad-str)",
         completion = CompletionInfo(
             tailText = "Returns a string padded on the left side to length len",
             priority = PhelCompletionPriority.STRING_FUNCTIONS,
@@ -236,7 +236,7 @@ Returns the index of the last occurrence of value in s, or nil if not found. The
             summary = "Returns a string padded on the left side to length len.",
             example = "(pad-left \"hello\" 10) ; =&gt; \"     hello\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/string.phel#L269",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/string.phel#L364",
                 docs = "",
             ),
         ),
@@ -244,7 +244,7 @@ Returns the index of the last occurrence of value in s, or nil if not found. The
     PhelFunction(
         namespace = "string",
         name = "string/pad-right",
-        signature = "(pad-right s len & [pad-str])",
+        signature = "(pad-right s len)\n(pad-right s len pad-str)",
         completion = CompletionInfo(
             tailText = "Returns a string padded on the right side to length len",
             priority = PhelCompletionPriority.STRING_FUNCTIONS,
@@ -253,7 +253,7 @@ Returns the index of the last occurrence of value in s, or nil if not found. The
             summary = "Returns a string padded on the right side to length len.",
             example = "(pad-right \"hello\" 10) ; =&gt; \"hello     \"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/string.phel#L276",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/string.phel#L370",
                 docs = "",
             ),
         ),
@@ -270,7 +270,7 @@ Returns the index of the last occurrence of value in s, or nil if not found. The
             summary = "Escapes special characters in a replacement string for literal use.",
             example = "(re-quote-replacement \"\$1.00\") ; =&gt; \"\\\$1.00\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/string.phel#L198",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/string.phel#L280",
                 docs = "",
             ),
         ),
@@ -287,7 +287,7 @@ Returns the index of the last occurrence of value in s, or nil if not found. The
             summary = "Returns a string containing n copies of s.",
             example = "(repeat \"ha\" 3) ; =&gt; \"hahaha\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/string.phel#L56",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/string.phel#L112",
                 docs = "",
             ),
         ),
@@ -301,10 +301,13 @@ Returns the index of the last occurrence of value in s, or nil if not found. The
             priority = PhelCompletionPriority.STRING_FUNCTIONS,
         ),
         documentation = DocumentationInfo(
-            summary = "Replaces all instances of match with replacement in s.",
+            summary = """
+Replaces all instances of match with replacement in s. Plain string matches<br />
+  are literal; use a regex literal for regular-expression matching.
+""",
             example = "(replace \"hello world\" \"world\" \"there\") ; =&gt; \"hello there\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/string.phel#L74",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/string.phel#L128",
                 docs = "",
             ),
         ),
@@ -318,10 +321,13 @@ Returns the index of the last occurrence of value in s, or nil if not found. The
             priority = PhelCompletionPriority.STRING_FUNCTIONS,
         ),
         documentation = DocumentationInfo(
-            summary = "Replaces the first instance of match with replacement in s.",
+            summary = """
+Replaces the first instance of match with replacement in s. Plain string<br />
+  matches are literal; use a regex literal for regular-expression matching.
+""",
             example = "(replace-first \"hello world world\" \"world\" \"there\") ; =&gt; \"hello there world\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/string.phel#L86",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/string.phel#L141",
                 docs = "",
             ),
         ),
@@ -338,7 +344,7 @@ Returns the index of the last occurrence of value in s, or nil if not found. The
             summary = "Returns s with its characters reversed.",
             example = "(reverse \"hello\") ; =&gt; \"olleh\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/string.phel#L48",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/string.phel#L104",
                 docs = "",
             ),
         ),
@@ -346,7 +352,7 @@ Returns the index of the last occurrence of value in s, or nil if not found. The
     PhelFunction(
         namespace = "string",
         name = "string/split",
-        signature = "(split s re & [limit])",
+        signature = "(split s re)\n(split s re limit)",
         completion = CompletionInfo(
             tailText = "Splits string on a regular expression, returning a vector of parts",
             priority = PhelCompletionPriority.STRING_FUNCTIONS,
@@ -355,7 +361,7 @@ Returns the index of the last occurrence of value in s, or nil if not found. The
             summary = "Splits string on a regular expression, returning a vector of parts.",
             example = "(split \"hello world foo bar\" #\"\\s+\") ; =&gt; [\"hello\" \"world\" \"foo\" \"bar\"]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/string.phel#L14",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/string.phel#L45",
                 docs = "",
             ),
         ),
@@ -372,7 +378,7 @@ Returns the index of the last occurrence of value in s, or nil if not found. The
             summary = "Splits s on \\n or \\r\\n. Trailing empty lines are not returned.",
             example = "(split-lines \"hello\\nworld\\ntest\") ; =&gt; [\"hello\" \"world\" \"test\"]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/string.phel#L257",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/string.phel#L352",
                 docs = "",
             ),
         ),
@@ -389,7 +395,7 @@ Returns the index of the last occurrence of value in s, or nil if not found. The
             summary = "True if s starts with substr.",
             example = "(starts-with? \"hello world\" \"hello\") ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/string.phel#L166",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/string.phel#L244",
                 docs = "",
             ),
         ),
@@ -397,7 +403,7 @@ Returns the index of the last occurrence of value in s, or nil if not found. The
     PhelFunction(
         namespace = "string",
         name = "string/subs",
-        signature = "(subs s start & [end])",
+        signature = "(subs s start)\n(subs s start end)",
         completion = CompletionInfo(
             tailText = "Returns the substring of s from start (inclusive) to end (exclusive)",
             priority = PhelCompletionPriority.STRING_FUNCTIONS,
@@ -406,7 +412,7 @@ Returns the index of the last occurrence of value in s, or nil if not found. The
             summary = "Returns the substring of s from start (inclusive) to end (exclusive).",
             example = "(subs \"hello world\" 0 5) ; =&gt; \"hello\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/string.phel#L38",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/string.phel#L85",
                 docs = "",
             ),
         ),
@@ -423,7 +429,7 @@ Returns the index of the last occurrence of value in s, or nil if not found. The
             summary = "Removes whitespace from both ends of string.",
             example = "(trim \"  hello  \") ; =&gt; \"hello\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/string.phel#L134",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/string.phel#L190",
                 docs = "",
             ),
         ),
@@ -440,7 +446,7 @@ Returns the index of the last occurrence of value in s, or nil if not found. The
             summary = "Removes all trailing newline or return characters from string.",
             example = "(trim-newline \"hello\\n\\n\") ; =&gt; \"hello\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/string.phel#L98",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/string.phel#L154",
                 docs = "",
             ),
         ),
@@ -457,7 +463,7 @@ Returns the index of the last occurrence of value in s, or nil if not found. The
             summary = "Removes whitespace from the left side of string.",
             example = "(triml \"  hello  \") ; =&gt; \"hello  \"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/string.phel#L141",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/string.phel#L197",
                 docs = "",
             ),
         ),
@@ -474,7 +480,7 @@ Returns the index of the last occurrence of value in s, or nil if not found. The
             summary = "Removes whitespace from the right side of string.",
             example = "(trimr \"  hello  \") ; =&gt; \"  hello\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/string.phel#L148",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/string.phel#L204",
                 docs = "",
             ),
         ),
@@ -491,7 +497,7 @@ Returns the index of the last occurrence of value in s, or nil if not found. The
             summary = "Converts string to all upper-case.",
             example = "(upper-case \"hello World\") ; =&gt; \"HELLO WORLD\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/string.phel#L127",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/string.phel#L183",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/registerTraceFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/registerTraceFunctions.kt
@@ -23,7 +23,7 @@ Like <code>defn</code>, but every call to the defined function prints its argume
 """,
             example = "(deftrace fact [n] (if (&lt;= n 1) 1 (* n (fact (dec n)))))\n(fact 2)\n; TRACE t1: (fact 2)\n; TRACE t2: | (fact 1)\n; TRACE t2: | =&gt; 1\n; TRACE t1: =&gt; 2",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/trace.phel#L58",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/trace.phel#L58",
                 docs = "",
             ),
         ),
@@ -42,7 +42,7 @@ Temporarily traces the given global functions while <code>body</code> runs, then
 """,
             example = "(defn add [a b] (+ a b))\n(dotrace [add] (add 1 2))\n; TRACE t1: (add 1 2)\n; TRACE t1: =&gt; 3",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/trace.phel#L70",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/trace.phel#L70",
                 docs = "",
             ),
         ),
@@ -61,7 +61,7 @@ Resets the trace depth and the trace id counter to their initial values. Useful 
 """,
             example = "(reset-trace-state!)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/trace.phel#L21",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/trace.phel#L21",
                 docs = "",
             ),
         ),
@@ -80,7 +80,7 @@ Prints <code>value</code> to the standard error stream and returns it unchanged.
 """,
             example = "(trace :sum (+ 1 2)) ; stderr: TRACE :sum: 3\n; =&gt; 3",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/trace.phel#L30",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/trace.phel#L30",
                 docs = "",
             ),
         ),
@@ -99,7 +99,7 @@ Returns a function that behaves like <code>f</code> but prints every call with i
 """,
             example = "(def fib-t (trace-fn \"fib\" fib))\n(fib-t 2)\n; TRACE t1: (fib 2)\n; TRACE t2: | (fib 1)\n; TRACE t2: | =&gt; 1\n; TRACE t1: =&gt; 1",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/trace.phel#L39",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/trace.phel#L39",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/registerTransitFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/registerTransitFunctions.kt
@@ -29,7 +29,7 @@ Options:<br />
 """,
             example = "(read-string \"[\\\"~:foo\\\", 1]\") ; =&gt; [:foo 1]\n(read-string \"[\\\"~#point\\\", [1, 2]]\" {:handlers {\"point\" (fn [v] v)}}) ; =&gt; [1 2]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/transit.phel#L182",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/transit.phel#L180",
                 docs = "",
             ),
         ),
@@ -48,7 +48,7 @@ Serialises <code>value</code> to a Transit+JSON-Verbose string.
 """,
             example = "(write-string {:a 1}) ; =&gt; \"[\\\"~#cmap\\\",[\\\"~:a\\\",1]]\"",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/transit.phel#L283",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/transit.phel#L281",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/registerWalkFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/registerWalkFunctions.kt
@@ -21,7 +21,7 @@ internal fun registerWalkFunctions(): List<PhelFunction> = listOf(
             summary = "Convert string map keys to keywords, recursively.",
             example = "(keywordize-keys {\"name\" \"phel\"}) ; =&gt; {:name \"phel\"}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/walk.phel#L59",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/walk.phel#L76",
                 docs = "",
             ),
         ),
@@ -36,9 +36,9 @@ internal fun registerWalkFunctions(): List<PhelFunction> = listOf(
         ),
         documentation = DocumentationInfo(
             summary = "Bottom-up tree walk — applies f after recursing into children.",
-            example = "(postwalk inc [1 [2 3]]) ; =&gt; [2 [3 4]]",
+            example = "(postwalk #(if (int? %) (inc %) %) [1 [2 3]]) ; =&gt; [2 [3 4]]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/walk.phel#L25",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/walk.phel#L42",
                 docs = "",
             ),
         ),
@@ -55,7 +55,7 @@ internal fun registerWalkFunctions(): List<PhelFunction> = listOf(
             summary = "Replace values bottom-up using a substitution map.",
             example = "(postwalk-replace {:a :b} [:a :c]) ; =&gt; [:b :c]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/walk.phel#L41",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/walk.phel#L58",
                 docs = "",
             ),
         ),
@@ -72,7 +72,7 @@ internal fun registerWalkFunctions(): List<PhelFunction> = listOf(
             summary = "Top-down tree walk — applies f before recursing into children.",
             example = "(prewalk identity [1 [2 3]]) ; =&gt; [1 [2 3]]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/walk.phel#L33",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/walk.phel#L50",
                 docs = "",
             ),
         ),
@@ -89,7 +89,7 @@ internal fun registerWalkFunctions(): List<PhelFunction> = listOf(
             summary = "Replace values top-down using a substitution map.",
             example = "(prewalk-replace {:a :b} [:a :c]) ; =&gt; [:b :c]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/walk.phel#L50",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/walk.phel#L67",
                 docs = "",
             ),
         ),
@@ -106,7 +106,7 @@ internal fun registerWalkFunctions(): List<PhelFunction> = listOf(
             summary = "Convert keyword map keys to strings, recursively.",
             example = "(stringify-keys {:name \"phel\"}) ; =&gt; {\"name\" \"phel\"}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/walk.phel#L74",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/walk.phel#L95",
                 docs = "",
             ),
         ),
@@ -123,7 +123,7 @@ internal fun registerWalkFunctions(): List<PhelFunction> = listOf(
             summary = "Generic tree walker for nested data structures.",
             example = "(walk inc identity [1 2 3]) ; =&gt; [2 3 4]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/walk.phel#L3",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/walk.phel#L3",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/registerWatchFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/registerWatchFunctions.kt
@@ -23,7 +23,7 @@ Removes every hook registered for <code>namespace</code>.
 """,
             example = "(clear-on-reload \"my-app\\core\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/watch.phel#L16",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/watch.phel#L15",
                 docs = "",
             ),
         ),
@@ -42,7 +42,7 @@ Registers a zero-arg function to run every time <code>namespace</code> is reload
 """,
             example = "(register-on-reload \"my-app\\core\" :refresh (fn [] (println \"reloaded\")))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/watch.phel#L7",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/watch.phel#L6",
                 docs = "",
             ),
         ),
@@ -61,7 +61,7 @@ Executes every hook registered for <code>namespace</code>. Returns the number of
 """,
             example = "(run-on-reload-hooks \"my-app\\core\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/watch.phel#L22",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/watch.phel#L21",
                 docs = "",
             ),
         ),
@@ -80,7 +80,7 @@ Starts the file watcher on the given vector of paths. Blocks until the watcher i
 """,
             example = "(watch! [\"src/\" \"tests/\"])",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/watch.phel#L33",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/watch.phel#L32",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/schema/registerSchemaCoercerFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/schema/registerSchemaCoercerFunctions.kt
@@ -23,7 +23,7 @@ Walks <code>schema</code> and returns <code>value</code> with string-typed input
 """,
             example = "(coerce :int \"42\") ; =&gt; 42",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema/coercer.phel#L221",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema/coercer.phel#L222",
                 docs = "",
             ),
         ),
@@ -42,7 +42,7 @@ Coerces <code>value</code> against <code>schema</code>. Returns the coerced valu
 """,
             example = "(conform :int \"42\") ; =&gt; 42",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema/coercer.phel#L231",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema/coercer.phel#L232",
                 docs = "",
             ),
         ),
@@ -61,7 +61,7 @@ Sentinel keyword returned by coercion when a value cannot be coerced to the targ
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema/coercer.phel#L15",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema/coercer.phel#L16",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/schema/registerSchemaExplainerFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/schema/registerSchemaExplainerFunctions.kt
@@ -23,7 +23,7 @@ Returns <code>nil</code> if <code>value</code> conforms to <code>schema</code>, 
 """,
             example = "(explain :int :oops)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema/explainer.phel#L234",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema/explainer.phel#L234",
                 docs = "",
             ),
         ),
@@ -42,7 +42,7 @@ Renders an explain result as a multi-line human string suitable for REPL or CI o
 """,
             example = "(human-readable-explain (explain :int :oops))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema/explainer.phel#L254",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema/explainer.phel#L254",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/schema/registerSchemaFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/schema/registerSchemaFunctions.kt
@@ -23,7 +23,7 @@ Walks <code>schema</code> and coerces string-shaped input into schema-required t
 """,
             example = "(coerce :int \"42\") ; =&gt; 42",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema.phel#L82",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema.phel#L82",
                 docs = "",
             ),
         ),
@@ -42,7 +42,7 @@ Coerces <code>value</code> against <code>schema</code>. Returns the coerced valu
 """,
             example = "(conform :int \"42\") ; =&gt; 42",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema.phel#L89",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema.phel#L89",
                 docs = "",
             ),
         ),
@@ -61,7 +61,7 @@ Returns the schema registered under <code>name</code>, or <code>nil</code>.
 """,
             example = "(deref-ref :email)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema.phel#L133",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema.phel#L133",
                 docs = "",
             ),
         ),
@@ -82,7 +82,7 @@ Returns <code>nil</code> when <code>value</code> conforms to <code>schema</code>
 """,
             example = "(explain :int :oops)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema.phel#L65",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema.phel#L65",
                 docs = "",
             ),
         ),
@@ -102,7 +102,7 @@ Generates a single value conforming to <code>schema</code>. Accepts <code>:size<
 """,
             example = "(generate :int)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema.phel#L100",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema.phel#L100",
                 docs = "",
             ),
         ),
@@ -122,7 +122,7 @@ Renders an <code>explain</code> result as a multi-line human string. Returns<br 
 """,
             example = "(human-readable-explain (explain :int :oops))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema.phel#L74",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema.phel#L74",
                 docs = "",
             ),
         ),
@@ -141,7 +141,7 @@ Registers <code>f</code> wrapped with <code>schema</code> under <code>name</code
 """,
             example = "(instrument! :add add [:=&gt; [:int :int] :int])",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema.phel#L185",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema.phel#L185",
                 docs = "",
             ),
         ),
@@ -160,7 +160,7 @@ Returns <code>true</code> if <code>name</code> is currently instrumented.
 """,
             example = "(instrumented? :add)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema.phel#L198",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema.phel#L198",
                 docs = "",
             ),
         ),
@@ -179,7 +179,7 @@ Sentinel value (<code>:phel.schema/invalid</code>) returned by <code>conform</co
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema.phel#L96",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema.phel#L96",
                 docs = "",
             ),
         ),
@@ -198,7 +198,7 @@ Registers <code>schema</code> under <code>name</code> in the global schema regis
 """,
             example = "(register! :email [:and :string [:re \"/@/\"]])",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema.phel#L119",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema.phel#L119",
                 docs = "",
             ),
         ),
@@ -217,7 +217,7 @@ Returns <code>true</code> if a schema is registered under <code>name</code>.
 """,
             example = "(registered? :email)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema.phel#L139",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema.phel#L139",
                 docs = "",
             ),
         ),
@@ -236,7 +236,7 @@ Returns the <code>phel\test\gen</code> generator associated with <code>schema</c
 """,
             example = "(schema-&gt;gen :int)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema.phel#L108",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema.phel#L108",
                 docs = "",
             ),
         ),
@@ -255,7 +255,7 @@ Returns the positional arguments of <code>schema</code> (children past the head 
 """,
             example = "(schema-args [:vector :int]) ; =&gt; [:int]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema.phel#L42",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema.phel#L42",
                 docs = "",
             ),
         ),
@@ -274,7 +274,7 @@ Returns <code>true</code> when runtime validation performed by the instrument he
 """,
             example = "(schema-check?) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema.phel#L149",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema.phel#L149",
                 docs = "",
             ),
         ),
@@ -293,7 +293,7 @@ Returns the dispatch head (kind keyword) of <code>schema</code>.
 """,
             example = "(schema-head [:vector :int]) ; =&gt; :vector",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema.phel#L36",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema.phel#L36",
                 docs = "",
             ),
         ),
@@ -312,7 +312,7 @@ Returns the options map of <code>schema</code> or <code>{}</code>.
 """,
             example = "(schema-options [:map {:closed true} [:k :int]]) ; =&gt; {:closed true}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema.phel#L48",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema.phel#L48",
                 docs = "",
             ),
         ),
@@ -331,7 +331,7 @@ Returns <code>true</code> if <code>x</code> has the shape of a schema value.
 """,
             example = "(schema? :int) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema.phel#L30",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema.phel#L30",
                 docs = "",
             ),
         ),
@@ -350,7 +350,7 @@ Enables (<code>true</code>) or disables (<code>false</code>) runtime validation.
 """,
             example = "(set-schema-check! false)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema.phel#L156",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema.phel#L156",
                 docs = "",
             ),
         ),
@@ -369,7 +369,7 @@ Removes the schema bound to <code>name</code>. Returns <code>nil</code>.
 """,
             example = "(unregister! :email)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema.phel#L126",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema.phel#L126",
                 docs = "",
             ),
         ),
@@ -388,7 +388,7 @@ Removes the instrumentation registered under <code>name</code> and returns the o
 """,
             example = "(unstrument! :add)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema.phel#L192",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema.phel#L192",
                 docs = "",
             ),
         ),
@@ -407,7 +407,7 @@ Returns <code>true</code> if <code>value</code> conforms to <code>schema</code>,
 """,
             example = "(validate :int 1) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema.phel#L58",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema.phel#L58",
                 docs = "",
             ),
         ),
@@ -427,7 +427,7 @@ Invokes zero-arg thunk <code>f</code> with runtime validation forced to<br />
 """,
             example = "(with-schema-check false (fn [] (risky-fn)))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema.phel#L163",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema.phel#L163",
                 docs = "",
             ),
         ),
@@ -446,7 +446,7 @@ Wraps <code>f</code> with the <code>[:=> args ret]</code> function schema.
 """,
             example = "(wrap-with-function-schema add [:=&gt; [:int :int] :int])",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema.phel#L178",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema.phel#L178",
                 docs = "",
             ),
         ),
@@ -465,7 +465,7 @@ Wraps <code>f</code> so calls validate arguments and return values against the s
 """,
             example = "(wrap-with-schema add [:int :int] :int)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema.phel#L171",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema.phel#L171",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/schema/registerSchemaGeneratorFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/schema/registerSchemaGeneratorFunctions.kt
@@ -24,7 +24,7 @@ Generates one random value conforming to <code>schema</code>. Accepts the same<b
 """,
             example = "(generate :int)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema/generator.phel#L184",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema/generator.phel#L178",
                 docs = "",
             ),
         ),
@@ -44,7 +44,7 @@ Returns a <code>phel\test\gen</code> generator for <code>schema</code>. Honours 
 """,
             example = "(schema-&gt;gen [:int])",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema/generator.phel#L167",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema/generator.phel#L161",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/schema/registerSchemaInstrumentFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/schema/registerSchemaInstrumentFunctions.kt
@@ -23,7 +23,7 @@ Removes every instrumentation entry. Returns <code>nil</code>.
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema/instrument.phel#L160",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema/instrument.phel#L160",
                 docs = "",
             ),
         ),
@@ -43,7 +43,7 @@ Returns <code>true</code> if <code>schema</code> is a function schema of the sha
 """,
             example = "(function-schema? [:=&gt; [:int] :int])",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema/instrument.phel#L60",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema/instrument.phel#L60",
                 docs = "",
             ),
         ),
@@ -62,7 +62,7 @@ Registers <code>f</code> under <code>name</code> (any key) wrapped with <code>sc
 """,
             example = "(def add* (instrument! :add add [:=&gt; [:int :int] :int]))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema/instrument.phel#L128",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema/instrument.phel#L128",
                 docs = "",
             ),
         ),
@@ -82,7 +82,7 @@ Returns the original, unwrapped function associated with <code>name</code>, or<b
 """,
             example = "(instrumented-original :add)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema/instrument.phel#L152",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema/instrument.phel#L152",
                 docs = "",
             ),
         ),
@@ -101,7 +101,7 @@ Returns <code>true</code> if <code>name</code> currently has an instrumentation 
 """,
             example = "(instrumented? :add)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema/instrument.phel#L146",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema/instrument.phel#L146",
                 docs = "",
             ),
         ),
@@ -120,7 +120,7 @@ Returns <code>true</code> when runtime validation is enabled.
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema/instrument.phel#L26",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema/instrument.phel#L26",
                 docs = "",
             ),
         ),
@@ -140,7 +140,7 @@ Returns <code>true</code> if <code>x</code> has the shape of a schema value (a k
 """,
             example = "(schema? :int) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema/instrument.phel#L49",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema/instrument.phel#L49",
                 docs = "",
             ),
         ),
@@ -160,7 +160,7 @@ Enables (<code>true</code>) or disables (<code>false</code>) runtime validation 
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema/instrument.phel#L31",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema/instrument.phel#L31",
                 docs = "",
             ),
         ),
@@ -179,7 +179,7 @@ Unregisters the instrumentation bound to <code>name</code> and returns the origi
 """,
             example = "(unstrument! :add)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema/instrument.phel#L137",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema/instrument.phel#L137",
                 docs = "",
             ),
         ),
@@ -198,7 +198,7 @@ Runs thunk <code>f</code> with runtime validation set to <code>enabled?</code>, 
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema/instrument.phel#L37",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema/instrument.phel#L37",
                 docs = "",
             ),
         ),
@@ -218,7 +218,7 @@ Convenience: accepts a <code>[:=> args-schema return-schema]</code> schema vecto
 """,
             example = "(wrap-with-function-schema add [:=&gt; [:int :int] :int])",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema/instrument.phel#L116",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema/instrument.phel#L116",
                 docs = "",
             ),
         ),
@@ -241,7 +241,7 @@ Wraps <code>f</code> so each call validates its arguments against <code>arg-sche
 """,
             example = "(wrap-with-schema add [:int :int] :int)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema/instrument.phel#L98",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema/instrument.phel#L98",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/schema/registerSchemaRegistryFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/schema/registerSchemaRegistryFunctions.kt
@@ -23,7 +23,7 @@ Removes every user-registered schema. Returns <code>nil</code>.
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema/registry.phel#L48",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema/registry.phel#L48",
                 docs = "",
             ),
         ),
@@ -42,7 +42,7 @@ Returns the schema registered under <code>name</code>, or <code>nil</code> if no
 """,
             example = "(deref-ref :email)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema/registry.phel#L29",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema/registry.phel#L29",
                 docs = "",
             ),
         ),
@@ -61,7 +61,7 @@ Registers <code>schema</code> under <code>name</code> (usually a keyword). Overw
 """,
             example = "(register! :email [:and :string [:re #\"@\"]])",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema/registry.phel#L13",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema/registry.phel#L13",
                 docs = "",
             ),
         ),
@@ -80,7 +80,7 @@ Returns <code>true</code> if a schema is registered under <code>name</code>.
 """,
             example = "(registered? :email) ; =&gt; true/false",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema/registry.phel#L36",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema/registry.phel#L36",
                 docs = "",
             ),
         ),
@@ -99,7 +99,7 @@ Returns the current registry as a plain map. Intended for inspection and testing
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema/registry.phel#L43",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema/registry.phel#L43",
                 docs = "",
             ),
         ),
@@ -118,7 +118,7 @@ Removes the schema bound to <code>name</code>. Returns <code>nil</code>.
 """,
             example = "(unregister! :email)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema/registry.phel#L21",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema/registry.phel#L21",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/schema/registerSchemaValidatorFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/schema/registerSchemaValidatorFunctions.kt
@@ -24,7 +24,7 @@ Returns <code>true</code> when a <code>[:map ...]</code> entry is declared with<
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema/validator.phel#L177",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema/validator.phel#L177",
                 docs = "",
             ),
         ),
@@ -43,7 +43,7 @@ Options map for a <code>[:map ...]</code> entry <code>[key opts? schema]</code>.
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema/validator.phel#L163",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema/validator.phel#L163",
                 docs = "",
             ),
         ),
@@ -62,7 +62,7 @@ Inner schema of a <code>[:map ...]</code> entry, skipping the options map when p
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema/validator.phel#L170",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema/validator.phel#L170",
                 docs = "",
             ),
         ),
@@ -81,7 +81,7 @@ Like <code>resolve-or-throw</code>, but returns <code>default</code> when <code>
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema/validator.phel#L38",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema/validator.phel#L38",
                 docs = "",
             ),
         ),
@@ -105,7 +105,7 @@ Every head-dispatching caller uses this so the error shape is<br />
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema/validator.phel#L24",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema/validator.phel#L24",
                 docs = "",
             ),
         ),
@@ -124,7 +124,7 @@ Returns the positional arguments of <code>schema</code> (children past the head 
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema/validator.phel#L65",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema/validator.phel#L65",
                 docs = "",
             ),
         ),
@@ -143,7 +143,7 @@ Returns the head (kind keyword) of <code>schema</code>. Keyword schemas are thei
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema/validator.phel#L49",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema/validator.phel#L49",
                 docs = "",
             ),
         ),
@@ -162,7 +162,7 @@ Returns the options map of <code>schema</code> or <code>{}</code> if none.
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema/validator.phel#L74",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema/validator.phel#L74",
                 docs = "",
             ),
         ),
@@ -181,7 +181,7 @@ Returns <code>true</code> if <code>value</code> conforms to <code>schema</code>,
 """,
             example = "(valid? :int 1) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/schema/validator.phel#L280",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/schema/validator.phel#L293",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/test/registerTestFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/test/registerTestFunctions.kt
@@ -21,7 +21,7 @@ internal fun registerTestFunctions(): List<PhelFunction> = listOf(
             summary = "Stack of testing context strings, most recent first.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test.phel#L21",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test.phel#L21",
                 docs = "",
             ),
         ),
@@ -40,7 +40,7 @@ Appends <code>reporter-fn</code> to the active reporter set. Returns the updated
 """,
             example = "(add-reporter! tap-reporter)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test.phel#L52",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test.phel#L52",
                 docs = "",
             ),
         ),
@@ -64,7 +64,7 @@ Checks multiple assertions with a template expression.<br />
 """,
             example = "(are [x y] (= x y)\n  2 (+ 1 1)\n  4 (* 2 2))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test.phel#L427",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test.phel#L428",
                 docs = "",
             ),
         ),
@@ -72,16 +72,61 @@ Checks multiple assertions with a template expression.<br />
     PhelFunction(
         namespace = "test",
         name = "test/assert-expr",
-        signature = "(assert-expr & __phel_4102)",
+        signature = "(assert-expr & args)",
         completion = CompletionInfo(
-            tailText = "",
+            tailText = "Public extension point for the is macro: an open multimethod dispatched on the first symbol of th...",
             priority = PhelCompletionPriority.TEST_FUNCTIONS,
         ),
         documentation = DocumentationInfo(
-            summary = "",
+            summary = """
+Public extension point for the <code>is</code> macro: an open multimethod dispatched on<br />
+  the first symbol of the asserted form (or <code>:default</code> for non-list forms and for<br />
+  lists not starting with a symbol).<br /><br />
+Extend it with <code>(defmethod phel.test/assert-expr 'my-form [message form] ...)</code>,<br />
+  returning a quoted form for <code>is</code> to evaluate. Methods must be loaded before any<br />
+  <code>is</code> form using their dispatch value is expanded.
+""",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test.phel#L322",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test.phel#L316",
+                docs = "",
+            ),
+        ),
+    ),
+    PhelFunction(
+        namespace = "test",
+        name = "test/assert-expr-methods",
+        signature = "",
+        completion = CompletionInfo(
+            tailText = "Dispatch table for the assert-expr multimethod: a map of dispatch value to implementing function",
+            priority = PhelCompletionPriority.TEST_FUNCTIONS,
+        ),
+        documentation = DocumentationInfo(
+            summary = """
+Dispatch table for the <code>assert-expr</code> multimethod: a map of dispatch value to implementing function. Registered through <code>defmethod</code>; not meant to be written directly.
+""",
+            example = null,
+            links = DocumentationLinks(
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test.phel#L316",
+                docs = "",
+            ),
+        ),
+    ),
+    PhelFunction(
+        namespace = "test",
+        name = "test/assert-expr-prefers",
+        signature = "",
+        completion = CompletionInfo(
+            tailText = "Preference table for the assert-expr multimethod, resolving ambiguity between two matching dispat...",
+            priority = PhelCompletionPriority.TEST_FUNCTIONS,
+        ),
+        documentation = DocumentationInfo(
+            summary = """
+Preference table for the <code>assert-expr</code> multimethod, resolving ambiguity between two matching dispatch values. Registered through <code>prefer-method</code>; not meant to be written directly.
+""",
+            example = null,
+            links = DocumentationLinks(
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test.phel#L316",
                 docs = "",
             ),
         ),
@@ -98,7 +143,7 @@ Checks multiple assertions with a template expression.<br />
             summary = "Removes every registered reporter. Returns an empty vector.",
             example = "(clear-reporters!)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test.phel#L59",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test.phel#L59",
                 docs = "",
             ),
         ),
@@ -118,7 +163,7 @@ Metadata attached to <code>test-name</code> is forwarded to the defined function
 """,
             example = "(deftest test-add)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test.phel#L383",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test.phel#L384",
                 docs = "",
             ),
         ),
@@ -137,7 +182,7 @@ Add file and line information to a test result and call report. If you are writi
 """,
             example = "(do-report {:state :pass :type :any :message \"ok\"})",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test.phel#L186",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test.phel#L186",
                 docs = "",
             ),
         ),
@@ -156,7 +201,7 @@ Returns the names (<code>ns/test-name</code>) of tests that failed or errored in
 """,
             example = "(get-failed-tests) ; =&gt; [\"my-app/foo-test\"]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test.phel#L1468",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test.phel#L1480",
                 docs = "",
             ),
         ),
@@ -173,7 +218,7 @@ Returns the names (<code>ns/test-name</code>) of tests that failed or errored in
             summary = "Returns the currently registered reporter functions as a vector.",
             example = "(get-reporters)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test.phel#L66",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test.phel#L66",
                 docs = "",
             ),
         ),
@@ -190,9 +235,9 @@ Returns the names (<code>ns/test-name</code>) of tests that failed or errored in
             summary = """
 Returns the current test statistics as a hash-map with :failed and :counts keys.
 """,
-            example = "(get-stats) ; =&gt; {:failed [] :counts {:failed 0 :error 0 :pass 0 :total 0}}",
+            example = "(get-stats) ; =&gt; {:failed [], :skipped [], :counts {:failed 0, :error 0, :pass 0, :skipped 0, :total 0}}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test.phel#L1456",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test.phel#L1468",
                 docs = "",
             ),
         ),
@@ -209,26 +254,7 @@ Returns the current test statistics as a hash-map with :failed and :counts keys.
             summary = "Asserts that an expression is true.",
             example = "(is (= 4 (+ 2 2)))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test.phel#L365",
-                docs = "",
-            ),
-        ),
-    ),
-    PhelFunction(
-        namespace = "test",
-        name = "test/print-summary",
-        signature = "(print-summary)",
-        completion = CompletionInfo(
-            tailText = "Emits the :summary event to the active reporter set",
-            priority = PhelCompletionPriority.TEST_FUNCTIONS,
-        ),
-        documentation = DocumentationInfo(
-            summary = """
-Emits the <code>:summary</code> event to the active reporter set. Kept for backwards compatibility; prefer letting <code>run-tests</code> emit the event at the end of the run.
-""",
-            example = "(print-summary)",
-            links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test.phel#L1098",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test.phel#L366",
                 docs = "",
             ),
         ),
@@ -247,7 +273,7 @@ Registers a custom reporter function under <code>name</code> (keyword or keyword
 """,
             example = "(register-reporter! :my-reporter (fn [event] ...))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test.phel#L1066",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test.phel#L1079",
                 docs = "",
             ),
         ),
@@ -255,7 +281,7 @@ Registers a custom reporter function under <code>name</code> (keyword or keyword
     PhelFunction(
         namespace = "test",
         name = "test/report",
-        signature = "(report & __phel_4053)",
+        signature = "(report & args)",
         completion = CompletionInfo(
             tailText = "Records a test-framework event and dispatches it to the active reporters",
             priority = PhelCompletionPriority.TEST_FUNCTIONS,
@@ -273,7 +299,45 @@ Records a test-framework event and dispatches it to the active<br />
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test.phel#L125",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test.phel#L125",
+                docs = "",
+            ),
+        ),
+    ),
+    PhelFunction(
+        namespace = "test",
+        name = "test/report-methods",
+        signature = "",
+        completion = CompletionInfo(
+            tailText = "Dispatch table for the report multimethod: a map of dispatch value to implementing function",
+            priority = PhelCompletionPriority.TEST_FUNCTIONS,
+        ),
+        documentation = DocumentationInfo(
+            summary = """
+Dispatch table for the <code>report</code> multimethod: a map of dispatch value to implementing function. Registered through <code>defmethod</code>; not meant to be written directly.
+""",
+            example = null,
+            links = DocumentationLinks(
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test.phel#L125",
+                docs = "",
+            ),
+        ),
+    ),
+    PhelFunction(
+        namespace = "test",
+        name = "test/report-prefers",
+        signature = "",
+        completion = CompletionInfo(
+            tailText = "Preference table for the report multimethod, resolving ambiguity between two matching dispatch va...",
+            priority = PhelCompletionPriority.TEST_FUNCTIONS,
+        ),
+        documentation = DocumentationInfo(
+            summary = """
+Preference table for the <code>report</code> multimethod, resolving ambiguity between two matching dispatch values. Registered through <code>prefer-method</code>; not meant to be written directly.
+""",
+            example = null,
+            links = DocumentationLinks(
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test.phel#L125",
                 docs = "",
             ),
         ),
@@ -292,7 +356,7 @@ Resets the test statistics to their initial state. Call this before running a ne
 """,
             example = "(reset-stats)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test.phel#L1443",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test.phel#L1455",
                 docs = "",
             ),
         ),
@@ -311,7 +375,7 @@ Returns the reporter function registered for <code>name</code> (keyword or strin
 """,
             example = "(resolve-reporter :junit-xml)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test.phel#L1057",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test.phel#L1070",
                 docs = "",
             ),
         ),
@@ -328,7 +392,7 @@ Returns the reporter function registered for <code>name</code> (keyword or strin
             summary = "Restores test statistics from a previously saved state.",
             example = "(restore-stats saved)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test.phel#L1462",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test.phel#L1474",
                 docs = "",
             ),
         ),
@@ -354,7 +418,7 @@ Recognized option keys include <code>:filter</code>, <code>:filters</code>, <cod
 """,
             example = "(run-tests {} 'my-app\\test)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test.phel#L1424",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test.phel#L1436",
                 docs = "",
             ),
         ),
@@ -373,7 +437,7 @@ Configures the output path the JUnit reporter writes to. When <code>nil</code>, 
 """,
             example = "(set-junit-output! \"build/junit.xml\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test.phel#L1032",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test.phel#L1045",
                 docs = "",
             ),
         ),
@@ -392,7 +456,7 @@ Replaces the active reporter set with <code>reporters</code> (a sequence of sing
 """,
             example = "(set-reporters! [my-reporter-fn])",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test.phel#L45",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test.phel#L45",
                 docs = "",
             ),
         ),
@@ -409,7 +473,7 @@ Replaces the active reporter set with <code>reporters</code> (a sequence of sing
             summary = "Checks if all tests passed.",
             example = "(successful?) # =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test.phel#L1449",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test.phel#L1461",
                 docs = "",
             ),
         ),
@@ -428,7 +492,7 @@ Adds a testing context string. Used inside deftest to describe a group of assert
 """,
             example = "(deftest test-math\n  (testing \"addition\"\n    (is (= 2 (+ 1 1)))))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test.phel#L400",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test.phel#L401",
                 docs = "",
             ),
         ),
@@ -453,7 +517,45 @@ Calling <code>use-fixtures</code> with no fixture functions removes all fixtures
 """,
             example = "(use-fixtures :once (fn [t] (setup) (t) (teardown)))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test.phel#L1125",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test.phel#L1137",
+                docs = "",
+            ),
+        ),
+    ),
+    PhelFunction(
+        namespace = "test",
+        name = "test/with-isolated-reporters",
+        signature = "(with-isolated-reporters reporters & body)",
+        completion = CompletionInfo(
+            tailText = "Installs reporters as the only active reporter set while body runs, then restores the previously ...",
+            priority = PhelCompletionPriority.MACROS,
+        ),
+        documentation = DocumentationInfo(
+            summary = """
+Installs <code>reporters</code> as the only active reporter set while <code>body</code> runs, then restores the previously registered reporters. Returns the value of the last form in <code>body</code>. Use it to capture the events a piece of code emits without permanently replacing the reporters the surrounding run relies on. The previous reporter set is restored even when <code>body</code> throws.
+""",
+            example = "(let [events (atom [])]\n  (with-isolated-reporters [(fn [event] (swap! events conj (:type event)))]\n    (report {:type :pass :state :pass}))\n  (deref events)) ; =&gt; [:pass]",
+            links = DocumentationLinks(
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test.phel#L1508",
+                docs = "",
+            ),
+        ),
+    ),
+    PhelFunction(
+        namespace = "test",
+        name = "test/with-isolated-stats",
+        signature = "(with-isolated-stats & body)",
+        completion = CompletionInfo(
+            tailText = "Runs body against a freshly reset statistics accumulator and returns the stats map that body prod...",
+            priority = PhelCompletionPriority.MACROS,
+        ),
+        documentation = DocumentationInfo(
+            summary = """
+Runs <code>body</code> against a freshly reset statistics accumulator and returns the stats map that <code>body</code> produced, then restores the statistics the caller had before. Use it when asserting on the outcome of assertions under test, so their pass/fail counts never leak into the surrounding run. Wrap <code>body</code> in <code>with-output-buffer</code> to swallow the reporter output those assertions emit. The caller's statistics are restored even when <code>body</code> throws.
+""",
+            example = "(:counts (with-isolated-stats (with-output-buffer (is (= 1 2))))) ; =&gt; {:failed 1, :error 0, :pass 0, :skipped 0, :total 1}",
+            links = DocumentationLinks(
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test.phel#L1496",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/test/registerTestGenFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/test/registerTestGenFunctions.kt
@@ -12,7 +12,7 @@ internal fun registerTestGenFunctions(): List<PhelFunction> = listOf(
     PhelFunction(
         namespace = "test.gen",
         name = "test.gen/boolean",
-        signature = "",
+        signature = "(boolean _size)",
         completion = CompletionInfo(
             tailText = "Generator of booleans",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -21,7 +21,7 @@ internal fun registerTestGenFunctions(): List<PhelFunction> = listOf(
             summary = "Generator of booleans.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/gen.phel#L62",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/gen.phel#L62",
                 docs = "",
             ),
         ),
@@ -29,7 +29,7 @@ internal fun registerTestGenFunctions(): List<PhelFunction> = listOf(
     PhelFunction(
         namespace = "test.gen",
         name = "test.gen/char",
-        signature = "",
+        signature = "(char _size)",
         completion = CompletionInfo(
             tailText = "Generator of printable ASCII characters (space through ~)",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -40,7 +40,7 @@ Generator of printable ASCII characters (space through <code>~</code>).
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/gen.phel#L111",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/gen.phel#L111",
                 docs = "",
             ),
         ),
@@ -48,7 +48,7 @@ Generator of printable ASCII characters (space through <code>~</code>).
     PhelFunction(
         namespace = "test.gen",
         name = "test.gen/char-alpha",
-        signature = "",
+        signature = "(char-alpha _size)",
         completion = CompletionInfo(
             tailText = "Generator of ASCII letters",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -57,7 +57,7 @@ Generator of printable ASCII characters (space through <code>~</code>).
             summary = "Generator of ASCII letters.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/gen.phel#L115",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/gen.phel#L115",
                 docs = "",
             ),
         ),
@@ -65,7 +65,7 @@ Generator of printable ASCII characters (space through <code>~</code>).
     PhelFunction(
         namespace = "test.gen",
         name = "test.gen/char-alphanumeric",
-        signature = "",
+        signature = "(char-alphanumeric _size)",
         completion = CompletionInfo(
             tailText = "Generator of ASCII letters and digits",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -74,7 +74,7 @@ Generator of printable ASCII characters (space through <code>~</code>).
             summary = "Generator of ASCII letters and digits.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/gen.phel#L119",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/gen.phel#L119",
                 docs = "",
             ),
         ),
@@ -93,7 +93,7 @@ Generator of integers in the closed interval <code>[lo hi]</code>.
 """,
             example = "((choose 1 6) 100) ; =&gt; 1..6",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/gen.phel#L84",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/gen.phel#L84",
                 docs = "",
             ),
         ),
@@ -112,7 +112,7 @@ Number of trials <code>quick-check</code> runs by default.
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/gen.phel#L34",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/gen.phel#L34",
                 docs = "",
             ),
         ),
@@ -131,7 +131,7 @@ Magnitude used when no <code>:size</code> option is supplied.
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/gen.phel#L30",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/gen.phel#L30",
                 docs = "",
             ),
         ),
@@ -160,7 +160,7 @@ Shape: <code>(defspec name options args-gen property)</code>.
 """,
             example = "(defspec addition-commutes {:num-tests 200}\n              (tuple int int)\n              (fn [a b] (= (+ a b) (+ b a))))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/gen.phel#L429",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/gen.phel#L429",
                 docs = "",
             ),
         ),
@@ -179,7 +179,7 @@ Generator that picks a random element from <code>coll</code>.
 """,
             example = "((elements [:a :b :c]) 100) ; =&gt; :a, :b or :c",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/gen.phel#L212",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/gen.phel#L212",
                 docs = "",
             ),
         ),
@@ -187,7 +187,7 @@ Generator that picks a random element from <code>coll</code>.
     PhelFunction(
         namespace = "test.gen",
         name = "test.gen/float",
-        signature = "",
+        signature = "(float _size)",
         completion = CompletionInfo(
             tailText = "Generator of floats in [0, 1)",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -198,7 +198,7 @@ Generator of floats in <code>[0, 1)</code>.
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/gen.phel#L80",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/gen.phel#L80",
                 docs = "",
             ),
         ),
@@ -217,7 +217,7 @@ Returns a generator that applies <code>f</code> to values produced by <code>g</c
 """,
             example = "((fmap inc (return 1)) 100) ; =&gt; 2",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/gen.phel#L180",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/gen.phel#L180",
                 docs = "",
             ),
         ),
@@ -236,7 +236,7 @@ Generator that picks one of the <code>[weight gen]</code> pairs with probability
 """,
             example = "((frequency [[9 (return :a)] [1 (return :b)]]) 100)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/gen.phel#L232",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/gen.phel#L232",
                 docs = "",
             ),
         ),
@@ -255,7 +255,7 @@ Runs <code>g</code> once and returns a single value. Accepts <code>:size</code> 
 """,
             example = "(generate int) ; =&gt; 42",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/gen.phel#L309",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/gen.phel#L309",
                 docs = "",
             ),
         ),
@@ -263,7 +263,7 @@ Runs <code>g</code> once and returns a single value. Accepts <code>:size</code> 
     PhelFunction(
         namespace = "test.gen",
         name = "test.gen/int",
-        signature = "",
+        signature = "(int size)",
         completion = CompletionInfo(
             tailText = "Generator of integers in [-size, size]",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -274,7 +274,7 @@ Generator of integers in <code>[-size, size]</code>.
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/gen.phel#L70",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/gen.phel#L70",
                 docs = "",
             ),
         ),
@@ -293,7 +293,7 @@ Generator of keywords with alphabetic names, length in <code>[1, max(1, size)]</
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/gen.phel#L162",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/gen.phel#L162",
                 docs = "",
             ),
         ),
@@ -301,7 +301,7 @@ Generator of keywords with alphabetic names, length in <code>[1, max(1, size)]</
     PhelFunction(
         namespace = "test.gen",
         name = "test.gen/large-int",
-        signature = "",
+        signature = "(large-int _size)",
         completion = CompletionInfo(
             tailText = "Generator of arbitrary PHP-range integers",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -310,7 +310,7 @@ Generator of keywords with alphabetic names, length in <code>[1, max(1, size)]</
             summary = "Generator of arbitrary PHP-range integers.",
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/gen.phel#L76",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/gen.phel#L76",
                 docs = "",
             ),
         ),
@@ -329,7 +329,7 @@ Generator of lists whose elements come from <code>g</code>. Length in <code>[0, 
 """,
             example = "((list-of int) 3) ; =&gt; (-1 2 0)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/gen.phel#L278",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/gen.phel#L278",
                 docs = "",
             ),
         ),
@@ -346,9 +346,9 @@ Generator of lists whose elements come from <code>g</code>. Length in <code>[0, 
             summary = """
 Generator of hash-maps with keys from <code>kg</code> and values from <code>vg</code>. Number of entries is in <code>[0, size]</code>.
 """,
-            example = "((map-of keyword int) 2) ; =&gt; {:a 1 :b -3}",
+            example = "((map-of keyword int) 2) ; =&gt; {:a 1, :b -3}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/gen.phel#L285",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/gen.phel#L285",
                 docs = "",
             ),
         ),
@@ -356,7 +356,7 @@ Generator of hash-maps with keys from <code>kg</code> and values from <code>vg</
     PhelFunction(
         namespace = "test.gen",
         name = "test.gen/nat",
-        signature = "",
+        signature = "(nat size)",
         completion = CompletionInfo(
             tailText = "Generator of non-negative integers in [0, size]",
             priority = PhelCompletionPriority.CORE_FUNCTIONS,
@@ -367,7 +367,7 @@ Generator of non-negative integers in <code>[0, size]</code>.
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/gen.phel#L66",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/gen.phel#L66",
                 docs = "",
             ),
         ),
@@ -386,7 +386,7 @@ Generator that selects uniformly from <code>gens</code> and runs the chosen one.
 """,
             example = "((one-of [int boolean]) 100)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/gen.phel#L222",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/gen.phel#L222",
                 docs = "",
             ),
         ),
@@ -415,7 +415,7 @@ Options:<br />
 """,
             example = "(quick-check 50 (tuple int int) (fn [a b] (= (+ a b) (+ b a))))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/gen.phel#L365",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/gen.phel#L365",
                 docs = "",
             ),
         ),
@@ -434,7 +434,7 @@ Returns a generator equivalent to <code>g</code> but with <code>size</code> forc
 """,
             example = "((resize 5 nat) 1000) ; =&gt; value in [0, 5]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/gen.phel#L206",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/gen.phel#L206",
                 docs = "",
             ),
         ),
@@ -453,7 +453,7 @@ Generator that always yields <code>x</code>.
 """,
             example = "((return 42) 100) ; =&gt; 42",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/gen.phel#L174",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/gen.phel#L174",
                 docs = "",
             ),
         ),
@@ -472,7 +472,7 @@ Runs <code>g</code> <code>num-samples</code> times (default 10) and returns a ve
 """,
             example = "(sample int 5) ; =&gt; [3 -7 0 1 -2]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/gen.phel#L317",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/gen.phel#L317",
                 docs = "",
             ),
         ),
@@ -489,9 +489,9 @@ Runs <code>g</code> <code>num-samples</code> times (default 10) and returns a ve
             summary = """
 Generator of hash-sets with elements from <code>g</code>. Cardinality in <code>[0, size]</code>.
 """,
-            example = "((set-of nat) 3) ; =&gt; (set 1 2 3)",
+            example = "((set-of nat) 3) ; =&gt; #{1 2 3}",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/gen.phel#L295",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/gen.phel#L295",
                 docs = "",
             ),
         ),
@@ -510,7 +510,7 @@ Builds a generator from a function <code>f</code> of <code>size</code>. The retu
 """,
             example = "(sized (fn [n] (return n)))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/gen.phel#L200",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/gen.phel#L200",
                 docs = "",
             ),
         ),
@@ -529,7 +529,7 @@ Renders the human-readable failure message for a <code>defspec</code> outcome ma
 """,
             example = "(spec-failure-message \"my-spec\" {:result :failed ...})",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/gen.phel#L389",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/gen.phel#L389",
                 docs = "",
             ),
         ),
@@ -548,7 +548,7 @@ Generator of printable ASCII strings, length in <code>[0, size]</code>.
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/gen.phel#L134",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/gen.phel#L134",
                 docs = "",
             ),
         ),
@@ -567,7 +567,7 @@ Generator of ASCII alphabetic strings, length in <code>[0, size]</code>.
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/gen.phel#L138",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/gen.phel#L138",
                 docs = "",
             ),
         ),
@@ -586,7 +586,7 @@ Generator of ASCII alphanumeric strings, length in <code>[0, size]</code>.
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/gen.phel#L142",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/gen.phel#L142",
                 docs = "",
             ),
         ),
@@ -606,7 +606,7 @@ Generator yielding only values from <code>g</code> that satisfy <code>pred</code
 """,
             example = "((such-that even? nat) 100)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/gen.phel#L186",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/gen.phel#L186",
                 docs = "",
             ),
         ),
@@ -625,7 +625,7 @@ Generator of symbols with alphabetic names, length in <code>[1, max(1, size)]</c
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/gen.phel#L166",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/gen.phel#L166",
                 docs = "",
             ),
         ),
@@ -644,7 +644,7 @@ Generator of a fixed-length vector produced by running each of the given generat
 """,
             example = "((tuple int boolean) 10) ; =&gt; [3 true]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/gen.phel#L251",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/gen.phel#L251",
                 docs = "",
             ),
         ),
@@ -664,7 +664,7 @@ Generator of vectors. Length is <code>[0, size]</code> with one arg, exactly <co
 """,
             example = "((vector-of int) 3) ; =&gt; [-1 2 0]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/gen.phel#L264",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/gen.phel#L264",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/test/registerTestRoseFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/test/registerTestRoseFunctions.kt
@@ -23,7 +23,7 @@ Rose tree for an integer <code>n</code> that shrinks toward zero.
 """,
             example = "(int-rose-tree 10)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/rose.phel#L213",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/rose.phel#L211",
                 docs = "",
             ),
         ),
@@ -42,7 +42,7 @@ Rose tree for <code>n</code> whose children shrink strictly toward <code>target<
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/rose.phel#L220",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/rose.phel#L218",
                 docs = "",
             ),
         ),
@@ -61,7 +61,7 @@ Monadic bind. <code>f</code> takes a value and returns a rose tree; the resultin
 """,
             example = "(rose-bind (rose-pure 1) (fn [n] (rose-pure (inc n))))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/rose.phel#L103",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/rose.phel#L101",
                 docs = "",
             ),
         ),
@@ -76,9 +76,9 @@ Monadic bind. <code>f</code> takes a value and returns a rose tree; the resultin
         ),
         documentation = DocumentationInfo(
             summary = "Returns the lazy sequence of immediate child rose trees.",
-            example = "(rose-children (rose-pure 1)) ; =&gt; @[]",
+            example = "(rose-children (rose-pure 1)) ; =&gt; ()",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/rose.phel#L70",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/rose.phel#L68",
                 docs = "",
             ),
         ),
@@ -99,7 +99,7 @@ Returns the subtree consisting only of nodes whose value satisfies<br />
 """,
             example = "(rose-filter pos? (rose-pure 1))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/rose.phel#L117",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/rose.phel#L115",
                 docs = "",
             ),
         ),
@@ -118,7 +118,7 @@ Applies <code>f</code> to every value in rose tree <code>t</code> (the root and,
 """,
             example = "(rose-fmap inc (rose-pure 1)) ; root = 2",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/rose.phel#L94",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/rose.phel#L92",
                 docs = "",
             ),
         ),
@@ -135,7 +135,7 @@ Applies <code>f</code> to every value in rose tree <code>t</code> (the root and,
             summary = "Flattens a rose tree of rose trees into a single rose tree.",
             example = "(rose-join (rose-pure (rose-pure 1)))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/rose.phel#L130",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/rose.phel#L128",
                 docs = "",
             ),
         ),
@@ -156,7 +156,7 @@ Rose tree for a hash-map. <code>entry-trees</code> is a vector of rose trees of<
 """,
             example = "(rose-map [...])",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/rose.phel#L297",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/rose.phel#L295",
                 docs = "",
             ),
         ),
@@ -175,7 +175,7 @@ Leaf rose tree: value <code>x</code> with no shrink candidates.
 """,
             example = "(rose-pure 42)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/rose.phel#L49",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/rose.phel#L47",
                 docs = "",
             ),
         ),
@@ -194,7 +194,7 @@ Returns the root value of rose tree <code>t</code>.
 """,
             example = "(rose-root (rose-pure 42)) ; =&gt; 42",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/rose.phel#L63",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/rose.phel#L61",
                 docs = "",
             ),
         ),
@@ -211,9 +211,9 @@ Returns the root value of rose tree <code>t</code>.
             summary = """
 Alias for <code>rose-children</code>: the lazy sequence of immediate smaller variants of the current root.
 """,
-            example = "(rose-shrinks (rose-pure 1)) ; =&gt; @[]",
+            example = "(rose-shrinks (rose-pure 1)) ; =&gt; ()",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/rose.phel#L77",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/rose.phel#L75",
                 docs = "",
             ),
         ),
@@ -230,7 +230,7 @@ Alias for <code>rose-children</code>: the lazy sequence of immediate smaller var
             summary = "Rose tree for a string whose elements are char rose trees.",
             example = "(rose-string [(rose-pure \" \")])",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/rose.phel#L280",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/rose.phel#L278",
                 docs = "",
             ),
         ),
@@ -249,7 +249,7 @@ Rose tree constructor. <code>children</code> should be a lazy sequence of rose t
 """,
             example = "(rose-tree 1 (list (rose-pure 0)))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/rose.phel#L56",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/rose.phel#L54",
                 docs = "",
             ),
         ),
@@ -268,7 +268,7 @@ Rose tree for a vector whose children are built from the rose trees of its eleme
 """,
             example = "(rose-vector [(int-rose-tree 3) (int-rose-tree 5)])",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/rose.phel#L253",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/rose.phel#L251",
                 docs = "",
             ),
         ),
@@ -287,7 +287,7 @@ Like <code>rose-vector</code> but preserves original length; only shrinks each e
 """,
             example = null,
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/rose.phel#L266",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/rose.phel#L264",
                 docs = "",
             ),
         ),
@@ -306,7 +306,7 @@ Takes a vector of rose trees and returns a rose tree whose root is the vector of
 """,
             example = "(rose-zip [(rose-pure 1) (rose-pure 2)])",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/rose.phel#L160",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/rose.phel#L158",
                 docs = "",
             ),
         ),
@@ -325,7 +325,7 @@ Returns <code>true</code> if <code>x</code> looks like a rose tree.
 """,
             example = "(rose? (rose-pure 1)) ; =&gt; true",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/rose.phel#L84",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/rose.phel#L82",
                 docs = "",
             ),
         ),
@@ -344,7 +344,7 @@ Shrink strategy toward zero: halving steps (<code>n/2</code>, <code>n/4</code>, 
 """,
             example = "(shrink-int 8)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/rose.phel#L200",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/rose.phel#L198",
                 docs = "",
             ),
         ),
@@ -364,7 +364,7 @@ Returns a seq of integer candidates strictly closer to <code>target</code> than<
 """,
             example = "(shrink-int-towards 0 10) ; =&gt; [0 5 8 9]",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/rose.phel#L180",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/rose.phel#L178",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/test/registerTestSelectorFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/test/registerTestSelectorFunctions.kt
@@ -23,7 +23,7 @@ Returns <code>true</code> when <code>options</code> contains at least one non-em
 """,
             example = "(has-selectors? {:include [:integration]})",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/selector.phel#L205",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/selector.phel#L210",
                 docs = "",
             ),
         ),
@@ -42,7 +42,7 @@ Returns <code>true</code> when <code>meta</code> carries <code>tag</code> (a key
 """,
             example = "(has-tag? {:integration true} :integration)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/selector.phel#L54",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/selector.phel#L55",
                 docs = "",
             ),
         ),
@@ -61,7 +61,7 @@ Returns <code>true</code> when the test described by <code>meta</code> and <code
 """,
             example = "(keep-test? {:include [:integration]} \"my.ns\" {:integration true :test-name \"t\"})",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/selector.phel#L188",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/selector.phel#L193",
                 docs = "",
             ),
         ),
@@ -80,7 +80,7 @@ Returns <code>true</code> when any tag in <code>excludes</code> is truthy on <co
 """,
             example = "(matches-exclude? [:slow] {:slow true})",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/selector.phel#L78",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/selector.phel#L79",
                 docs = "",
             ),
         ),
@@ -99,7 +99,7 @@ Returns <code>true</code> when <code>patterns</code> is empty (no restriction) o
 """,
             example = "(matches-filter? [\"add-\"] \"test-add-one\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/selector.phel#L176",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/selector.phel#L181",
                 docs = "",
             ),
         ),
@@ -118,7 +118,7 @@ Returns <code>true</code> when <code>includes</code> is empty (no restriction) o
 """,
             example = "(matches-include? [:integration] {:integration true})",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/selector.phel#L70",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/selector.phel#L71",
                 docs = "",
             ),
         ),
@@ -137,7 +137,7 @@ Returns <code>true</code> when <code>patterns</code> is empty (no restriction) o
 """,
             example = "(matches-ns? [\"phel.http.*\"] \"phel.http.client\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/selector.phel#L145",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/selector.phel#L148",
                 docs = "",
             ),
         ),
@@ -156,7 +156,7 @@ Returns <code>true</code> when <code>pattern</code> (a PCRE <code>/.../</code> s
 """,
             example = "(name-matches? \"add-\" \"test-add-one\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/selector.phel#L167",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/selector.phel#L172",
                 docs = "",
             ),
         ),
@@ -178,7 +178,7 @@ Returns <code>true</code> when <code>ns-name</code> matches the glob <code>patte
 """,
             example = "(ns-matches? \"phel.http.*\" \"phel\\\\http\\\\client\")",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/selector.phel#L132",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/selector.phel#L135",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/registry/data/test/registerTestShrinkFunctions.kt
+++ b/src/main/kotlin/org/phellang/registry/data/test/registerTestShrinkFunctions.kt
@@ -23,7 +23,7 @@ Rose tree whose root is <code>args</code> and children shrink each positional ar
 """,
             example = "(args-&gt;rose [10])",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/shrink.phel#L103",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/shrink.phel#L105",
                 docs = "",
             ),
         ),
@@ -44,7 +44,7 @@ Walks rose tree <code>tree</code> depth-first, greedily descending into any<br /
 """,
             example = "(shrink pred (value-&gt;rose failing-value))",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/shrink.phel#L84",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/shrink.phel#L86",
                 docs = "",
             ),
         ),
@@ -65,7 +65,7 @@ Shrinks a failing args vector using <code>property</code>. Returns<br />
 """,
             example = "(shrink-args property [10])",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/shrink.phel#L111",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/shrink.phel#L113",
                 docs = "",
             ),
         ),
@@ -84,7 +84,7 @@ Builds a rose tree for <code>v</code> using the built-in shrink strategy that ma
 """,
             example = "(value-&gt;rose 10)",
             links = DocumentationLinks(
-                github = "https://github.com/phel-lang/phel-lang/blob/v0.49.0/src/phel/test/shrink.phel#L48",
+                github = "https://github.com/phel-lang/phel-lang/blob/v0.50.0/src/phel/test/shrink.phel#L50",
                 docs = "",
             ),
         ),

--- a/src/main/kotlin/org/phellang/tools/generator/NamespaceConfig.kt
+++ b/src/main/kotlin/org/phellang/tools/generator/NamespaceConfig.kt
@@ -12,6 +12,7 @@ object NamespaceConfig {
         "ai" to NamespaceInfo("registerAiFunctions", "registerAiFunctions.kt"),
         "async" to NamespaceInfo("registerAsyncFunctions", "registerAsyncFunctions.kt"),
         "base64" to NamespaceInfo("registerBase64Functions", "registerBase64Functions.kt"),
+        "bench" to NamespaceInfo("registerBenchFunctions", "registerBenchFunctions.kt"),
         "cli" to NamespaceInfo("registerCliFunctions", "registerCliFunctions.kt"),
         "core" to NamespaceInfo("registerCoreFunctions", "registerCoreFunctions.kt"),
         "edn" to NamespaceInfo("registerEdnFunctions", "registerEdnFunctions.kt"),

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -139,6 +139,14 @@
                 implementationClass="org.phellang.inspection.deprecated.PhelBackslashNamespaceInspection"/>
         <localInspection
                 language="Phel"
+                shortName="PhelSupersededForm"
+                displayName="Superseded interop or var form"
+                groupName="Phel"
+                enabledByDefault="true"
+                level="WARNING"
+                implementationClass="org.phellang.inspection.deprecated.PhelSupersededFormInspection"/>
+        <localInspection
+                language="Phel"
                 shortName="PhelArityMismatch"
                 displayName="Function arity mismatch"
                 groupName="Phel"

--- a/src/main/resources/inspectionDescriptions/PhelSupersededForm.html
+++ b/src/main/resources/inspectionDescriptions/PhelSupersededForm.html
@@ -1,0 +1,27 @@
+<html>
+<body>
+<p>Reports the source forms Phel 0.50 superseded, mirroring the compiler's own
+    <code>--warn-deprecations</code> output in the editor.</p>
+
+<p>The rule behind the interop entries is that <code>php/</code> means host access, and is never a
+    second spelling for something Phel already says the Clojure way. The superseded forms keep
+    working for every 1.x release and remain the target the Clojure-style shorthand expands to, so
+    they still appear in completion; they are the candidates for removal at the next major.</p>
+
+<table>
+    <tr><th>Superseded</th><th>Write instead</th></tr>
+    <tr><td><code>(php/new Foo arg)</code></td><td><code>(Foo. arg)</code> or <code>(new Foo arg)</code></td></tr>
+    <tr><td><code>(php/-&gt; obj (method arg))</code></td><td><code>(.method obj arg)</code> or <code>(.-field obj)</code></td></tr>
+    <tr><td><code>(php/:: Foo (method arg))</code></td><td><code>(Foo/method arg)</code> or <code>Foo/CONST</code></td></tr>
+    <tr><td><code>(set-var v x)</code></td><td><code>(alter-var-root #'v f)</code>, or <code>(set! v x)</code> for the current binding frame</td></tr>
+</table>
+
+<p>The rest of the <code>php/</code> family is not reported. <code>php/aget</code>,
+    <code>php/aset</code>, <code>php/apush</code>, <code>php/aunset</code>, <code>php/oset</code>,
+    <code>php/ref</code> and <code>php/callable</code> each reach a PHP capability Phel has no other
+    word for, so they are current rather than superseded.</p>
+
+<p>No quick-fix is offered: every replacement here reorders or re-nests the call's arguments, so
+    there is no text substitution that would be correct in general.</p>
+</body>
+</html>

--- a/src/test/kotlin/org/phellang/fixtures/PhelDeprecatedFunctionFixtures.kt
+++ b/src/test/kotlin/org/phellang/fixtures/PhelDeprecatedFunctionFixtures.kt
@@ -1,0 +1,99 @@
+package org.phellang.fixtures
+
+import org.phellang.registry.CompletionInfo
+import org.phellang.registry.DeprecationInfo
+import org.phellang.registry.DocumentationInfo
+import org.phellang.registry.PhelCompletionPriority
+import org.phellang.registry.PhelFunction
+
+/**
+ * In-memory deprecated functions for the deprecation feature's tests.
+ *
+ * Phel v0.50.0 removed every deprecated function from the language, so `api.json` — and therefore
+ * the generated registry — no longer contains a single entry with deprecation metadata. The
+ * feature itself (inspection, annotator rule, quick-fix, completion priority) is unchanged and
+ * still ships; only its test data disappeared.
+ *
+ * These fixtures reproduce the entries as they were generated for Phel v0.49.0, so the tests keep
+ * exercising the real shapes the code has to handle:
+ *
+ *  - a plain `version` + `replacement` pair ([PUT] and friends), and
+ *  - the `version = "Use phel\ns\fn"` convention, where the version field carries the replacement
+ *    instead ([STR_CONTAINS]), which [DeprecationInfo.rawReplacement] has to unpack.
+ *
+ * Core functions are named without a `core/` prefix, matching how the generator emits them.
+ *
+ * Install with `PhelFunctionRegistry.installTestFunctions(...)` and always clear afterwards.
+ */
+object PhelDeprecatedFunctionFixtures {
+
+    val PUT = deprecated(
+        name = "put",
+        signature = "(put ds key value)",
+        summary = "Puts a value into a data structure.",
+        deprecation = DeprecationInfo(version = "0.25.0", replacement = "assoc"),
+    )
+
+    val PUT_IN = deprecated(
+        name = "put-in",
+        signature = "(put-in ds ks v)",
+        summary = "Puts a value into a nested data structure.",
+        deprecation = DeprecationInfo(version = "0.25.0", replacement = "assoc-in"),
+    )
+
+    val PUSH = deprecated(
+        name = "push",
+        signature = "(push xs x)",
+        summary = "Inserts x at the end of the sequence xs.",
+        deprecation = DeprecationInfo(version = "0.25.0", replacement = "conj"),
+    )
+
+    val UNSET = deprecated(
+        name = "unset",
+        signature = "(unset ds key)",
+        summary = "Removes an entry from a data structure.",
+        deprecation = DeprecationInfo(version = "0.25.0", replacement = "dissoc"),
+    )
+
+    val UNSET_IN = deprecated(
+        name = "unset-in",
+        signature = "(unset-in ds ks)",
+        summary = "Removes an entry from a nested data structure.",
+        deprecation = DeprecationInfo(version = "0.25.0", replacement = "dissoc-in"),
+    )
+
+    val FUNCTION_P = deprecated(
+        name = "function?",
+        signature = "(function? x)",
+        summary = "Checks if x is a function.",
+        deprecation = DeprecationInfo(version = "0.32.0", replacement = "fn?"),
+    )
+
+    /** The "Use xyz" convention: the replacement rides in the version field, not in `replacement`. */
+    val STR_CONTAINS = deprecated(
+        name = "str-contains?",
+        signature = "(str-contains? s subs)",
+        summary = "Checks if the string contains the substring.",
+        deprecation = DeprecationInfo(version = "Use phel\\string\\contains?"),
+    )
+
+    /** Every fixture, for tests that just need the registry to report deprecations again. */
+    val ALL = listOf(PUT, PUT_IN, PUSH, UNSET, UNSET_IN, FUNCTION_P, STR_CONTAINS)
+
+    private fun deprecated(
+        name: String,
+        signature: String,
+        summary: String,
+        deprecation: DeprecationInfo,
+    ) = PhelFunction(
+        namespace = "core",
+        name = name,
+        signature = signature,
+        completion = CompletionInfo(
+            tailText = summary,
+            // The generator routes any deprecated function here before any other rule.
+            priority = PhelCompletionPriority.DEPRECATED_FUNCTIONS,
+        ),
+        documentation = DocumentationInfo(summary = summary, deprecation = deprecation),
+    )
+}

--- a/src/test/kotlin/org/phellang/integration/annotator/PhelDeprecatedAnnotatorTest.kt
+++ b/src/test/kotlin/org/phellang/integration/annotator/PhelDeprecatedAnnotatorTest.kt
@@ -1,13 +1,27 @@
 package org.phellang.integration.annotator
 
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.phellang.core.highlighting.PhelAnnotationConstants
+import org.phellang.fixtures.PhelDeprecatedFunctionFixtures
 import org.phellang.registry.PhelFunctionRegistry
 
 class PhelDeprecatedAnnotatorTest {
+
+    // No stdlib function has been deprecated since Phel v0.50.0; see the fixtures' KDoc.
+    @BeforeEach
+    fun installFixtures() {
+        PhelFunctionRegistry.installTestFunctions(PhelDeprecatedFunctionFixtures.ALL)
+    }
+
+    @AfterEach
+    fun clearFixtures() {
+        PhelFunctionRegistry.clearTestFunctions()
+    }
 
     @Nested
     inner class DeprecationHighlighting {

--- a/src/test/kotlin/org/phellang/integration/completion/PhelReferCompletionIntegrationTest.kt
+++ b/src/test/kotlin/org/phellang/integration/completion/PhelReferCompletionIntegrationTest.kt
@@ -53,7 +53,9 @@ class PhelReferCompletionIntegrationTest {
         @Test
         fun `callable functions should have signature information`() {
             val functions = PhelFunctionRegistry.getFunctions(Namespace.TEST)
-                .filter { !it.name.contains("*") && !it.name.endsWith("-methods") }
+                // `-methods` and `-prefers` are multimethod dispatch/preference tables, not
+                // callables: api.json gives them no signature.
+                .filter { !it.name.contains("*") && !it.name.endsWith("-methods") && !it.name.endsWith("-prefers") }
 
             functions.forEach { function ->
                 assertNotNull(function.signature, "Function should have signature: ${function.name}")
@@ -64,7 +66,9 @@ class PhelReferCompletionIntegrationTest {
         @Test
         fun `callable functions should have documentation summary`() {
             val functions = PhelFunctionRegistry.getFunctions(Namespace.TEST)
-                .filter { !it.name.contains("*") && !it.name.endsWith("-methods") }
+                // `-methods` and `-prefers` are multimethod dispatch/preference tables, not
+                // callables: api.json gives them no signature.
+                .filter { !it.name.contains("*") && !it.name.endsWith("-methods") && !it.name.endsWith("-prefers") }
 
             val functionsWithDocs = functions.filter { it.documentation.summary.isNotBlank() }
             assertTrue(

--- a/src/test/kotlin/org/phellang/integration/inspection/PhelArityMismatchInspectionIntegrationTest.kt
+++ b/src/test/kotlin/org/phellang/integration/inspection/PhelArityMismatchInspectionIntegrationTest.kt
@@ -141,11 +141,13 @@ class PhelArityMismatchInspectionIntegrationTest : PhelIntegrationTestCase() {
         assertTrue("discard dropping a required arg should be flagged: $warnings", warnings.any { it.contains("'some'") })
     }
 
-    fun testShortFnArgIsNotMiscounted() {
-        // Phel's deprecated `|(...)` short-fn is a single anonymous-function argument.
-        // (some |(> $ 10) coll) is a 2-arg call, not 3.
-        val warnings = inspect("(ns app\\m)\n(some |(> $ 10) coll)\n")
-        assertTrue("|(...) short-fn arg should count as one form: $warnings", warnings.isEmpty())
+    fun testRemovedShortFnIsNoLongerTreatedAsOneForm() {
+        // Phel v0.50.0 removed the `|(...)` short fn, and `|` is no longer a token: the reader
+        // reports an unresolvable symbol `|`. So (some |(> % 10) coll) is a genuine 3-arg call to
+        // a 2-arg function, and suppressing the arity warning would hide a real error.
+        val warnings = inspect("(ns app\\m)\n(some |(> % 10) coll)\n")
+        assertTrue("removed |(...) syntax should not suppress the arity check: $warnings",
+            warnings.any { it.contains("'some'") })
     }
 
     fun testHashFnArgIsNotMiscounted() {

--- a/src/test/kotlin/org/phellang/integration/inspection/PhelArityMismatchInspectionIntegrationTest.kt
+++ b/src/test/kotlin/org/phellang/integration/inspection/PhelArityMismatchInspectionIntegrationTest.kt
@@ -136,9 +136,9 @@ class PhelArityMismatchInspectionIntegrationTest : PhelIntegrationTestCase() {
     }
 
     fun testDiscardTurningValidCallInvalidIsFlagged() {
-        // Discarding a required arg makes (push coll) a 1-arg call -- still wrong.
-        val warnings = inspect("(ns app\\m)\n(push coll #_x)\n")
-        assertTrue("discard dropping a required arg should be flagged: $warnings", warnings.any { it.contains("'push'") })
+        // Discarding a required arg makes (some pred) a 1-arg call -- still wrong.
+        val warnings = inspect("(ns app\\m)\n(some pred #_coll)\n")
+        assertTrue("discard dropping a required arg should be flagged: $warnings", warnings.any { it.contains("'some'") })
     }
 
     fun testShortFnArgIsNotMiscounted() {

--- a/src/test/kotlin/org/phellang/integration/inspection/PhelDeprecatedFunctionInspectionFiringTest.kt
+++ b/src/test/kotlin/org/phellang/integration/inspection/PhelDeprecatedFunctionInspectionFiringTest.kt
@@ -4,9 +4,11 @@ import com.intellij.codeInspection.InspectionManager
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiRecursiveElementVisitor
+import org.phellang.fixtures.PhelDeprecatedFunctionFixtures
 import org.phellang.integration.PhelIntegrationTestCase
 import org.phellang.inspection.deprecated.PhelDeprecatedFunctionInspection
 import org.phellang.language.psi.files.PhelFile
+import org.phellang.registry.PhelFunctionRegistry
 
 /**
  * Confirms the deprecated-function inspection actually fires against parsed PSI (it visits
@@ -14,6 +16,21 @@ import org.phellang.language.psi.files.PhelFile
  * deprecated core name.
  */
 class PhelDeprecatedFunctionInspectionFiringTest : PhelIntegrationTestCase() {
+
+    // Phel v0.50.0 deleted every deprecated function, so 'put' is supplied as a fixture; the
+    // inspection under test still reaches it through the ordinary registry lookup.
+    override fun setUp() {
+        super.setUp()
+        PhelFunctionRegistry.installTestFunctions(PhelDeprecatedFunctionFixtures.ALL)
+    }
+
+    override fun tearDown() {
+        try {
+            PhelFunctionRegistry.clearTestFunctions()
+        } finally {
+            super.tearDown()
+        }
+    }
 
     fun testDeprecatedCallIsFlagged() {
         val warnings = inspect("(ns app\\m)\n(put {} :a 1)\n")

--- a/src/test/kotlin/org/phellang/integration/inspection/PhelDeprecatedFunctionInspectionIntegrationTest.kt
+++ b/src/test/kotlin/org/phellang/integration/inspection/PhelDeprecatedFunctionInspectionIntegrationTest.kt
@@ -1,14 +1,28 @@
 package org.phellang.integration.inspection
 
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.phellang.fixtures.PhelDeprecatedFunctionFixtures
 import org.phellang.registry.DeprecationInfo
 import org.phellang.registry.PhelFunctionRegistry
 import org.phellang.inspection.deprecated.DeprecationMessageBuilder
 import org.phellang.registry.ReplacementParser
 
 class PhelDeprecatedFunctionInspectionIntegrationTest {
+
+    // No stdlib function has been deprecated since Phel v0.50.0; see the fixtures' KDoc.
+    @BeforeEach
+    fun installFixtures() {
+        PhelFunctionRegistry.installTestFunctions(PhelDeprecatedFunctionFixtures.ALL)
+    }
+
+    @AfterEach
+    fun clearFixtures() {
+        PhelFunctionRegistry.clearTestFunctions()
+    }
 
     @Nested
     inner class DeprecationDetectionWorkflow {

--- a/src/test/kotlin/org/phellang/integration/inspection/PhelSupersededFormInspectionTest.kt
+++ b/src/test/kotlin/org/phellang/integration/inspection/PhelSupersededFormInspectionTest.kt
@@ -1,0 +1,89 @@
+package org.phellang.integration.inspection
+
+import com.intellij.codeInspection.InspectionManager
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiRecursiveElementVisitor
+import org.phellang.inspection.deprecated.PhelSupersededFormInspection
+import org.phellang.integration.PhelIntegrationTestCase
+import org.phellang.language.psi.files.PhelFile
+
+/**
+ * The forms Phel v0.50.0 superseded (#2877, #2888), and — just as important — the rest of the
+ * `php/` family, which it deliberately kept and which must stay silent.
+ */
+class PhelSupersededFormInspectionTest : PhelIntegrationTestCase() {
+
+    private var fileIndex = 0
+
+    private fun inspect(source: String): List<String> {
+        val file = myFixture.configureByText("s${fileIndex++}.phel", "(ns app\\m)\n$source") as PhelFile
+        val holder = ProblemsHolder(InspectionManager.getInstance(project), file, true)
+        val visitor = PhelSupersededFormInspection().buildVisitor(holder, true)
+        file.accept(object : PsiRecursiveElementVisitor() {
+            override fun visitElement(element: PsiElement) {
+                element.accept(visitor)
+                super.visitElement(element)
+            }
+        })
+        return holder.results.map { it.descriptionTemplate }
+    }
+
+    fun testPhpNewIsFlaggedWithItsClojureSpelling() {
+        val warnings = inspect("(php/new Foo 1)")
+        assertTrue("php/new should be flagged: $warnings", warnings.any { it.contains("'php/new'") })
+        assertTrue("should name the replacement: $warnings", warnings.any { it.contains("(Foo. arg)") })
+    }
+
+    fun testPhpArrowIsFlagged() {
+        val warnings = inspect("(php/-> obj (method 1))")
+        assertTrue("php/-> should be flagged: $warnings", warnings.any { it.contains("'php/->'") })
+    }
+
+    fun testPhpStaticIsFlagged() {
+        val warnings = inspect("(php/:: Foo (method 1))")
+        assertTrue("php/:: should be flagged: $warnings", warnings.any { it.contains("'php/::'") })
+    }
+
+    fun testSetVarIsFlagged() {
+        val warnings = inspect("(set-var v 1)")
+        assertTrue("set-var should be flagged: $warnings", warnings.any { it.contains("'set-var'") })
+        assertTrue("should name alter-var-root: $warnings", warnings.any { it.contains("alter-var-root") })
+    }
+
+    fun testInteropFormsWithNoClojureSpellingStaySilent() {
+        // Each of these reaches a PHP capability Phel has no other word for, so none is superseded.
+        for (form in listOf(
+            "(php/aget arr 0)",
+            "(php/aset arr 0 1)",
+            "(php/apush arr 1)",
+            "(php/aunset arr 0)",
+            "(php/oset (php/:: Foo slot) 1)",
+            "(php/ref x)",
+            "(php/callable f)",
+        )) {
+            val warnings = inspect(form).filterNot { it.contains("'php/::'") }
+            assertTrue("$form should stay silent: $warnings", warnings.isEmpty())
+        }
+    }
+
+    fun testClojureStyleSpellingsStaySilent() {
+        for (form in listOf(
+            "(Foo. 1)",
+            "(new Foo 1)",
+            "(.method obj 1)",
+            "(.-field obj)",
+            "(Foo/method 1)",
+            "(println Foo/CONST)",
+            "(set! v 1)",
+        )) {
+            val warnings = inspect(form)
+            assertTrue("$form is the current spelling and should stay silent: $warnings", warnings.isEmpty())
+        }
+    }
+
+    fun testALocalNamedLikeASupersededFormIsNotFlagged() {
+        val warnings = inspect("(defn f [set-var]\n  (set-var 1))")
+        assertTrue("a local binding shadowing the name is not the form: $warnings", warnings.isEmpty())
+    }
+}

--- a/src/test/kotlin/org/phellang/unit/annotator/highlighters/rules/PhelHighlightRuleTest.kt
+++ b/src/test/kotlin/org/phellang/unit/annotator/highlighters/rules/PhelHighlightRuleTest.kt
@@ -1,8 +1,10 @@
 package org.phellang.unit.annotator.highlighters.rules
 
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -24,7 +26,9 @@ import org.phellang.core.highlighting.PhelAnnotationConstants.FUNCTION_CALL
 import org.phellang.core.highlighting.PhelAnnotationConstants.NAMESPACE_SYMBOL
 import org.phellang.core.highlighting.PhelAnnotationConstants.PHP_INTEROP
 import org.phellang.core.highlighting.PhelAnnotationConstants.REGULAR_SYMBOL
+import org.phellang.fixtures.PhelDeprecatedFunctionFixtures
 import org.phellang.language.psi.PhelSymbol
+import org.phellang.registry.PhelFunctionRegistry
 
 /**
  * Covers the rules whose decision is driven by the symbol's text alone, which is every rule that
@@ -79,7 +83,19 @@ class PhelHighlightRuleTest {
     @Nested
     inner class Deprecation {
 
-        /** `function?` and `push` are marked deprecated in the generated registry data. */
+        // The rule asks the registry, which has held no deprecated functions since Phel v0.50.0
+        // dropped them all, so the names below are supplied as fixtures.
+        @BeforeEach
+        fun installFixtures() {
+            PhelFunctionRegistry.installTestFunctions(PhelDeprecatedFunctionFixtures.ALL)
+        }
+
+        @AfterEach
+        fun clearFixtures() {
+            PhelFunctionRegistry.clearTestFunctions()
+        }
+
+        /** `function?` and `push` were deprecated core functions up to Phel v0.49.0. */
         @ParameterizedTest
         @ValueSource(strings = ["function?", "push"])
         fun `paints deprecated core functions`(text: String) {

--- a/src/test/kotlin/org/phellang/unit/annotator/validators/PhelNamespaceValidatorTest.kt
+++ b/src/test/kotlin/org/phellang/unit/annotator/validators/PhelNamespaceValidatorTest.kt
@@ -19,6 +19,7 @@ class PhelNamespaceValidatorTest {
                 "ai" to "phel.ai",
                 "async" to "phel.async",
                 "base64" to "phel.base64",
+                "bench" to "phel.bench",
                 "cli" to "phel.cli",
                 "core" to "phel.core",
                 "debug" to "phel.debug",

--- a/src/test/kotlin/org/phellang/unit/completion/data/PhelFunctionDeprecationTest.kt
+++ b/src/test/kotlin/org/phellang/unit/completion/data/PhelFunctionDeprecationTest.kt
@@ -1,19 +1,34 @@
 package org.phellang.unit.completion.data
 
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.phellang.fixtures.PhelDeprecatedFunctionFixtures
 import org.phellang.registry.PhelFunctionRegistry
 
 class PhelFunctionDeprecationTest {
+
+    // Phel v0.50.0 removed every deprecated function from the stdlib, so the deprecation lookups
+    // are exercised against in-memory fixtures rather than whatever api.json ships this release.
+    @BeforeEach
+    fun installFixtures() {
+        PhelFunctionRegistry.installTestFunctions(PhelDeprecatedFunctionFixtures.ALL)
+    }
+
+    @AfterEach
+    fun clearFixtures() {
+        PhelFunctionRegistry.clearTestFunctions()
+    }
 
     @Nested
     inner class IsDeprecatedProperty {
 
         @Test
         fun `should return true for deprecated functions`() {
-            // These are actual deprecated functions from the generated registry
+            // Installed fixtures, mirroring how these were generated while Phel still shipped them
             val deprecatedFunctions = listOf(
                 "put",     // core/put - deprecated in favor of assoc
                 "push",    // core/push - deprecated in favor of conj

--- a/src/test/kotlin/org/phellang/unit/inspection/PhelDeprecatedFunctionInspectionTest.kt
+++ b/src/test/kotlin/org/phellang/unit/inspection/PhelDeprecatedFunctionInspectionTest.kt
@@ -1,14 +1,28 @@
 package org.phellang.unit.inspection
 
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.phellang.fixtures.PhelDeprecatedFunctionFixtures
 import org.phellang.registry.DeprecationInfo
 import org.phellang.registry.PhelFunctionRegistry
 import org.phellang.inspection.deprecated.DeprecationMessageBuilder
 import org.phellang.registry.ReplacementParser
 
 class PhelDeprecatedFunctionInspectionTest {
+
+    // The stdlib has carried no deprecated functions since Phel v0.50.0; see the fixtures' KDoc.
+    @BeforeEach
+    fun installFixtures() {
+        PhelFunctionRegistry.installTestFunctions(PhelDeprecatedFunctionFixtures.ALL)
+    }
+
+    @AfterEach
+    fun clearFixtures() {
+        PhelFunctionRegistry.clearTestFunctions()
+    }
 
     @Nested
     inner class DeprecationInfoDataClass {

--- a/src/test/kotlin/org/phellang/unit/language/PhelLexerTest.kt
+++ b/src/test/kotlin/org/phellang/unit/language/PhelLexerTest.kt
@@ -333,6 +333,59 @@ class PhelLexerTest {
         assertEquals("x", tokens[1].second)
     }
 
+    /**
+     * Phel v0.50.0 removed the bare `#` line comment, so `#` heads no token of its own: the reader
+     * rejects it and the rest of the line is read as ordinary forms. Rejecting the character is the
+     * contract — do not "fix" this by reviving a comment rule.
+     */
+    @Test
+    fun `bare hash line comment is rejected, not lexed as a comment`() {
+        val tokens = tokenize("# old comment\n(+ 1 2)")
+
+        assertEquals(TokenType.BAD_CHARACTER, tokens[0].first)
+        assertEquals("#", tokens[0].second)
+        // The remainder is read as code, not swallowed as comment text.
+        assertEquals(PhelTypes.SYM, tokens[2].first)
+        assertEquals("old", tokens[2].second)
+    }
+
+    /** `#| ... |#` went with it: `#` is rejected and the delimiters fall out as plain symbols. */
+    @Test
+    fun `hash-pipe block comment is rejected, not lexed as a comment`() {
+        val tokens = tokenize("#| block |# (+ 1 2)")
+
+        assertEquals(TokenType.BAD_CHARACTER, tokens[0].first)
+        assertEquals("#", tokens[0].second)
+        assertEquals(PhelTypes.SYM, tokens[1].first)
+        assertEquals("|", tokens[1].second)
+        // `block` is code, not comment text.
+        assertEquals(PhelTypes.SYM, tokens[3].first)
+        assertEquals("block", tokens[3].second)
+    }
+
+    /**
+     * The trailing `$` auto-gensym was replaced by a trailing `#`. Both are ordinary symbol
+     * characters to the lexer, so this pins that neither is given reader-macro meaning.
+     */
+    @Test
+    fun `trailing dollar is an ordinary symbol, not auto-gensym`() {
+        val tokens = tokenize("foo$")
+
+        assertEquals(1, tokens.size, "expected a single symbol, got $tokens")
+        assertEquals(PhelTypes.SYM, tokens[0].first)
+        assertEquals("foo$", tokens[0].second)
+    }
+
+    /** `$1` was a `|(...)` short-fn parameter; with that syntax gone it is just a name. */
+    @Test
+    fun `dollar-digit is an ordinary symbol, not a short-fn parameter`() {
+        val tokens = tokenize("$1")
+
+        assertEquals(1, tokens.size, "expected a single symbol, got $tokens")
+        assertEquals(PhelTypes.SYM, tokens[0].first)
+        assertEquals("$1", tokens[0].second)
+    }
+
     // --- Dot-separated namespaces (v0.32.0+): phel.core/fn, clojure.core/fn ---
 
     @Test

--- a/src/test/kotlin/org/phellang/unit/language/psi/PhelProjectNamespaceFinderTest.kt
+++ b/src/test/kotlin/org/phellang/unit/language/psi/PhelProjectNamespaceFinderTest.kt
@@ -65,6 +65,7 @@ class PhelProjectNamespaceFinderTest {
                 "phel.ai",
                 "phel.async",
                 "phel.base64",
+                "phel.bench",
                 "phel.cli",
                 "phel.core",
                 "phel.debug",

--- a/src/test/kotlin/org/phellang/unit/registry/PhpNativeFunctionsTest.kt
+++ b/src/test/kotlin/org/phellang/unit/registry/PhpNativeFunctionsTest.kt
@@ -16,7 +16,10 @@ import org.phellang.registry.PhelFunctionRegistry
  */
 class PhpNativeFunctionsTest {
 
+    // The superglobals share this namespace but are variables, not functions: they carry no
+    // signature and link to php.net's reserved-variables page. See PhpSuperglobalsTest.
     private val functions = PhelFunctionRegistry.getFunctions(Namespace.PHP_NATIVE)
+        .filterNot { it.name.startsWith("php/$") }
 
     @Test
     fun `every entry is php-prefixed, PHP_INTEROP priority, with a php_net function link`() {

--- a/src/test/kotlin/org/phellang/unit/registry/PhpSuperglobalsTest.kt
+++ b/src/test/kotlin/org/phellang/unit/registry/PhpSuperglobalsTest.kt
@@ -1,0 +1,60 @@
+package org.phellang.unit.registry
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.phellang.registry.Namespace
+import org.phellang.registry.PhelCompletionPriority
+import org.phellang.registry.PhelFunctionRegistry
+
+/**
+ * PHP's superglobals reach the registry, so completion and hover offer `php/$_SERVER` the way
+ * Phel's own tooling does since v0.50.0 (#3037).
+ */
+class PhpSuperglobalsTest {
+
+    private val superglobals = PhelFunctionRegistry.getFunctions(Namespace.PHP_NATIVE)
+        .filter { it.name.startsWith("php/$") }
+
+    @Test
+    fun `every PHP superglobal is registered`() {
+        val expected = setOf(
+            "php/\$GLOBALS", "php/\$_SERVER", "php/\$_GET", "php/\$_POST", "php/\$_FILES",
+            "php/\$_COOKIE", "php/\$_SESSION", "php/\$_REQUEST", "php/\$_ENV",
+        )
+
+        assertEquals(expected, superglobals.map { it.name }.toSet())
+    }
+
+    @Test
+    fun `a superglobal is reachable by name`() {
+        val server = PhelFunctionRegistry.getFunction("php/\$_SERVER")
+
+        assertNotNull(server, "php/\$_SERVER should resolve")
+        assertTrue(server!!.documentation.summary.isNotBlank(), "should carry a summary for hover")
+    }
+
+    @Test
+    fun `superglobals are values, not calls`() {
+        superglobals.forEach {
+            assertEquals("", it.signature, "${it.name} is a variable and takes no signature")
+            assertTrue(!it.isCallOnly, "${it.name} must be usable in value position")
+        }
+    }
+
+    @Test
+    fun `superglobals complete at PHP interop priority`() {
+        superglobals.forEach {
+            assertEquals(PhelCompletionPriority.PHP_INTEROP, it.completion.priority, it.name)
+        }
+    }
+
+    @Test
+    fun `superglobals do not displace the generated native functions`() {
+        val natives = PhelFunctionRegistry.getFunctions(Namespace.PHP_NATIVE)
+
+        assertTrue(natives.size > superglobals.size, "generated natives should still be present")
+        assertNotNull(PhelFunctionRegistry.getFunction("php/array_map"), "php/array_map should still resolve")
+    }
+}


### PR DESCRIPTION
Brings the plugin up to Phel **v0.50.0**: regenerates the registry, adds the missing `bench` namespace, and closes the gaps the v0.50.0 syntax changes left behind.

## Why

`updatePhelRegistry` was logging `Warning: Unknown namespace 'bench' with 2 functions - skipping` on every run, and the registry was still pinned to v0.49.0. Regenerating surfaced two further things: v0.50.0 removed every deprecated stdlib function, and it changed the language's syntax surface.

## What changed

### `bench` namespace

`api.json` ships a `bench` namespace that `NamespaceConfig` did not know about, so `KotlinCodeGenerator` skipped its two functions. One config entry was enough — the generated file, the `Namespace` constant and the registry wiring all follow from `updatePhelRegistry`. `PhelProjectNamespaceFinder`'s map is hand-maintained rather than generated, so it needs `bench` spelled out; its guard test is what caught the omission.

### Registry regenerated to v0.50.0

Doc links repointed at the v0.50.0 sources, multi-arity signatures emitted one arity per line instead of collapsed into an `& [...]` tail, and a new core interop bucket.

v0.50.0 also **removed every deprecated function from the language**, so no generated entry carries deprecation metadata any more (11 → 0). The deprecation feature still ships unchanged; its tests were pinned to `put` / `push` / `function?` as live registry entries, so they now run against synthetic fixtures through a narrow `@TestOnly` overlay on `PhelFunctionRegistry`. The overlay backs `getFunction` and `isDeprecated` only and stays out of `flattenedFunctions`, so it cannot leak into completion or the priority caches.

### Syntax: v0.50.0

Most of the new syntax already worked — verified by running the inspections over each form rather than reading the code. `PDO/$ATTR`, `(set! PDO/slot 1)`, `Foo/.bar`, `php/$_SERVER`, dotted class names, enum cases, `#php {:a 1}` and `` `(let [v# 1] v#) `` all pass clean, and the lexer was already correct on the removed reader syntax (comma is whitespace, no `#|` / bare-`#` / `|(` rules).

Two places still propped up syntax Phel deleted:

- `PhelArityCallSite` skipped the arity check for any call containing a bare `|`, to accommodate `|(...)`. Since `|` is no longer a token, `(some |(> % 10) coll)` is a genuine 3-arg call to a 2-arg function — the skip was hiding a real error rather than preventing a false one.
- `PhelUnresolvedSymbolFinder` silenced every `$`-prefixed name for the dead `$` / `$1` short-fn params. Narrowed to bare `$`, which v0.50.0 keeps as the `fn` `:post` return value.

Two additions:

- **`PhelSupersededFormInspection`** — v0.50.0 deprecated `php/new`, `php/->`, `php/::` (#2877) and `set-var` (#2888); the plugin was silently blessing them. Mirrors the compiler's `--warn-deprecations` the way `PhelBackslashNamespaceInspection` mirrors the separator warning. The rest of the `php/` family stays silent (each reaches a PHP capability Phel has no other word for), and a test pins that. No quick fix: every replacement re-nests the arguments, so no text substitution is correct in general.
- **PHP superglobals** in completion and hover, mirroring #3037. Hand-curated because `updatePhpRegistry` derives from php/doc-en method synopses and a superglobal is a variable, so no generator can find it.

## Test plan

- `./gradlew build` green — **1783 tests, 0 failed, 0 skipped** (1771 before, +12 new).
- Commits are ordered so **every one is green**, verified individually rather than assumed. The test decoupling lands first, against the *old* v0.49.0 data, proving the fixtures take over from the real deprecation entries without changing what any test asserts while those entries still existed. The regeneration then lands on tests that no longer depend on the data it deletes.
- `updatePhelRegistry` re-run after the fact produces **zero diff** against the committed data and preserves the hand-wiring kept outside the `// region GENERATED` blocks, so the generated output is reproducible.
- New coverage: `PhelSupersededFormInspectionTest` (7), `PhpSuperglobalsTest` (5), plus the inverted arity test.

## Not included

The plugin still cannot complete PHP *class members* (`Foo/$prop`, `Foo/.m`). It accepts them without complaint, but has no PHP reflection to suggest names from. That is a pre-existing feature gap, not a regression, and considerably larger than this change.
