### PR TITLE
chore(deps): bump JUnit to 6.1.3 and Gradle to 9.7.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
 }
 
 tasks.withType<Wrapper> {
-    gradleVersion = "9.3.0"
+    gradleVersion = "9.7.0"
 }
 
 repositories {
@@ -72,11 +72,11 @@ dependencies {
         testFramework(org.jetbrains.intellij.platform.gradle.TestFrameworkType.Platform)
     }
 
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:6.1.2")
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher:6.1.2")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:6.1.2")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:6.1.2")
-    testRuntimeOnly("org.junit.vintage:junit-vintage-engine:6.1.2")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:6.1.3")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher:6.1.3")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:6.1.3")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:6.1.3")
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine:6.1.3")
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.mockito:mockito-core:5.23.0")
     testImplementation("org.mockito:mockito-junit-jupiter:5.23.0")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500


### PR DESCRIPTION
Consolidates the open dependabot PRs into one change, so the suite runs once against the whole set rather than six times against six partial ones.

## Included

| Dependency | From | To | Supersedes |
|---|---|---|---|
| `junit-jupiter-engine`, `junit-jupiter-api`, `junit-jupiter-params` | 6.1.2 | 6.1.3 | #318, #320 |
| `junit-platform-launcher` | 6.1.2 | 6.1.3 | #317 |
| `junit-vintage-engine` | 6.1.2 | 6.1.3 | #319 |
| Gradle wrapper | 9.6.1 | 9.7.0 | #316 |

#318 and #320 proposed the identical three-artifact bump, so the four JUnit PRs are really two distinct changes.

## Also fixed: the wrapper version had drifted

`build.gradle.kts` pinned `gradleVersion = "9.3.0"` in the `Wrapper` task while `gradle-wrapper.properties` was on 9.6.1. Dependabot only edits the properties file, so the two have been diverging across several bumps — the task pin has not moved since `2a7fd78`.

Anyone running `./gradlew wrapper` would have **silently downgraded the project by six minor versions**. Both now read 9.7.0. Worth keeping them in step whenever the wrapper moves.

## Not included: #315

`gradle/actions/setup-gradle@v6` → `@v6.2.0`. Left on the floating tag deliberately:

- `@v6` already resolves to 6.2.0, so the pin changes nothing that runs today.
- The five sibling actions (`actions/checkout@v7`, `actions/setup-java@v5`, `actions/upload-artifact@v7`, `codecov/codecov-action@v7`, and setup-gradle itself) all float on their major. Pinning this one alone would make it the odd one out and generate a dependabot PR for every future 6.x patch.

Happy to fold it in if you would rather pin — say the word, or just merge #315 on top. Otherwise #315 can be closed.

## Test plan

- `./gradlew build` green on the new toolchain: **1787 tests, 0 failed, 0 skipped**, identical to before the bump.
- Gradle 9.7.0 was actually downloaded and used for that build, not just declared — `./gradlew --version` reports `Gradle 9.7.0`.
- Confirmed the vintage engine is still wired up after the JUnit bump: the JUnit3-style `BasePlatformTestCase` tests still execute rather than silently disappearing from the run, which is the failure mode a bad engine/launcher combination produces.
