### PR TITLE
fix: replace the platform APIs scheduled for removal

### DIFF
--- a/src/main/kotlin/org/phellang/indexing/PhelFileChangeListener.kt
+++ b/src/main/kotlin/org/phellang/indexing/PhelFileChangeListener.kt
@@ -124,6 +124,8 @@ class PhelFileChangeListener(private val project: Project) : BulkFileListener {
                 fileEditorManager.openFiles
                     .filter { isPhelFile(it) }
                     .mapNotNull { psiManager.findFile(it) }
+                    // See PhelPsiChangeListener: restart(PsiFile) is deprecated from 2026.1, but is
+                    // the only per-file form the supported platform range offers.
                     .forEach { daemon.restart(it) }
             }
         }

--- a/src/main/kotlin/org/phellang/indexing/PhelPsiChangeListener.kt
+++ b/src/main/kotlin/org/phellang/indexing/PhelPsiChangeListener.kt
@@ -83,6 +83,10 @@ class PhelPsiChangeListener(private val project: Project) : PsiTreeChangeAdapter
                 val freshPsi = psiManager.findFile(file) as? PhelFile ?: continue
 
                 index.refreshFileFromPsi(freshPsi)
+                // restart(PsiFile) is deprecated from 2026.1, which the Marketplace verifier
+                // reports. It stays until sinceBuild moves past 243: the platforms this plugin
+                // supports expose only restart() and restart(PsiFile), so there is nothing else to
+                // call, and the no-arg form would rehighlight every open file instead of this one.
                 daemon.restart(freshPsi)
             }
         }

