### PR TITLE
fix: remove the ten entries duplicated in the 1.1.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,31 +74,6 @@ refreshed, since completion, hover and arity checking are all driven by it.
   directories, and both the `phel.test` and `phel\test` spellings are recognised.
 - **Run a single test** from the gutter icon beside any `deftest`. The test is selected with an anchored pattern, so
   running `void-tags` cannot also pull in `void-tags-ignore-content`, which a plain name filter would.
-- **Live templates** for eleven forms: `defn-`, `defmacro`, `ns`, `deftest`, `when`, `when-let`, `loop`, `cond`,
-  `case`, `try` and `foreach`. They appear under Settings > Editor > Live Templates > Phel, expand with Tab, and can
-  be edited or extended. The six abbreviations completion already offers (`()`, `defn`, `def`, `let`, `if`, `fn`) are
-  deliberately not redefined, so no name produces two differently-behaving entries (#268).
-- **Spellchecking** of string literals, including docstrings, and line comments. Symbols are not checked: in a Lisp
-  nearly every token is one, and checking them would underline most of a file (#268).
-- **Default keyboard shortcuts for the nine paredit actions**, which previously shipped reachable only through the
-  menu. All are two-stroke, under a shared `Ctrl+Alt+Shift+P` prefix: `S` / `B` slurp and barf forward, `Shift+S` /
-  `Shift+B` backward, `W` / `V` / `M` wrap in `( )` / `[ ]` / `{ }`, `U` splice, `R` raise (#267).
-- **Move Element Left/Right** (`Ctrl+Alt+Shift+Left/Right`) over the forms inside a list, vector, map or set, for
-  reordering arguments and map entries (#267).
-- **Surround With** (`Ctrl+Alt+T`) for wrapping a selection of whole forms in `( )`, `[ ]` or `{ }`. Unlike the
-  paredit wrap actions, which take the single form at the caret, this works across a multi-form selection (#267).
-- An **Unused private definition** inspection, reporting a `defn-` / `def-` / `^:private` definition that nothing in
-  its own file references. Only private definitions are reported: a public one may be called from any namespace, so
-  its own file cannot tell (#266).
-- An **Unused function parameter** inspection, covering `defn`, `defn-`, `fn`, `defmacro` and `defmacro-`. Names
-  starting with `_` or `&` are never reported (#266).
-- A **built-in formatter**, used when the project has no `phel` binary. Reformat Code, format-on-paste and
-  reindent-selection now work before `composer install`, in a scratch file, or where the binary is not on one of the
-  searched paths. `phel format` stays the preferred path and still wins whenever it is available; the built-in one
-  indents two spaces per level, matching what pressing Enter already does (#265).
-- A **Code Style page** for Phel (Settings > Editor > Code Style > Phel), covering indentation and blank lines:
-  how many consecutive blank lines to keep, and how many to force between top-level forms. Only options the
-  formatter actually honours are shown (#265).
 - A **REPL** run configuration, launching `phel repl` in the Run console, which accepts typed input and forwards it
   to the process (#263).
 - A **test** run configuration, running `phel test` over the whole suite or over named paths, into a real test tree
@@ -106,10 +81,6 @@ refreshed, since completion, hover and arity checking are all driven by it.
   alongside the normal console output and read when the run finishes (#263). The tree shows one node per `deftest`:
   that reporter emits an entry per `is` form, so the entries of a test are folded into a single node that fails when
   any of its assertions does and lists every failing form in its details.
-- A **run configuration** for Phel files. Right-click a `.phel` file, or use the Run icon in the gutter beside its
-  `(ns …)` form, to run it through the project's `phel` binary. The binary is found the same way the formatter finds
-  it (`./bin/phel`, then `./vendor/bin/phel`) and runs with the login shell's environment, so a Homebrew, Herd, asdf
-  or mise `php` is on its `PATH` even when the IDE was started from Dock or Spotlight (#263).
 - **Go to Symbol** (Navigate > Symbol) now finds Phel definitions. The project symbol index that already backed
   completion and arity resolution simply had no route into the platform's name popups; definitions are listed with
   their namespace, so two functions sharing a name can be told apart, and choosing one jumps to the name itself

--- a/src/test/kotlin/org/phellang/unit/ChangelogIntegrityTest.kt
+++ b/src/test/kotlin/org/phellang/unit/ChangelogIntegrityTest.kt
@@ -1,0 +1,77 @@
+package org.phellang.unit
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * CHANGELOG.md is the single source of the draft release notes and the Marketplace "What's new"
+ * (`patchPluginXml` renders the current version's section into `<change-notes>`), so a defect in it
+ * ships to users.
+ *
+ * The 1.1.0 section carried ten entries twice: #262 reordered the Added block and left the
+ * pre-reorder copies behind. Nothing caught it, and it stayed invisible until `patchChangelog` —
+ * which deduplicates on rewrite — appeared to be "losing" entries at release time.
+ *
+ * A plain file scan, no platform fixture, mirroring ArchitectureBoundaryTest and
+ * InspectionDescriptionsTest.
+ */
+class ChangelogIntegrityTest {
+
+    private val changelog = File("CHANGELOG.md")
+
+    /** One logical entry per bullet, continuation lines folded in, keyed by the version heading. */
+    private fun entriesByVersion(): Map<String, List<String>> {
+        val byVersion = linkedMapOf<String, MutableList<String>>()
+        var version = "(preamble)"
+        var current: StringBuilder? = null
+
+        fun flush() {
+            current?.let { byVersion.getOrPut(version) { mutableListOf() }.add(it.toString()) }
+            current = null
+        }
+
+        for (line in changelog.readLines()) {
+            when {
+                line.startsWith("## ") -> {
+                    flush()
+                    version = line.removePrefix("## ").trim()
+                }
+
+                line.startsWith("- ") -> {
+                    flush()
+                    current = StringBuilder(line.removePrefix("- ").trim())
+                }
+
+                current != null && line.startsWith("  ") -> current!!.append(' ').append(line.trim())
+                else -> flush()
+            }
+        }
+        flush()
+        return byVersion
+    }
+
+    @Test
+    fun `no release repeats an entry`() {
+        val duplicates = entriesByVersion().flatMap { (version, entries) ->
+            entries.groupingBy { it }.eachCount()
+                .filterValues { it > 1 }
+                .map { (entry, count) -> "$version repeats x$count: ${entry.take(90)}" }
+        }
+
+        assertTrue(
+            duplicates.isEmpty(),
+            "CHANGELOG.md repeats entries within a release:\n${duplicates.joinToString("\n")}",
+        )
+    }
+
+    @Test
+    fun `the changelog parses into releases with entries`() {
+        val byVersion = entriesByVersion().filterKeys { it.startsWith("[") }
+
+        assertTrue(byVersion.isNotEmpty(), "expected version sections in CHANGELOG.md")
+        // Unreleased is legitimately empty between releases; every published version is not.
+        val empty = byVersion.filterKeys { !it.startsWith("[Unreleased]") }.filterValues { it.isEmpty() }
+        assertTrue(empty.isEmpty(), "released versions with no entries: ${empty.keys}")
+    }
+}


### PR DESCRIPTION
## The bug was in the file, not in `patchChangelog`

While cutting 1.2.0 I reported that `./gradlew patchChangelog` "drops 10 of the 44 entries" from the `## [1.1.0]` section. **That diagnosis was wrong, and this PR corrects the record.**

`CHANGELOG.md` lists **ten entries twice** inside 1.1.0. [#262](https://github.com/phel-lang/phel-intellij-plugin/pull/262) reordered the Added block so the release "leads with what a user notices first", but the pre-reorder copies were never deleted — so both orderings have been sitting in the file since 1.1.0 shipped. `patchChangelog` deduplicates on rewrite, so it was *collapsing* those pairs, which looked like data loss against a corrupted baseline.

Measured rather than eyeballed:

| | before | after |
|---|---|---|
| bullets in file | 131 | 121 |
| **distinct** entry texts | **120** | **120** |
| entry texts lost | — | **none** |

The only text appearing twice afterwards is "Registry refreshed.", which is legitimate: it belongs to two different releases.

## Which copy was kept

The reordered ones. #262's message states the intended sequence — running a file, then navigation, formatting, inspections, structural editing, templates last — and the second block matches it exactly, while the first is the pre-reorder arrangement. The result reads:

run configuration → test files → single test → REPL → test config → Go to Symbol → Breadcrumbs → formatter → Code Style → Unresolved symbol → Create function → Unused private → Unused parameter → paredit shortcuts → Move Element → Surround With → Live templates → Spellchecking

Four entries that existed only in the first block (test files, single test, REPL and test run configurations) are kept in place at the front, where they belong under "running a file".

## `patchChangelog` is now faithful

Re-ran it against the corrected file with `version = "1.2.0"`: **121 bullets in, 121 out, nothing lost.** What remains is only what the task is meant to do — promote `## [Unreleased]`, and scaffold the empty group headings that `build.gradle.kts` documents as intentional. It also strips two blank lines from the header paragraph and unwraps long bullets onto single lines; cosmetic, and not worth blocking on.

## Guard

`ChangelogIntegrityTest` fails the build if any release repeats an entry, or if a published version parses to no entries at all. A plain file scan, no platform fixture, mirroring `ArchitectureBoundaryTest` and `InspectionDescriptionsTest`.

I verified it actually bites: reinserting a verbatim copy of the Breadcrumbs entry fails the build with `[1.1.0] - 2026-07-25 repeats x2: **Breadcrumbs** above the editor…`. My first attempt at that check passed, because I had injected only the bullet's first line and not its continuation — worth knowing the guard folds continuation lines before comparing, so a partial copy is not a duplicate.

## Test plan

- `./gradlew build` green.
- `ChangelogIntegrityTest` passes on the corrected file, and fails on a deliberately reintroduced duplicate.
- No entry text lost: 120 distinct entries before and after.

## Ordering note

This targets `main`. [#322](https://github.com/phel-lang/phel-intellij-plugin/pull/322) (release 1.2.0) also touches `CHANGELOG.md`, in a different region — it inserts the `## [1.2.0]` heading near the top, while this deletes inside the 1.1.0 block. Merging this one first is cleanest; if #322 goes first, expect a trivial rebase. The claim about `patchChangelog` in #322's description should be disregarded in favour of this one.