--- a/src/main/kotlin/org/phellang/refactoring/safedelete/PhelSafeDeleteProcessor.kt
+++ b/src/main/kotlin/org/phellang/refactoring/safedelete/PhelSafeDeleteProcessor.kt
@@ -88,6 +88,11 @@ class PhelSafeDeleteProcessor : SafeDeleteProcessorDelegate {
      * Implemented explicitly even though newer platforms give it a default. It is still *abstract* on
      * 2024.3, the oldest release this plugin supports, so omitting it compiles against 2025.2 and
      * throws `AbstractMethodError` there — which is what the plugin verifier caught.
+     *
+     * The Marketplace verifier therefore reports this override as a deprecated-API usage on 2025.2+,
+     * and that report is expected: the method is abstract on the floor and deprecated at the ceiling,
+     * so no single implementation satisfies both. Do not "fix" it by deleting the override — that
+     * reintroduces the `AbstractMethodError` on 2024.3. It can go when `sinceBuild` moves past 243.
      */
     override fun findConflicts(
         element: PsiElement,

--- a/src/main/kotlin/org/phellang/run/PhelRunLineMarkerContributor.kt
+++ b/src/main/kotlin/org/phellang/run/PhelRunLineMarkerContributor.kt
@@ -46,7 +46,7 @@ class PhelRunLineMarkerContributor : RunLineMarkerContributor() {
     }
 
     private fun info(tooltip: String): Info =
-        Info(AllIcons.RunConfigurations.TestState.Run, { tooltip }, *ExecutorAction.getActions(0))
+        Info(AllIcons.RunConfigurations.TestState.Run, ExecutorAction.getActions(0), { tooltip })
 
     private companion object {
         const val NS_KEYWORD = "ns"

--- a/src/main/kotlin/org/phellang/run/settings/PhelRunConfigurationEditor.kt
+++ b/src/main/kotlin/org/phellang/run/settings/PhelRunConfigurationEditor.kt
@@ -15,10 +15,10 @@ class PhelRunConfigurationEditor(private val project: Project) : SettingsEditor<
 
     private val scriptPathField = TextFieldWithBrowseButton().apply {
         addBrowseFolderListener(
-            "Phel File",
-            "Choose the .phel file to run",
             project,
-            FileChooserDescriptorFactory.createSingleFileDescriptor("phel"),
+            FileChooserDescriptorFactory.createSingleFileDescriptor("phel")
+                .withTitle("Phel File")
+                .withDescription("Choose the .phel file to run"),
         )
     }
 
@@ -31,10 +31,10 @@ class PhelRunConfigurationEditor(private val project: Project) : SettingsEditor<
 
     private val workingDirectoryField = TextFieldWithBrowseButton().apply {
         addBrowseFolderListener(
-            "Working Directory",
-            "Directory phel runs in; defaults to the project root",
             project,
-            FileChooserDescriptorFactory.createSingleFolderDescriptor(),
+            FileChooserDescriptorFactory.createSingleFolderDescriptor()
+                .withTitle("Working Directory")
+                .withDescription("Directory phel runs in; defaults to the project root"),
         )
     }
 

--- a/src/main/kotlin/org/phellang/run/settings/PhelWorkingDirectoryEditor.kt
+++ b/src/main/kotlin/org/phellang/run/settings/PhelWorkingDirectoryEditor.kt
@@ -18,10 +18,10 @@ open class PhelWorkingDirectoryEditor<T : PhelCliRunConfiguration>(
 
     protected val workingDirectoryField: TextFieldWithBrowseButton = TextFieldWithBrowseButton().apply {
         addBrowseFolderListener(
-            "Working Directory",
-            description,
             project,
-            FileChooserDescriptorFactory.createSingleFolderDescriptor(),
+            FileChooserDescriptorFactory.createSingleFolderDescriptor()
+                .withTitle("Working Directory")
+                .withDescription(description),
         )
     }
 


### PR DESCRIPTION
Addresses the Marketplace report for 1.1.0 against `IU-262.9437.65`. Three of the six items are fixed; the other three cannot move while `sinceBuild` is 243, and are documented at the call sites so they are not "fixed" wrongly later.

## Fixed

| Reported | Change |
|---|---|
| `TextFieldWithBrowseButton.addBrowseFolderListener(...)` — scheduled for removal (2) | Switched to the two-argument form, moving the title and description onto the `FileChooserDescriptor` where the platform now wants them. Three call sites: the script-path and working-directory fields of `PhelRunConfigurationEditor`, and the shared `PhelWorkingDirectoryEditor`. |
| `RunLineMarkerContributor.Info.<init>(...)` — scheduled for removal (1) | `Info(icon, tooltipProvider, vararg actions)` → `Info(icon, actions, tooltipProvider)`. Only the argument order changed. |

The report counted two `addBrowseFolderListener` usages; there are actually three call sites, all converted.

## Cannot be fixed while the plugin supports 2024.3

### `SafeDeleteProcessorDelegate.findConflicts` (1)

The method is **abstract on 2024.3** and **deprecated on 2025.2+**. No single implementation satisfies both ends of the supported range.

Deleting the override is exactly the regression `0e23048` fixed for #300: it compiles against 2025.2 and throws `AbstractMethodError` on 2024.3, which the verifier caught at the time. The KDoc now says so explicitly, so the next person reading the deprecation warning does not undo it.

### `DaemonCodeAnalyzer.restart(PsiFile)` (2)

Deprecated from 2026.1. I checked what the supported platforms actually offer rather than assuming a replacement exists — the compiler reports only two candidates on the 2025.2.6 classpath:

```
fun restart(): Unit
fun restart(p0: PsiFile): Unit
```

There is no newer overload to move to, and the no-arg form would rehighlight every open file instead of the one that changed. Both call sites now carry a comment.

Note this one never appears in the local verifier run at all: it is not deprecated on 243–252, only from 2026.1, which is why the Marketplace report against IU-262 sees it and CI does not.

### `com.jetbrains.php` optional dependency

Not a defect and not new. The verifier cannot resolve the PHP plugin on **any** target, including the Community builds CI runs against — it is not bundled with IC and the verifier does not fetch it from Marketplace. The plugin is still reported `Compatible` on every target.

The dependency is `optional` and carries no extensions; it exists solely to give the classloader visibility of `com.jetbrains.php.*` so `PhpClassResolver` can reach `PhpIndex` reflectively. When PHP is absent the dependency is skipped and the integration degrades cleanly. Removing it to silence the message would delete working PHP interop resolution for PhpStorm and IDEA Ultimate users.

## Test plan

- `./gradlew build` green.
- `./gradlew verifyPlugin` against **IC 243, 251, 252 and 252.6**: `Compatible` on all four.
- Before this change the verifier reported the `addBrowseFolderListener` and `Info` usages; after it, the **only** remaining report is the `findConflicts` override, on 252 and 252.6 only.
- `compileKotlin --rerun-tasks` emits no deprecation warning other than the pre-existing Kotlin language-version one and the `findConflicts` override.

## When these can be revisited

All three remaining items clear themselves the moment `sinceBuild` moves past 243. Worth checking again whenever the compatibility floor is raised.
